### PR TITLE
Enable fastrtps for rcl

### DIFF
--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -530,7 +530,7 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
     // Compare the timeout to the time until next callback for each timer.
     // Take the lowest and use that for the wait timeout.
     uint64_t i = 0;
-    for (i = 0; i < wait_set->size_of_timers; ++i) {
+    for (i = 0; i < wait_set->impl->timer_index; ++i) {
       if (!wait_set->timers[i]) {
         continue;  // Skip NULL timers.
       }
@@ -583,7 +583,7 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
   }
   // Check for ready timers next, and set not ready timers to NULL.
   size_t i;
-  for (i = 0; i < wait_set->size_of_timers; ++i) {
+  for (i = 0; i < wait_set->impl->timer_index; ++i) {
     bool is_ready = false;
     rcl_ret_t ret = rcl_timer_is_ready(wait_set->timers[i], &is_ready);
     if (ret != RCL_RET_OK) {

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -21,13 +21,6 @@ macro(test_target)
 endmacro()
 
 function(test_target_function)
-  # TODO(wjwwood): remove these when C type support is supported by typesupport_introspection.
-  #                after removing, we can also recombine the function and macro
-  if(rmw_implementation STREQUAL "rmw_fastrtps_cpp")
-    message(STATUS "Skipping tests for '${rmw_implementation}'")
-    return()
-  endif()
-
   message(STATUS "Creating tests for '${rmw_implementation}'")
 
   # Gtests


### PR DESCRIPTION
Preliminary CI shows that with this and https://github.com/eProsima/ROS-RMW-Fast-RTPS-cpp/pull/18, we can we can use fastrtps as a backend for rcl:

http://ci.ros2.org/job/ci_linux/1083/

Connects to eProsima/ROS-RMW-Fast-RTPS-cpp#27
