### PR TITLE
Fix atomics on Windows

### DIFF
--- a/rcl/src/rcl/stdatomic_helper/win32/stdatomic.h
+++ b/rcl/src/rcl/stdatomic_helper/win32/stdatomic.h
@@ -67,6 +67,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 
 // In MSVC, correct alignment of each type is already ensured.
 #define _Atomic(T) struct { T __val; }
@@ -205,6 +206,8 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         out = _InterlockedCompareExchange8((char *) object, desired, *expected); \
         break; \
       default: \
+        fprintf(stderr, "Unsupported integer type in atomic_compare_exchange_strong"); \
+        exit(-1); \
         break; \
     } \
   } while (0); \
@@ -231,6 +234,8 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         out = _InterlockedExchange8((char *) object, desired); \
         break; \
       default: \
+        fprintf(stderr, "Unsupported integer type in atomic_exchange_strong"); \
+        exit(-1); \
         break; \
     } \
   } while (0); \
@@ -254,6 +259,8 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         out = _InterlockedExchangeAdd8((char *) object, operand); \
         break; \
       default: \
+        fprintf(stderr, "Unsupported integer type in atomic_fetch_add"); \
+        exit(-1); \
         break; \
     } \
   } while (0); \
@@ -277,6 +284,8 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         out = _InterlockedAnd8((char *) object, operand); \
         break; \
       default: \
+        fprintf(stderr, "Unsupported integer type in atomic_fetch_and"); \
+        exit(-1); \
         break; \
     } \
   } while (0); \
@@ -300,6 +309,8 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         out = _InterlockedOr8((char *) object, operand); \
         break; \
       default: \
+        fprintf(stderr, "Unsupported integer type in atomic_fetch_or"); \
+        exit(-1); \
         break; \
     } \
   } while (0); \
@@ -326,6 +337,8 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         out = _InterlockedXor8((char *) object, operand); \
         break; \
       default: \
+        fprintf(stderr, "Unsupported integer type in atomic_fetch_xor"); \
+        exit(-1); \
         break; \
     } \
   } while (0); \
@@ -347,8 +360,10 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         break; \
       case sizeof(uint8_t): \
         out = _InterlockedExchangeAdd8((char *) object, 0); \
-		break; \
+        break; \
       default: \
+        fprintf(stderr, "Unsupported integer type in atomic_load"); \
+        exit(-1); \
         break; \
     } \
   } while (0); \

--- a/rcl/src/rcl/stdatomic_helper/win32/stdatomic.h
+++ b/rcl/src/rcl/stdatomic_helper/win32/stdatomic.h
@@ -191,7 +191,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
   __pragma(warning(push)) \
   __pragma(warning(disable: 4244)) \
   do { \
-    switch (sizeof(object)) { \
+    switch (sizeof(out)) { \
       case sizeof(uint64_t): \
         out = _InterlockedCompareExchange64((LONGLONG *) object, desired, *expected); \
         break; \
@@ -200,6 +200,9 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         break; \
       case sizeof(uint16_t): \
         out = _InterlockedCompareExchange16((SHORT *) object, desired, *expected); \
+        break; \
+      case sizeof(uint8_t): \
+        out = _InterlockedCompareExchange8((char *) object, desired, *expected); \
         break; \
       default: \
         break; \
@@ -214,7 +217,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
   __pragma(warning(push)) \
   __pragma(warning(disable: 4244)) \
   do { \
-    switch (sizeof(object)) { \
+    switch (sizeof(out)) { \
       case sizeof(uint64_t): \
         out = _InterlockedExchange64((LONGLONG *) object, desired); \
         break; \
@@ -223,6 +226,9 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         break; \
       case sizeof(uint16_t): \
         out = _InterlockedExchange16((SHORT *) object, desired); \
+        break; \
+      case sizeof(uint8_t): \
+        out = _InterlockedExchange8((char *) object, desired); \
         break; \
       default: \
         break; \
@@ -234,7 +240,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
   __pragma(warning(push)) \
   __pragma(warning(disable: 4244)) \
   do { \
-    switch (sizeof(object)) { \
+    switch (sizeof(out)) { \
       case sizeof(uint64_t): \
         out = _InterlockedExchangeAdd64((LONGLONG *) object, operand); \
         break; \
@@ -243,6 +249,9 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         break; \
       case sizeof(uint16_t): \
         out = _InterlockedExchangeAdd16((SHORT *) object, operand); \
+        break; \
+      case sizeof(uint8_t): \
+        out = _InterlockedExchangeAdd8((char *) object, operand); \
         break; \
       default: \
         break; \
@@ -254,7 +263,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
   __pragma(warning(push)) \
   __pragma(warning(disable: 4244)) \
   do { \
-    switch (sizeof(object)) { \
+    switch (sizeof(out)) { \
       case sizeof(uint64_t): \
         out = _InterlockedAnd64((LONGLONG *) object, operand); \
         break; \
@@ -263,6 +272,9 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         break; \
       case sizeof(uint16_t): \
         out = _InterlockedAnd16((SHORT *) object, operand); \
+        break; \
+      case sizeof(uint8_t): \
+        out = _InterlockedAnd8((char *) object, operand); \
         break; \
       default: \
         break; \
@@ -274,7 +286,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
   __pragma(warning(push)) \
   __pragma(warning(disable: 4244)) \
   do { \
-    switch (sizeof(object)) { \
+    switch (sizeof(out)) { \
       case sizeof(uint64_t): \
         out = _InterlockedOr64((LONGLONG *) object, operand); \
         break; \
@@ -283,6 +295,9 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         break; \
       case sizeof(uint16_t): \
         out = _InterlockedOr16((SHORT *) object, operand); \
+        break; \
+      case sizeof(uint8_t): \
+        out = _InterlockedOr8((char *) object, operand); \
         break; \
       default: \
         break; \
@@ -297,7 +312,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
   __pragma(warning(push)) \
   __pragma(warning(disable: 4244)) \
   do { \
-    switch (sizeof(object)) { \
+    switch (sizeof(out)) { \
       case sizeof(uint64_t): \
         out = _InterlockedXor64((LONGLONG *) object, operand); \
         break; \
@@ -306,6 +321,9 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
         break; \
       case sizeof(uint16_t): \
         out = _InterlockedXor16((SHORT *) object, operand); \
+        break; \
+      case sizeof(uint8_t): \
+        out = _InterlockedXor8((char *) object, operand); \
         break; \
       default: \
         break; \
@@ -317,7 +335,7 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
   __pragma(warning(push)) \
   __pragma(warning(disable: 4244)) \
   do { \
-    switch (sizeof(object)) { \
+    switch (sizeof(out)) { \
       case sizeof(uint64_t): \
         out = _InterlockedExchangeAdd64((LONGLONG *) object, 0); \
         break; \
@@ -327,6 +345,9 @@ typedef _Atomic (uintmax_t) atomic_uintmax_t;
       case sizeof(uint16_t): \
         out = _InterlockedExchangeAdd16((SHORT *) object, 0); \
         break; \
+      case sizeof(uint8_t): \
+        out = _InterlockedExchangeAdd8((char *) object, 0); \
+		break; \
       default: \
         break; \
     } \


### PR DESCRIPTION
in the macros for atomic instructions on Windows, the `object` variable is a pointer to an int, so it will always be 64-bit for 64-bit systems or 32-bit for 32-bit systems. The macros were not defined for 8-bit integer sizes so I added them in here. Also added error-checking for unsupported types.