### PR TITLE
check rmw id using RCL_ASSERT_RMW_ID_MATCHES

### DIFF
--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -24,11 +24,12 @@ set(${PROJECT_NAME}_sources
   src/rcl/node.c
   src/rcl/publisher.c
   src/rcl/rcl.c
+  src/rcl/rmw_implementation_identifier_check.c
   src/rcl/service.c
   src/rcl/subscription.c
-  src/rcl/wait.c
   src/rcl/time.c
   src/rcl/timer.c
+  src/rcl/wait.c
 )
 
 macro(target)

--- a/rcl/include/rcl/types.h
+++ b/rcl/include/rcl/types.h
@@ -26,6 +26,7 @@ typedef rmw_ret_t rcl_ret_t;
 #define RCL_RET_NOT_INIT 101
 #define RCL_RET_BAD_ALLOC 102
 #define RCL_RET_INVALID_ARGUMENT 103
+#define RCL_RET_MISMATCHED_RMW_ID 104
 // rcl node specific ret codes in 2XX
 #define RCL_RET_NODE_INVALID 200
 // rcl publisher specific ret codes in 3XX

--- a/rcl/src/rcl/rmw_implementation_identifier_check.c
+++ b/rcl/src/rcl/rmw_implementation_identifier_check.c
@@ -23,6 +23,7 @@ extern "C"
 
 #include <rmw/rmw.h>
 
+#include "rcl/types.h"
 #include "./common.h"
 
 // Extracted this portable method of doing a "shared library constructor" from SO:
@@ -58,16 +59,17 @@ INITIALIZER(initialize)
       "Error getting environement variable 'RCL_CHECK_RMW_ID_MATCHES_OR_DIE': %s\n",
       rcl_get_error_string_safe()
     );
-    exit(1);
+    exit(ret);
   }
   // If the environment variable is set, and it does not match, print a warning and exit.
   if (strlen(expected) > 0 && strcmp(rmw_get_implementation_identifier(), expected) != 0) {
     fprintf(stderr,
-      "Expected RMW implementation identifier of '%s' but instead found '%s', exiting with 1.",
+      "Expected RMW implementation identifier of '%s' but instead found '%s', exiting with %d.\n",
       expected,
-      rmw_get_implementation_identifier()
+      rmw_get_implementation_identifier(),
+      RCL_RET_MISMATCHED_RMW_ID
     );
-    exit(1);
+    exit(RCL_RET_MISMATCHED_RMW_ID);
   }
 }
 

--- a/rcl/src/rcl/rmw_implementation_identifier_check.c
+++ b/rcl/src/rcl/rmw_implementation_identifier_check.c
@@ -33,10 +33,10 @@ extern "C"
 #if defined(_MSC_VER)
   #pragma section(".CRT$XCU", read)
   #define INITIALIZER2_(f, p) \
-    static void f(void); \
-    __declspec(allocate(".CRT$XCU")) void (*f##_)(void) = f; \
-    __pragma(comment(linker, "/include:" p #f "_")) \
-    static void f(void)
+  static void f(void); \
+  __declspec(allocate(".CRT$XCU")) void(*f ## _)(void) = f; \
+  __pragma(comment(linker, "/include:" p #f "_")) \
+  static void f(void)
   #ifdef _WIN64
     #define INITIALIZER(f) INITIALIZER2_(f, "")
   #else
@@ -44,12 +44,11 @@ extern "C"
   #endif
 #else
   #define INITIALIZER(f) \
-    static void f(void) __attribute__((constructor)); \
-    static void f(void)
+  static void f(void) __attribute__((constructor)); \
+  static void f(void)
 #endif
 
-INITIALIZER(initialize)
-{
+INITIALIZER(initialize) {
   // If the environement variable RCL_ASSERT_RMW_ID_MATCHES is set,
   // check that the result of `rmw_get_implementation_identifier` matches.
   const char * expected = NULL;

--- a/rcl/src/rcl/rmw_implementation_identifier_check.c
+++ b/rcl/src/rcl/rmw_implementation_identifier_check.c
@@ -50,13 +50,13 @@ extern "C"
 
 INITIALIZER(initialize)
 {
-  // If the environement variable RCL_CHECK_RMW_ID_MATCHES_OR_DIE is set,
+  // If the environement variable RCL_ASSERT_RMW_ID_MATCHES is set,
   // check that the result of `rmw_get_implementation_identifier` matches.
   const char * expected = NULL;
-  rcl_ret_t ret = rcl_impl_getenv("RCL_CHECK_RMW_ID_MATCHES_OR_DIE", &expected);
+  rcl_ret_t ret = rcl_impl_getenv("RCL_ASSERT_RMW_ID_MATCHES", &expected);
   if (ret != RCL_RET_OK) {
     fprintf(stderr,
-      "Error getting environement variable 'RCL_CHECK_RMW_ID_MATCHES_OR_DIE': %s\n",
+      "Error getting environement variable 'RCL_ASSERT_RMW_ID_MATCHES': %s\n",
       rcl_get_error_string_safe()
     );
     exit(ret);

--- a/rcl/src/rcl/rmw_implementation_identifier_check.c
+++ b/rcl/src/rcl/rmw_implementation_identifier_check.c
@@ -1,0 +1,76 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <rmw/rmw.h>
+
+#include "./common.h"
+
+// Extracted this portable method of doing a "shared library constructor" from SO:
+//   http://stackoverflow.com/a/2390626/671658
+// Initializer/finalizer sample for MSVC and GCC/Clang.
+// 2010-2016 Joe Lowe. Released into the public domain.
+#if defined(_MSC_VER)
+  #pragma section(".CRT$XCU", read)
+  #define INITIALIZER2_(f, p) \
+    static void f(void); \
+    __declspec(allocate(".CRT$XCU")) void (*f##_)(void) = f; \
+    __pragma(comment(linker, "/include:" p #f "_")) \
+    static void f(void)
+  #ifdef _WIN64
+    #define INITIALIZER(f) INITIALIZER2_(f, "")
+  #else
+    #define INITIALIZER(f) INITIALIZER2_(f, "_")
+  #endif
+#else
+  #define INITIALIZER(f) \
+    static void f(void) __attribute__((constructor)); \
+    static void f(void)
+#endif
+
+INITIALIZER(initialize)
+{
+  // If the environement variable RCL_CHECK_RMW_ID_MATCHES_OR_DIE is set,
+  // check that the result of `rmw_get_implementation_identifier` matches.
+  const char * expected = NULL;
+  rcl_ret_t ret = rcl_impl_getenv("RCL_CHECK_RMW_ID_MATCHES_OR_DIE", &expected);
+  if (ret != RCL_RET_OK) {
+    fprintf(stderr,
+      "Error getting environement variable 'RCL_CHECK_RMW_ID_MATCHES_OR_DIE': %s\n",
+      rcl_get_error_string_safe()
+    );
+    exit(1);
+  }
+  // If the environment variable is set, and it does not match, print a warning and exit.
+  if (strlen(expected) > 0 && strcmp(rmw_get_implementation_identifier(), expected) != 0) {
+    fprintf(stderr,
+      "Expected RMW implementation identifier of '%s' but instead found '%s', exiting with 1.",
+      expected,
+      rmw_get_implementation_identifier()
+    );
+    exit(1);
+  }
+}
+
+#if __cplusplus
+}
+#endif


### PR DESCRIPTION
With this pr, if you set `RCL_CHECK_RMW_ID_MATCHES_OR_DIE` to an rmw implementation like `rmw_connext_cpp`, and the `librcl` that your program is using returns a different answer it will exit with return code 1 before running the main. If the environment variable is not set, then nothing happens.

Taking an `rcl` test as an example:

```
william@farl ~/ros2_ws/build_isolated/rcl/test (git:master:fc1a991)
% ./test_time__rmw_connext_cpp
Running main() from gtest_main.cc
[==========] Running 8 tests from 2 test cases.
...
[==========] 8 tests from 2 test cases ran. (102 ms total)
[  PASSED  ] 8 tests.

william@farl ~/ros2_ws/build_isolated/rcl/test (git:master:fc1a991)
% RCL_CHECK_RMW_ID_MATCHES_OR_DIE=rmw_connext_cpp ./test_time__rmw_connext_cpp
Running main() from gtest_main.cc
[==========] Running 8 tests from 2 test cases.
...
[==========] 8 tests from 2 test cases ran. (103 ms total)
[  PASSED  ] 8 tests.

william@farl ~/ros2_ws/build_isolated/rcl/test (git:master:fc1a991)
% RCL_CHECK_RMW_ID_MATCHES_OR_DIE=rmw_opensplice_cpp ./test_time__rmw_connext_cpp
Expected RMW implementation identifier of 'rmw_opensplice_cpp' but instead found 'rmw_connext_cpp', exiting with 1.

william@farl ~/ros2_ws/build_isolated/rcl/test (git:master:fc1a991)
% echo $?
1
```

This would be used with @dhood's pr, see: https://github.com/ros2/examples/pull/106#discussion_r61017417