### PR TITLE
tests generated for each RMW impl must have unique names to be distinguishable

### DIFF
--- a/rcl/test/rcl/test_allocator.cpp
+++ b/rcl/test/rcl/test_allocator.cpp
@@ -18,10 +18,17 @@
 
 #include "../memory_tools/memory_tools.hpp"
 
-class TestAllocatorFixture : public ::testing::Test
+#ifdef RMW_IMPLEMENTATION
+# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
+# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
+#else
+# define CLASSNAME(NAME, SUFFIX) NAME
+#endif
+
+class CLASSNAME(TestAllocatorFixture, RMW_IMPLEMENTATION) : public ::testing::Test
 {
 public:
-  TestAllocatorFixture()
+  CLASSNAME(TestAllocatorFixture, RMW_IMPLEMENTATION)()
   {
     start_memory_checking();
     stop_memory_checking();
@@ -48,7 +55,7 @@ public:
 
 /* Tests the default allocator.
  */
-TEST_F(TestAllocatorFixture, test_default_allocator_normal) {
+TEST_F(CLASSNAME(TestAllocatorFixture, RMW_IMPLEMENTATION), test_default_allocator_normal) {
 #if defined(WIN32)
   printf("Allocator tests disabled on Windows.\n");
   return;

--- a/rcl/test/rcl/test_common.cpp
+++ b/rcl/test/rcl/test_common.cpp
@@ -19,6 +19,13 @@
 #include "../../src/rcl/common.h"
 #include "../../src/rcl/common.c"
 
+#ifdef RMW_IMPLEMENTATION
+# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
+# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
+#else
+# define CLASSNAME(NAME, SUFFIX) NAME
+#endif
+
 /* Tests the default allocator.
  *
  * Expected environment variables must be set by the calling code:
@@ -28,7 +35,7 @@
  *
  * These are set in the call to `ament_add_gtest()` in the `CMakeLists.txt`.
  */
-TEST(TestCommon, test_getenv) {
+TEST(CLASSNAME(TestCommon, RMW_IMPLEMENTATION), test_getenv) {
   const char * env;
   rcl_ret_t ret;
   ret = rcl_impl_getenv("NORMAL_TEST", NULL);

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -24,7 +24,14 @@
 #include "../scope_exit.hpp"
 #include "rcl/error_handling.h"
 
-class TestNodeFixture : public ::testing::Test
+#ifdef RMW_IMPLEMENTATION
+# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
+# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
+#else
+# define CLASSNAME(NAME, SUFFIX) NAME
+#endif
+
+class CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION) : public ::testing::Test
 {
 public:
   void SetUp()
@@ -57,7 +64,7 @@ bool is_windows = false;
 
 /* Tests the node accessors, i.e. rcl_node_get_* functions.
  */
-TEST_F(TestNodeFixture, test_rcl_node_accessors) {
+TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) {
   stop_memory_checking();
   rcl_ret_t ret;
   // Initialize rcl with rcl_init().
@@ -226,7 +233,7 @@ TEST_F(TestNodeFixture, test_rcl_node_accessors) {
 
 /* Tests the node life cycle, including rcl_node_init() and rcl_node_fini().
  */
-TEST_F(TestNodeFixture, test_rcl_node_life_cycle) {
+TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_life_cycle) {
   stop_memory_checking();
   rcl_ret_t ret;
   rcl_node_t node = rcl_get_zero_initialized_node();

--- a/rcl/test/rcl/test_publisher.cpp
+++ b/rcl/test/rcl/test_publisher.cpp
@@ -25,7 +25,14 @@
 #include "../scope_exit.hpp"
 #include "rcl/error_handling.h"
 
-class TestPublisherFixture : public ::testing::Test
+#ifdef RMW_IMPLEMENTATION
+# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
+# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
+#else
+# define CLASSNAME(NAME, SUFFIX) NAME
+#endif
+
+class CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION) : public ::testing::Test
 {
 public:
   rcl_node_t * node_ptr;
@@ -66,7 +73,7 @@ public:
 
 /* Basic nominal test of a publisher.
  */
-TEST_F(TestPublisherFixture, test_publisher_nominal) {
+TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_nominal) {
   stop_memory_checking();
   rcl_ret_t ret;
   rcl_publisher_t publisher = rcl_get_zero_initialized_publisher();
@@ -100,7 +107,7 @@ TEST_F(TestPublisherFixture, test_publisher_nominal) {
 
 /* Basic nominal test of a publisher with a string.
  */
-TEST_F(TestPublisherFixture, test_publisher_nominal_string) {
+TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_nominal_string) {
   stop_memory_checking();
   rcl_ret_t ret;
   rcl_publisher_t publisher = rcl_get_zero_initialized_publisher();
@@ -126,7 +133,7 @@ TEST_F(TestPublisherFixture, test_publisher_nominal_string) {
 
 /* Testing the publisher init and fini functions.
  */
-TEST_F(TestPublisherFixture, test_publisher_init_fini) {
+TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_init_fini) {
   stop_memory_checking();
   rcl_ret_t ret;
   // Setup valid inputs.

--- a/rcl/test/rcl/test_rcl.cpp
+++ b/rcl/test/rcl/test_rcl.cpp
@@ -19,7 +19,14 @@
 #include "../memory_tools/memory_tools.hpp"
 #include "rcl/error_handling.h"
 
-class TestRCLFixture : public ::testing::Test
+#ifdef RMW_IMPLEMENTATION
+# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
+# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
+#else
+# define CLASSNAME(NAME, SUFFIX) NAME
+#endif
+
+class CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION) : public ::testing::Test
 {
 public:
   void SetUp()
@@ -80,7 +87,7 @@ private:
 
 /* Tests the rcl_init(), rcl_ok(), and rcl_shutdown() functions.
  */
-TEST_F(TestRCLFixture, test_rcl_init_and_ok_and_shutdown) {
+TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_init_and_ok_and_shutdown) {
   rcl_ret_t ret;
   // A shutdown before any init has been called should fail.
   ret = rcl_shutdown();
@@ -160,7 +167,7 @@ TEST_F(TestRCLFixture, test_rcl_init_and_ok_and_shutdown) {
 
 /* Tests the rcl_get_instance_id() and rcl_ok() functions.
  */
-TEST_F(TestRCLFixture, test_rcl_get_instance_id_and_ok) {
+TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_get_instance_id_and_ok) {
   rcl_ret_t ret;
   // Instance id should be 0 before rcl_init().
   EXPECT_EQ(0u, rcl_get_instance_id());

--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -29,7 +29,14 @@
 #include "../scope_exit.hpp"
 #include "rcl/error_handling.h"
 
-class TestSubscriptionFixture : public ::testing::Test
+#ifdef RMW_IMPLEMENTATION
+# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
+# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
+#else
+# define CLASSNAME(NAME, SUFFIX) NAME
+#endif
+
+class CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION) : public ::testing::Test
 {
 public:
   rcl_node_t * node_ptr;
@@ -107,7 +114,7 @@ wait_for_subscription_to_be_ready(
 
 /* Basic nominal test of a subscription.
  */
-TEST_F(TestSubscriptionFixture, test_subscription_nominal) {
+TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription_nominal) {
   stop_memory_checking();
   rcl_ret_t ret;
   rcl_publisher_t publisher = rcl_get_zero_initialized_publisher();
@@ -172,7 +179,7 @@ TEST_F(TestSubscriptionFixture, test_subscription_nominal) {
 
 /* Basic nominal test of a publisher with a string.
  */
-TEST_F(TestSubscriptionFixture, test_subscription_nominal_string) {
+TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription_nominal_string) {
   stop_memory_checking();
   rcl_ret_t ret;
   rcl_publisher_t publisher = rcl_get_zero_initialized_publisher();

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -24,7 +24,14 @@
 
 #include "../memory_tools/memory_tools.hpp"
 
-class TestTimeFixture : public ::testing::Test
+#ifdef RMW_IMPLEMENTATION
+# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
+# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
+#else
+# define CLASSNAME(NAME, SUFFIX) NAME
+#endif
+
+class CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION) : public ::testing::Test
 {
 public:
   void SetUp()
@@ -48,7 +55,7 @@ public:
 };
 
 // Tests the rcl_system_time_now() function.
-TEST_F(TestTimeFixture, test_rcl_system_time_now) {
+TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_system_time_now) {
   assert_no_realloc_begin();
   rcl_ret_t ret;
   // Check for invalid argument error condition (allowed to alloc).
@@ -80,7 +87,7 @@ TEST_F(TestTimeFixture, test_rcl_system_time_now) {
 }
 
 // Tests the rcl_steady_time_now() function.
-TEST_F(TestTimeFixture, test_rcl_steady_time_now) {
+TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_steady_time_now) {
   assert_no_realloc_begin();
   rcl_ret_t ret;
   // Check for invalid argument error condition (allowed to alloc).
@@ -118,7 +125,7 @@ TEST_F(TestTimeFixture, test_rcl_steady_time_now) {
 }
 
 // Tests the rcl_set_ros_time_override() function.
-TEST_F(TestTimeFixture, test_rcl_set_ros_time_override) {
+TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_set_ros_time_override) {
   rcl_time_source_t * ros_time_source = rcl_get_default_ros_time_source();
   assert_no_realloc_begin();
   rcl_ret_t ret;
@@ -219,7 +226,7 @@ TEST_F(TestTimeFixture, test_rcl_set_ros_time_override) {
   }
 }
 
-TEST_F(TestTimeFixture, test_rcl_init_time_source_and_point) {
+TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_init_time_source_and_point) {
   assert_no_realloc_begin();
   rcl_ret_t ret;
   // Check for invalid argument error condition (allowed to alloc).
@@ -265,7 +272,7 @@ TEST_F(TestTimeFixture, test_rcl_init_time_source_and_point) {
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
 }
 
-TEST(rcl_time, time_source_validation) {
+TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), time_source_validation) {
   ASSERT_FALSE(rcl_time_source_valid(NULL));
   rcl_time_source_t uninitialized;
   // Not reliably detectable due to random values.
@@ -275,7 +282,7 @@ TEST(rcl_time, time_source_validation) {
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
 }
 
-TEST(rcl_time, default_time_source_instanciation) {
+TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), default_time_source_instanciation) {
   rcl_time_source_t * ros_time_source = rcl_get_default_ros_time_source();
   ASSERT_TRUE(rcl_time_source_valid(ros_time_source));
   rcl_time_source_t * steady_time_source = rcl_get_default_steady_time_source();
@@ -284,7 +291,7 @@ TEST(rcl_time, default_time_source_instanciation) {
   ASSERT_TRUE(rcl_time_source_valid(system_time_source));
 }
 
-TEST(rcl_time, rcl_time_difference) {
+TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_difference) {
   rcl_ret_t ret;
   rcl_time_point_t a, b;
   ret = rcl_init_time_point(&a, nullptr);
@@ -333,7 +340,7 @@ void post_callback(void)
 }
 
 
-TEST(rcl_time, rcl_time_update_callbacks) {
+TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_update_callbacks) {
   rcl_time_source_t * ros_time_source = rcl_get_default_ros_time_source();
   rcl_time_point_t query_now;
   rcl_ret_t ret;

--- a/rcl/test/rcl_add_custom_gtest.cmake
+++ b/rcl/test/rcl_add_custom_gtest.cmake
@@ -96,5 +96,7 @@ macro(rcl_add_custom_gtest target)
       endif()
       ament_target_dependencies(${target} ${_ARG_AMENT_DEPENDENCIES})
     endif()
+    target_compile_definitions(${target}
+      PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
   endif()
 endmacro()


### PR DESCRIPTION
Otherwise test results in Jenkins are not really tell which version of the test fails: http://ci.ros2.org/job/ci_windows/1114/testReport/(root)/TestSubscriptionFixture/

http://ci.ros2.org/job/ci_windows/1122/testReport/(root)/TestSubscriptionFixture__rmw_connext_dynamic_cpp/