### PR TITLE
Remove check argument for null from int64_t

### DIFF
--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -488,7 +488,6 @@ rcl_ret_t
 rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(wait_set, RCL_RET_INVALID_ARGUMENT);
-  RCL_CHECK_ARGUMENT_FOR_NULL(timeout, RCL_RET_INVALID_ARGUMENT);
   if (!__wait_set_is_valid(wait_set)) {
     RCL_SET_ERROR_MSG("wait set is invalid");
     return RCL_RET_WAIT_SET_INVALID;


### PR DESCRIPTION
I believe a timeout value of 0 is a valid input to `rcl_wait` (no blocking). However, there is check for a null argument that interprets the argument as a pointer, and if timeout is equal to zero then it is interpreted as a null pointer and the function returns an error.