### PR TITLE
include launch in the package.xml

### DIFF
--- a/rcl/package.xml
+++ b/rcl/package.xml
@@ -28,6 +28,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rmw</test_depend>
+  <test_depend>launch</test_depend>
   <test_depend>example_interfaces</test_depend>
   <test_depend>std_msgs</test_depend>
 


### PR DESCRIPTION
This should fix the failing launchtests in rcl.

http://ci.ros2.org/job/ci_linux/1203/ :boom: