### PR TITLE
tests for rcl_wait

### DIFF
--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -29,6 +29,9 @@ extern "C"
 #include "rcl/time.h"
 #include "rmw/rmw.h"
 
+// XXX
+#include <stdio.h>
+
 typedef struct rcl_wait_set_impl_t
 {
   size_t subscription_index;
@@ -521,8 +524,8 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
     temporary_timeout_storage.sec = 0;
     temporary_timeout_storage.nsec = 0;
     timeout_argument = &temporary_timeout_storage;
-  } else if (timeout > 0) {
-    int64_t min_timeout = timeout;
+  } else if (timeout > 0 || wait_set->size_of_timers > 0) {
+    int64_t min_timeout = timeout > 0 ? timeout : INT64_MAX;
     // Compare the timeout to the time until next callback for each timer.
     // Take the lowest and use that for the wait timeout.
     uint64_t i = 0;

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -29,9 +29,6 @@ extern "C"
 #include "rcl/time.h"
 #include "rmw/rmw.h"
 
-// XXX
-#include <stdio.h>
-
 typedef struct rcl_wait_set_impl_t
 {
   size_t subscription_index;

--- a/rcl/test/rcl/test_wait.cpp
+++ b/rcl/test/rcl/test_wait.cpp
@@ -31,7 +31,7 @@
 #endif
 
 
-#define TOLERANCE RCL_US_TO_NS(200)
+#define TOLERANCE RCL_US_TO_NS(600)
 
 TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), test_resize_to_zero) {
   // Initialize a waitset with a subscription and then resize it to zero.
@@ -54,7 +54,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), finite_timeout) {
   rcl_ret_t ret = rcl_wait_set_init(&wait_set, 0, 0, 1, 0, 0, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 
-  int64_t timeout = RCL_MS_TO_NS(1);  // nanoseconds
+  int64_t timeout = RCL_MS_TO_NS(10);  // nanoseconds
   std::chrono::steady_clock::time_point before_sc = std::chrono::steady_clock::now();
   ret = rcl_wait(&wait_set, timeout);
   std::chrono::steady_clock::time_point after_sc = std::chrono::steady_clock::now();
@@ -80,7 +80,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), negative_timeout) {
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 
   rcl_timer_t timer = rcl_get_zero_initialized_timer();
-  ret = rcl_timer_init(&timer, RCL_MS_TO_NS(1), nullptr, rcl_get_default_allocator());
+  ret = rcl_timer_init(&timer, RCL_MS_TO_NS(10), nullptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
   ret = rcl_wait_set_add_timer(&wait_set, &timer);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
@@ -103,7 +103,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), negative_timeout) {
   ASSERT_EQ(RCL_RET_TIMEOUT, ret) << rcl_get_error_string_safe();
   // Check time
   int64_t diff = std::chrono::duration_cast<std::chrono::nanoseconds>(after_sc - before_sc).count();
-  EXPECT_LE(diff, RCL_MS_TO_NS(1) + TOLERANCE);
+  EXPECT_LE(diff, RCL_MS_TO_NS(10) + TOLERANCE);
 }
 
 // Test rcl_wait with a timeout value of 0 (non-blocking)
@@ -166,7 +166,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), guard_condition) {
   std::chrono::nanoseconds trigger_diff;
   std::thread trigger_thread([&p, &guard_cond, &trigger_diff]() {
     std::chrono::steady_clock::time_point before_trigger = std::chrono::steady_clock::now();
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
     rcl_ret_t ret = rcl_trigger_guard_condition(&guard_cond);
     std::chrono::steady_clock::time_point after_trigger = std::chrono::steady_clock::now();
     trigger_diff = std::chrono::duration_cast<std::chrono::nanoseconds>(

--- a/rcl/test/rcl/test_wait.cpp
+++ b/rcl/test/rcl/test_wait.cpp
@@ -16,7 +16,7 @@
 #include <future>
 #include <thread>
 
-#include <gtest/gtest.h>
+#include "gtest/gtest.h"
 
 #include "rcl/rcl.h"
 #include "rcl/error_handling.h"
@@ -80,8 +80,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), negative_timeout) {
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 
 
-  // TODO Make sure timer assumption fits with original rcl timer assumptions,
-  // maybe by duplication test separately.
+  // TODO(jacquelinekay) rcl timer tests?
   rcl_timer_t timer = rcl_get_zero_initialized_timer();
   rcl_timer_callback_t callback;
   ret = rcl_timer_init(&timer, 1000000, callback, rcl_get_default_allocator());
@@ -151,14 +150,14 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), guard_condition) {
 
   std::chrono::nanoseconds trigger_diff;
   std::thread trigger_thread([&p, &guard_cond, &trigger_diff]() {
-      std::chrono::steady_clock::time_point before_trigger = std::chrono::steady_clock::now();
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
-      rcl_ret_t ret = rcl_trigger_guard_condition(&guard_cond);
-      std::chrono::steady_clock::time_point after_trigger = std::chrono::steady_clock::now();
-      trigger_diff = std::chrono::duration_cast<std::chrono::nanoseconds>(
-        after_trigger - before_trigger);
-      p.set_value(ret);
-    }
+    std::chrono::steady_clock::time_point before_trigger = std::chrono::steady_clock::now();
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    rcl_ret_t ret = rcl_trigger_guard_condition(&guard_cond);
+    std::chrono::steady_clock::time_point after_trigger = std::chrono::steady_clock::now();
+    trigger_diff = std::chrono::duration_cast<std::chrono::nanoseconds>(
+      after_trigger - before_trigger);
+    p.set_value(ret);
+  }
   );
   auto f = p.get_future();
 

--- a/rcl/test/rcl/test_wait.cpp
+++ b/rcl/test/rcl/test_wait.cpp
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
+#include <future>
+#include <thread>
 
 #include <gtest/gtest.h>
 
@@ -26,6 +29,8 @@
 # define CLASSNAME(NAME, SUFFIX) NAME
 #endif
 
+
+#define TOLERANCE 100000  // clock error tolerance in nanoseconds
 
 TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), test_resize_to_zero) {
   // Initialize a waitset with a subscription and then resize it to zero.
@@ -43,16 +48,131 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), test_resize_to_zero) {
 }
 
 // Some test cases for the waitset
+TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), finite_timeout) {
+  rcl_wait_set_t wait_set = rcl_get_zero_initialized_wait_set();
+  rcl_ret_t ret = rcl_wait_set_init(&wait_set, 0, 0, 1, 0, 0, rcl_get_default_allocator());
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
+
+  int64_t timeout = 1000000;  // nanoseconds
+  std::chrono::steady_clock::time_point before_sc = std::chrono::steady_clock::now();
+  ret = rcl_wait(&wait_set, timeout);
+  std::chrono::steady_clock::time_point after_sc = std::chrono::steady_clock::now();
+  // Check time
+  int64_t diff = (after_sc - before_sc).count();
+  EXPECT_LE(diff, timeout + TOLERANCE);
+
+  ret = rcl_wait_set_fini(&wait_set);
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
+}
 
 // give a negative timeout
-// check interaction with timer
+// check that a timer overrides a negative timeout
 TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), negative_timeout) {
+  rcl_wait_set_t wait_set = rcl_get_zero_initialized_wait_set();
+  rcl_ret_t ret = rcl_wait_set_init(&wait_set, 0, 1, 1, 0, 0, rcl_get_default_allocator());
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
+
+  // Add a dummy guard condition to avoid an error
+  rcl_guard_condition_t guard_cond = rcl_get_zero_initialized_guard_condition();
+  ret = rcl_guard_condition_init(&guard_cond, rcl_guard_condition_get_default_options());
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
+  ret = rcl_wait_set_add_guard_condition(&wait_set, &guard_cond);
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
+
+
+  // TODO Make sure timer assumption fits with original rcl timer assumptions,
+  // maybe by duplication test separately.
+  rcl_timer_t timer = rcl_get_zero_initialized_timer();
+  rcl_timer_callback_t callback;
+  ret = rcl_timer_init(&timer, 1000000, callback, rcl_get_default_allocator());
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
+  ret = rcl_wait_set_add_timer(&wait_set, &timer);
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
+
+  int64_t timeout = -1;
+  std::chrono::steady_clock::time_point before_sc = std::chrono::steady_clock::now();
+  ret = rcl_wait(&wait_set, timeout);
+  std::chrono::steady_clock::time_point after_sc = std::chrono::steady_clock::now();
+  // We expect a timeout here (timer value reached)
+  ASSERT_EQ(RCL_RET_TIMEOUT, ret) << rcl_get_error_string_safe();
+  // Check time
+  int64_t diff = (after_sc - before_sc).count();
+  EXPECT_LE(diff, 1000000 + TOLERANCE);
+
+  ret = rcl_wait_set_fini(&wait_set);
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
+  ret = rcl_timer_fini(&timer);
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 }
 
 // give zero timeout
-// check interaction with timer
 TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), zero_timeout) {
+  rcl_wait_set_t wait_set = rcl_get_zero_initialized_wait_set();
+  rcl_ret_t ret = rcl_wait_set_init(&wait_set, 0, 1, 1, 0, 0, rcl_get_default_allocator());
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
+
+  // Add a dummy guard condition to avoid an error
+  rcl_guard_condition_t guard_cond = rcl_get_zero_initialized_guard_condition();
+  ret = rcl_guard_condition_init(&guard_cond, rcl_guard_condition_get_default_options());
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
+  ret = rcl_wait_set_add_guard_condition(&wait_set, &guard_cond);
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
+
+
+  // Time spent during wait should be negligible.
+  int64_t timeout = 0;
+  std::chrono::steady_clock::time_point before_sc = std::chrono::steady_clock::now();
+  ret = rcl_wait(&wait_set, timeout);
+  std::chrono::steady_clock::time_point after_sc = std::chrono::steady_clock::now();
+  // We expect a timeout here (timer value reached)
+  ASSERT_EQ(RCL_RET_TIMEOUT, ret) << rcl_get_error_string_safe();
+  int64_t diff = (after_sc - before_sc).count();
+  EXPECT_LE(diff, TOLERANCE);
+
+  ret = rcl_wait_set_fini(&wait_set);
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 }
 
+// Check the interaction of a guard condition and a negative timeout by
+// triggering a guard condition in a separate thread
 TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), guard_condition) {
+  rcl_wait_set_t wait_set = rcl_get_zero_initialized_wait_set();
+  rcl_ret_t ret = rcl_wait_set_init(&wait_set, 0, 1, 0, 0, 0, rcl_get_default_allocator());
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
+  rcl_guard_condition_t guard_cond = rcl_get_zero_initialized_guard_condition();
+  ret = rcl_guard_condition_init(&guard_cond, rcl_guard_condition_get_default_options());
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
+  ret = rcl_wait_set_add_guard_condition(&wait_set, &guard_cond);
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
+
+  std::promise<rcl_ret_t> p;
+
+  int64_t timeout = -1;
+
+  std::chrono::nanoseconds trigger_diff;
+  std::thread trigger_thread([&p, &guard_cond, &trigger_diff]() {
+      std::chrono::steady_clock::time_point before_trigger = std::chrono::steady_clock::now();
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      rcl_ret_t ret = rcl_trigger_guard_condition(&guard_cond);
+      std::chrono::steady_clock::time_point after_trigger = std::chrono::steady_clock::now();
+      trigger_diff = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        after_trigger - before_trigger);
+      p.set_value(ret);
+    }
+  );
+  auto f = p.get_future();
+
+  std::chrono::steady_clock::time_point before_sc = std::chrono::steady_clock::now();
+  ret = rcl_wait(&wait_set, timeout);
+  std::chrono::steady_clock::time_point after_sc = std::chrono::steady_clock::now();
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
+  int64_t diff = (after_sc - before_sc).count();
+  EXPECT_EQ(RCL_RET_OK, f.get());
+
+  ret = rcl_wait_set_fini(&wait_set);
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
+  trigger_thread.join();
+  EXPECT_LE(std::abs(diff - trigger_diff.count()), TOLERANCE);
+  ret = rcl_guard_condition_fini(&guard_cond);
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 }

--- a/rcl/test/rcl/test_wait.cpp
+++ b/rcl/test/rcl/test_wait.cpp
@@ -31,7 +31,7 @@
 #endif
 
 
-#define TOLERANCE RCL_US_TO_NS(100)
+#define TOLERANCE RCL_US_TO_NS(200)
 
 TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), test_resize_to_zero) {
   // Initialize a waitset with a subscription and then resize it to zero.

--- a/rcl/test/rcl/test_wait.cpp
+++ b/rcl/test/rcl/test_wait.cpp
@@ -31,7 +31,7 @@
 #endif
 
 
-#define TOLERANCE RCL_US_TO_NS(600)
+#define TOLERANCE RCL_MS_TO_NS(3)
 
 TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), test_resize_to_zero) {
   // Initialize a waitset with a subscription and then resize it to zero.
@@ -92,8 +92,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), negative_timeout) {
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
     ret = rcl_timer_fini(&timer);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
-  }
-    );
+  });
 
   int64_t timeout = -1;
   std::chrono::steady_clock::time_point before_sc = std::chrono::steady_clock::now();

--- a/rcl/test/rcl/test_wait.cpp
+++ b/rcl/test/rcl/test_wait.cpp
@@ -59,7 +59,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), finite_timeout) {
   ret = rcl_wait(&wait_set, timeout);
   std::chrono::steady_clock::time_point after_sc = std::chrono::steady_clock::now();
   // Check time
-  int64_t diff = (after_sc - before_sc).count();
+  int64_t diff = std::chrono::duration_cast<std::chrono::nanoseconds>(after_sc - before_sc).count();
   EXPECT_LE(diff, timeout + TOLERANCE);
 
   ret = rcl_wait_set_fini(&wait_set);

--- a/rcl/test/rcl/test_wait.cpp
+++ b/rcl/test/rcl/test_wait.cpp
@@ -31,7 +31,7 @@
 #endif
 
 
-#define TOLERANCE RCL_MS_TO_NS(3)
+#define TOLERANCE RCL_MS_TO_NS(6)
 
 TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), test_resize_to_zero) {
   // Initialize a waitset with a subscription and then resize it to zero.

--- a/rcl/test/rcl/test_wait.cpp
+++ b/rcl/test/rcl/test_wait.cpp
@@ -30,7 +30,7 @@
 #endif
 
 
-#define TOLERANCE 100000  // clock error tolerance in nanoseconds
+#define TOLERANCE RCL_US_TO_NS(100)
 
 TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), test_resize_to_zero) {
   // Initialize a waitset with a subscription and then resize it to zero.
@@ -47,13 +47,13 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), test_resize_to_zero) {
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 }
 
-// Some test cases for the waitset
+// Test rcl_wait with a positive finite timeout value (1ms)
 TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), finite_timeout) {
   rcl_wait_set_t wait_set = rcl_get_zero_initialized_wait_set();
   rcl_ret_t ret = rcl_wait_set_init(&wait_set, 0, 0, 1, 0, 0, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 
-  int64_t timeout = 1000000;  // nanoseconds
+  int64_t timeout = RCL_MS_TO_NS(1);  // nanoseconds
   std::chrono::steady_clock::time_point before_sc = std::chrono::steady_clock::now();
   ret = rcl_wait(&wait_set, timeout);
   std::chrono::steady_clock::time_point after_sc = std::chrono::steady_clock::now();
@@ -65,8 +65,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), finite_timeout) {
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 }
 
-// give a negative timeout
-// check that a timer overrides a negative timeout
+// Check that a timer overrides a negative timeout value (blocking forever)
 TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), negative_timeout) {
   rcl_wait_set_t wait_set = rcl_get_zero_initialized_wait_set();
   rcl_ret_t ret = rcl_wait_set_init(&wait_set, 0, 1, 1, 0, 0, rcl_get_default_allocator());
@@ -80,10 +79,10 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), negative_timeout) {
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 
 
-  // TODO(jacquelinekay) rcl timer tests?
+  // TODO(jacquelinekay) separate rcl timer tests
   rcl_timer_t timer = rcl_get_zero_initialized_timer();
   rcl_timer_callback_t callback;
-  ret = rcl_timer_init(&timer, 1000000, callback, rcl_get_default_allocator());
+  ret = rcl_timer_init(&timer, RCL_MS_TO_NS(1), callback, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
   ret = rcl_wait_set_add_timer(&wait_set, &timer);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
@@ -96,7 +95,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), negative_timeout) {
   ASSERT_EQ(RCL_RET_TIMEOUT, ret) << rcl_get_error_string_safe();
   // Check time
   int64_t diff = (after_sc - before_sc).count();
-  EXPECT_LE(diff, 1000000 + TOLERANCE);
+  EXPECT_LE(diff, RCL_MS_TO_NS(1) + TOLERANCE);
 
   ret = rcl_wait_set_fini(&wait_set);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
@@ -104,7 +103,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), negative_timeout) {
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 }
 
-// give zero timeout
+// Test rcl_wait with a timeout value of 0 (non-blocking)
 TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), zero_timeout) {
   rcl_wait_set_t wait_set = rcl_get_zero_initialized_wait_set();
   rcl_ret_t ret = rcl_wait_set_init(&wait_set, 0, 1, 1, 0, 0, rcl_get_default_allocator());

--- a/rcl/test/rcl/test_wait.cpp
+++ b/rcl/test/rcl/test_wait.cpp
@@ -41,3 +41,18 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), test_resize_to_zero) {
   ret = rcl_wait_set_fini(&wait_set);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 }
+
+// Some test cases for the waitset
+
+// give a negative timeout
+// check interaction with timer
+TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), negative_timeout) {
+}
+
+// give zero timeout
+// check interaction with timer
+TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), zero_timeout) {
+}
+
+TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), guard_condition) {
+}


### PR DESCRIPTION
I wrote a few tests for simple cases in `rcl_wait` and made a fix to the way timeouts and timers are handled in `rcl_wait`.

The cases are:

- positive timeout argument (1 ms)
- negative timeout argument (block forever) and a timer with 1 ms callback
- zero timeout (nonblocking)
- negative timeout argument with guard condition in the waitset that is triggered from another thread.