### PR TITLE
add test for topic name

### DIFF
--- a/rcl/test/rcl/test_publisher.cpp
+++ b/rcl/test/rcl/test_publisher.cpp
@@ -97,6 +97,7 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_nomin
     rcl_ret_t ret = rcl_publisher_fini(&publisher, this->node_ptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
   });
+  EXPECT_EQ(strcmp(rcl_publisher_get_topic_name(&publisher), topic_name), 0);
   std_msgs__msg__Int64 msg;
   std_msgs__msg__Int64__init(&msg);
   msg.data = 42;

--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -147,6 +147,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
     rcl_ret_t ret = rcl_subscription_fini(&subscription, this->node_ptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
   });
+  EXPECT_EQ(strcmp(rcl_subscription_get_topic_name(&subscription), topic), 0);
   // TODO(wjwwood): add logic to wait for the connection to be established
   //                probably using the count_subscriptions busy wait mechanism
   //                until then we will sleep for a short period of time


### PR DESCRIPTION
I noticed that the topic_name field doesn't actually get set in any rmw implementation, so this test case fails. Fix coming up.