### PR TITLE
extend the library path with the location of the memory tools also

### DIFF
--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -5,8 +5,9 @@ include(rcl_add_custom_gtest.cmake)
 
 set(extra_test_libraries)
 set(extra_test_env)
+set(extra_lib_dirs "${rcl_lib_dir}")
 
-# This subdirectory extends both extra_test_libraries and extra_test_env.
+# This subdirectory extends both extra_test_libraries, extra_test_env, and extra_lib_dirs.
 add_subdirectory(memory_tools)
 
 macro(test_target)
@@ -31,7 +32,7 @@ function(test_target_function)
   rcl_add_custom_gtest(test_allocator${target_suffix}
     SRCS rcl/test_allocator.cpp
     ENV ${extra_test_env}
-    APPEND_LIBRARY_DIRS "${rcl_lib_dir}"
+    APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME}${target_suffix} ${extra_test_libraries}
     AMENT_DEPENDENCIES ${rmw_implementation}
   )
@@ -39,7 +40,7 @@ function(test_target_function)
   rcl_add_custom_gtest(test_time${target_suffix}
     SRCS rcl/test_time.cpp
     ENV ${extra_test_env}
-    APPEND_LIBRARY_DIRS "${rcl_lib_dir}"
+    APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME}${target_suffix} ${extra_test_libraries}
     AMENT_DEPENDENCIES ${rmw_implementation}
   )
@@ -50,7 +51,7 @@ function(test_target_function)
       ${extra_test_env}
       EMPTY_TEST=
       NORMAL_TEST=foo
-    APPEND_LIBRARY_DIRS "${rcl_lib_dir}"
+    APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME}${target_suffix} ${extra_test_libraries}
     AMENT_DEPENDENCIES ${rmw_implementation}
   )
@@ -58,7 +59,7 @@ function(test_target_function)
   rcl_add_custom_gtest(test_rcl${target_suffix}
     SRCS rcl/test_rcl.cpp
     ENV ${extra_test_env}
-    APPEND_LIBRARY_DIRS "${rcl_lib_dir}"
+    APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME}${target_suffix} ${extra_test_libraries}
     AMENT_DEPENDENCIES ${rmw_implementation}
   )
@@ -66,7 +67,7 @@ function(test_target_function)
   rcl_add_custom_gtest(test_node${target_suffix}
     SRCS rcl/test_node.cpp
     ENV ${extra_test_env}
-    APPEND_LIBRARY_DIRS "${rcl_lib_dir}"
+    APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME}${target_suffix} ${extra_test_libraries}
     AMENT_DEPENDENCIES ${rmw_implementation}
   )
@@ -74,7 +75,7 @@ function(test_target_function)
   rcl_add_custom_gtest(test_publisher${target_suffix}
     SRCS rcl/test_publisher.cpp
     ENV ${extra_test_env}
-    APPEND_LIBRARY_DIRS "${rcl_lib_dir}"
+    APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME}${target_suffix} ${extra_test_libraries}
     AMENT_DEPENDENCIES ${rmw_implementation} "std_msgs"
   )
@@ -82,7 +83,7 @@ function(test_target_function)
   rcl_add_custom_gtest(test_subscription${target_suffix}
     SRCS rcl/test_subscription.cpp
     ENV ${extra_test_env}
-    APPEND_LIBRARY_DIRS "${rcl_lib_dir}"
+    APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME}${target_suffix} ${extra_test_libraries}
     AMENT_DEPENDENCIES ${rmw_implementation} "std_msgs"
   )

--- a/rcl/test/memory_tools/CMakeLists.txt
+++ b/rcl/test/memory_tools/CMakeLists.txt
@@ -16,6 +16,7 @@ if(UNIX AND NOT APPLE)
   list(APPEND extra_test_libraries dl)
   list(APPEND extra_test_env DL_PRELOAD=$<TARGET_FILE:${PROJECT_NAME}_memory_tools>)
 endif()
+list(APPEND extra_lib_dirs $<TARGET_FILE_DIR:${PROJECT_NAME}_memory_tools>)
 target_link_libraries(${PROJECT_NAME}_memory_tools ${extra_test_libraries})
 target_compile_definitions(${PROJECT_NAME}_memory_tools
   PRIVATE "RCL_MEMORY_TOOLS_BUILDING_DLL")
@@ -34,3 +35,4 @@ endif()
 
 set(extra_test_libraries ${extra_test_libraries} PARENT_SCOPE)
 set(extra_test_env ${extra_test_env} PARENT_SCOPE)
+set(extra_lib_dirs ${extra_lib_dirs} PARENT_SCOPE)


### PR DESCRIPTION
This commit got excluded from #21 somehow. It should address the failing `rcl` tests on Windows.