### PR TITLE
Keep service around until client exits

### DIFF
--- a/rcl/test/rcl/service_fixture.cpp
+++ b/rcl/test/rcl/service_fixture.cpp
@@ -151,7 +151,7 @@ int main(int argc, char ** argv)
     // Our scope exits should take care of fini for everything
     // stick around until we are killed by the client
     // To avoid an infinite loop and signal handling, just sleep for a "long" time
-    std::this_thread::sleep_for(std::chrono::seconds(10));
+    std::this_thread::sleep_for(std::chrono::seconds(3));
   }
   return main_ret;
 }

--- a/rcl/test/rcl/service_fixture.cpp
+++ b/rcl/test/rcl/service_fixture.cpp
@@ -151,7 +151,9 @@ int main(int argc, char ** argv)
     // Our scope exits should take care of fini for everything
     // stick around until we are killed by the client
     // To avoid an infinite loop and signal handling, just sleep for a "long" time
-    std::this_thread::sleep_for(std::chrono::seconds(3));
+    while (true) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
   }
   return main_ret;
 }

--- a/rcl/test/rcl/service_fixture.cpp
+++ b/rcl/test/rcl/service_fixture.cpp
@@ -147,8 +147,7 @@ int main(int argc, char ** argv)
       return -1;
     }
     // Our scope exits should take care of fini for everything
-    // stick around until we are killed by the client
-    // To avoid an infinite loop and signal handling, just sleep for a "long" time
+    // stick around until launch gives us a signal to exit
     while (true) {
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }

--- a/rcl/test/rcl/service_fixture.cpp
+++ b/rcl/test/rcl/service_fixture.cpp
@@ -149,6 +149,10 @@ int main(int argc, char ** argv)
       return -1;
     }
     // Our scope exits should take care of fini for everything
+    // stick around until we are killed by the client
+    while (true) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
   }
   return main_ret;
 }

--- a/rcl/test/rcl/service_fixture.cpp
+++ b/rcl/test/rcl/service_fixture.cpp
@@ -113,8 +113,6 @@ int main(int argc, char ** argv)
       }
     });
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-
     // Initialize a response.
     example_interfaces__srv__AddTwoInts_Response service_response;
     example_interfaces__srv__AddTwoInts_Response__init(&service_response);

--- a/rcl/test/rcl/service_fixture.cpp
+++ b/rcl/test/rcl/service_fixture.cpp
@@ -150,9 +150,8 @@ int main(int argc, char ** argv)
     }
     // Our scope exits should take care of fini for everything
     // stick around until we are killed by the client
-    while (true) {
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
-    }
+    // To avoid an infinite loop and signal handling, just sleep for a "long" time
+    std::this_thread::sleep_for(std::chrono::seconds(10));
   }
   return main_ret;
 }

--- a/rcl/test/rcl/test_two_executables.py.in
+++ b/rcl/test/rcl/test_two_executables.py.in
@@ -16,6 +16,7 @@ def @TEST_NAME@():
     ld.add_process(
         cmd=['@TEST_EXECUTABLE2@', '@TEST_EXECUTABLE1_NAME@'],
         name='@TEST_EXECUTABLE2_NAME@',
+        exit_handler=primary_exit_handler,
     )
 
     launcher = DefaultLauncher()

--- a/rcl/test/rcl/test_two_executables.py.in
+++ b/rcl/test/rcl/test_two_executables.py.in
@@ -1,6 +1,7 @@
 # generated from rcl/test/test_two_executables.py.in
 
 from launch import LaunchDescriptor
+from launch.exit_handler import ignore_signal_exit_handler
 from launch.exit_handler import primary_exit_handler
 from launch.launcher import DefaultLauncher
 
@@ -11,6 +12,7 @@ def @TEST_NAME@():
     ld.add_process(
         cmd=['@TEST_EXECUTABLE1@'],
         name='@TEST_EXECUTABLE1_NAME@',
+        exit_handler=ignore_signal_exit_handler,
     )
 
     ld.add_process(

--- a/rcl/test/rcl/test_two_executables.py.in
+++ b/rcl/test/rcl/test_two_executables.py.in
@@ -23,7 +23,8 @@ def @TEST_NAME@():
     launcher.add_launch_descriptor(ld)
     rc = launcher.launch()
 
-    assert rc == 0, "The launch file failed with exit code '" + str(rc) + "'. "
+    # -2 is SIGINT; ignore it for the secondary process
+    assert rc == 0 or rc == -2, "The launch file failed with exit code '" + str(rc) + "'. "
 
 
 if __name__ == '__main__':

--- a/rcl/test/rcl/test_two_executables.py.in
+++ b/rcl/test/rcl/test_two_executables.py.in
@@ -23,8 +23,7 @@ def @TEST_NAME@():
     launcher.add_launch_descriptor(ld)
     rc = launcher.launch()
 
-    # -2 is SIGINT; ignore it for the secondary process
-    assert rc == 0 or rc == -2, "The launch file failed with exit code '" + str(rc) + "'. "
+    assert rc == 0, "The launch file failed with exit code '" + str(rc) + "'. "
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Connects to ros2/launch#27
The remote services test is flaky for Connext because the service process needs to stick around until the client exits.