### PR TITLE
Make timer callback optional and fix timer logic

### DIFF
--- a/rcl/include/rcl/timer.h
+++ b/rcl/include/rcl/timer.h
@@ -153,7 +153,8 @@ rcl_timer_fini(rcl_timer_t * timer);
  * the timer's period has not yet elapsed.
  * It is up to the calling code to make sure the period has elapsed by first
  * calling rcl_timer_is_ready().
- * If the callback option was set to null in init, no callback is fired.
+ * If the callback pointer is null (either set in init or exchanged after
+ * initialized), no callback is fired.
  * However, this function should still be called by the client library to
  * update the state of the timer.
  * The order of operations in this command are as follows:

--- a/rcl/include/rcl/timer.h
+++ b/rcl/include/rcl/timer.h
@@ -77,7 +77,12 @@ rcl_get_zero_initialized_timer(void);
  * The period is a duration (rather an absolute time in the future).
  * If the period is 0 then it will always be ready.
  *
- * The callback must be a function which returns void and takes two arguments,
+ * The callback is an optional argument. Valid inputs are either a pointer
+ * to the function callback, or NULL to indicate that no callback will be
+ * stored in rcl.
+ * If the callback is null, the caller client library is responsible for
+ * firing the timer callback.
+ * Else, it must be a function which returns void and takes two arguments,
  * the first being a pointer to the associated timer, and the second a uint64_t
  * which is the time since the previous call, or since the timer was created
  * if it is the first call to the callback.
@@ -148,6 +153,9 @@ rcl_timer_fini(rcl_timer_t * timer);
  * the timer's period has not yet elapsed.
  * It is up to the calling code to make sure the period has elapsed by first
  * calling rcl_timer_is_ready().
+ * If the callback option was set to null in init, no callback is fired.
+ * However, this function should still be called by the client library to
+ * update the state of the timer.
  * The order of operations in this command are as follows:
  *
  *  - Ensure the timer has not been canceled.
@@ -326,7 +334,9 @@ rcl_timer_get_callback(const rcl_timer_t * timer);
 /* This function can fail, and therefore return NULL, if:
  *   - timer is NULL
  *   - timer has not been initialized (the implementation is invalid)
- *   - the new_callback argument is NULL
+ *
+ * This function can set callback to null, in which case the callback is
+ * ignored when rcl_timer_call is called.
  *
  * This function is thread-safe.
  * This function is lock-free so long as the C11's stdatomic.h function

--- a/rcl/include/rcl/timer.h
+++ b/rcl/include/rcl/timer.h
@@ -77,9 +77,9 @@ rcl_get_zero_initialized_timer(void);
  * The period is a duration (rather an absolute time in the future).
  * If the period is 0 then it will always be ready.
  *
- * The callback is an optional argument. Valid inputs are either a pointer
- * to the function callback, or NULL to indicate that no callback will be
- * stored in rcl.
+ * The callback is an optional argument.
+ * Valid inputs are either a pointer to the function callback, or NULL to
+ * indicate that no callback will be stored in rcl.
  * If the callback is null, the caller client library is responsible for
  * firing the timer callback.
  * Else, it must be a function which returns void and takes two arguments,

--- a/rcl/include/rcl/wait.h
+++ b/rcl/include/rcl/wait.h
@@ -186,7 +186,7 @@ rcl_wait_set_add_subscription(
 /// Remove (sets to NULL) the subscriptions in the wait set.
 /* This function should be used after passing using rcl_wait, but before
  * adding new subscriptions to the set.
- * Sets all of the entries in the underlying rmw array to null, and sets the 
+ * Sets all of the entries in the underlying rmw array to null, and sets the
  * count in the rmw array to 0.
  *
  * Calling this on an uninitialized (zero initialized) wait set will fail.

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -523,8 +523,8 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
     timeout_argument = &temporary_timeout_storage;
   } else {
     int64_t min_timeout = INT64_MAX;
-    // If min_timeout is > 0, then compare it to the time until each timer.
     if (timeout > 0) {
+      // Compare the timeout to the time until next callback for each timer.
       min_timeout = timeout;
     }
     // Take the lowest and use that for the wait timeout.

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -545,6 +545,10 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
     if (min_timeout == INT64_MAX) {
       timeout_argument = NULL;
     } else {
+      // If min_timeout was negative, we need to wake up immediately.
+      if (min_timeout < 0) {
+        min_timeout = 0;
+      }
       temporary_timeout_storage.sec = RCL_NS_TO_S(min_timeout);
       temporary_timeout_storage.nsec = min_timeout % 1000000000;
       timeout_argument = &temporary_timeout_storage;


### PR DESCRIPTION
two tweaks to timers that were giving me trouble in the rcl/rclcpp refactor:

1. Make the timer callback optional. If the callback is null, it is simply ignored. In rclcpp, timers take care of their own callbacks instead of storing them in rcl, since lambdas, bound functions, etc. have unexpected function signatures.

2. Fix the logic determining when to wake up `rmw_wait`.