### PR TITLE
Fix "function declaration isn't a prototype" warnings

### DIFF
--- a/rcl/include/rcl/allocator.h
+++ b/rcl/include/rcl/allocator.h
@@ -64,7 +64,7 @@ typedef struct rcl_allocator_t
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_allocator_t
-rcl_get_default_allocator();
+rcl_get_default_allocator(void);
 
 /// Emulate the behavior of reallocf.
 /* This function will return NULL if the allocator is NULL or has NULL for

--- a/rcl/include/rcl/guard_condition.h
+++ b/rcl/include/rcl/guard_condition.h
@@ -44,7 +44,7 @@ typedef struct rcl_guard_condition_options_t
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_guard_condition_t
-rcl_get_zero_initialized_guard_condition();
+rcl_get_zero_initialized_guard_condition(void);
 
 /// Initialize a rcl guard_condition.
 /* After calling this function on a rcl_guard_condition_t, it can be passed to
@@ -121,7 +121,7 @@ rcl_guard_condition_fini(rcl_guard_condition_t * guard_condition, rcl_node_t * n
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_guard_condition_options_t
-rcl_guard_condition_get_default_options();
+rcl_guard_condition_get_default_options(void);
 
 /// Trigger a rcl guard condition.
 /* This function can fail, and therefore return NULL, if the:

--- a/rcl/include/rcl/node.h
+++ b/rcl/include/rcl/node.h
@@ -62,7 +62,7 @@ typedef struct rcl_node_options_t
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_node_t
-rcl_get_zero_initialized_node();
+rcl_get_zero_initialized_node(void);
 
 /// Initialize a ROS node.
 /* Calling this on a rcl_node_t makes it a valid node handle until rcl_shutdown
@@ -140,7 +140,7 @@ rcl_node_fini(rcl_node_t * node);
 /// Return the default node options in a rcl_node_options_t.
 RCL_PUBLIC
 rcl_node_options_t
-rcl_node_get_default_options();
+rcl_node_get_default_options(void);
 
 /// Get the name of the node.
 /* This function returns the node's internal name string.

--- a/rcl/include/rcl/publisher.h
+++ b/rcl/include/rcl/publisher.h
@@ -54,7 +54,7 @@ typedef struct rcl_publisher_options_t
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_publisher_t
-rcl_get_zero_initialized_publisher();
+rcl_get_zero_initialized_publisher(void);
 
 /// Initialize a rcl publisher.
 /* After calling this function on a rcl_publisher_t, it can be used to publish
@@ -161,7 +161,7 @@ rcl_publisher_fini(rcl_publisher_t * publisher, rcl_node_t * node);
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_publisher_options_t
-rcl_publisher_get_default_options();
+rcl_publisher_get_default_options(void);
 
 /// Publish a ROS message on a topic using a publisher.
 /* It is the job of the caller to ensure that the type of the ros_message

--- a/rcl/include/rcl/rcl.h
+++ b/rcl/include/rcl/rcl.h
@@ -92,7 +92,7 @@ rcl_init(int argc, char ** argv, rcl_allocator_t allocator);
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
-rcl_shutdown();
+rcl_shutdown(void);
 
 /// Returns an uint64_t number that is unique for the latest rcl_init call.
 /* If called before rcl_init or after rcl_shutdown then 0 will be returned.
@@ -107,7 +107,7 @@ rcl_shutdown();
 RCL_PUBLIC
 RCL_WARN_UNUSED
 uint64_t
-rcl_get_instance_id();
+rcl_get_instance_id(void);
 
 /// Return true if rcl is currently initialized, otherwise false.
 /* This function does not allocate memory.
@@ -118,7 +118,7 @@ rcl_get_instance_id();
 RCL_PUBLIC
 RCL_WARN_UNUSED
 bool
-rcl_ok();
+rcl_ok(void);
 
 #if __cplusplus
 }

--- a/rcl/include/rcl/subscription.h
+++ b/rcl/include/rcl/subscription.h
@@ -56,7 +56,7 @@ typedef struct rcl_subscription_options_t
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_subscription_t
-rcl_get_zero_initialized_subscription();
+rcl_get_zero_initialized_subscription(void);
 
 /// Initialize a ROS subscription.
 /* After calling this function on a rcl_subscription_t, it can be used to take
@@ -164,7 +164,7 @@ rcl_subscription_fini(rcl_subscription_t * subscription, rcl_node_t * node);
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_subscription_options_t
-rcl_subscription_get_default_options();
+rcl_subscription_get_default_options(void);
 
 /// Take a ROS message from a topic using a rcl subscription.
 /* It is the job of the caller to ensure that the type of the ros_message

--- a/rcl/include/rcl/timer.h
+++ b/rcl/include/rcl/timer.h
@@ -54,7 +54,7 @@ typedef void (* rcl_timer_callback_t)(rcl_timer_t *, uint64_t);
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_timer_t
-rcl_get_zero_initialized_timer();
+rcl_get_zero_initialized_timer(void);
 
 /// Initialize a timer.
 /* A timer consists of a callback function and a period.

--- a/rcl/include/rcl/wait.h
+++ b/rcl/include/rcl/wait.h
@@ -52,7 +52,7 @@ typedef struct rcl_wait_set_t
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_wait_set_t
-rcl_get_zero_initialized_wait_set();
+rcl_get_zero_initialized_wait_set(void);
 
 /// Initialize a rcl wait set with space for items to be waited on.
 /* This function allocates space for the subscriptions and other wait-able


### PR DESCRIPTION
Fix "function declaration isn't a prototype" warnings

Connects to https://github.com/ros2/rmw/pull/53