### PR TITLE
Clarify wait concurrency

### DIFF
--- a/rcl/include/rcl/wait.h
+++ b/rcl/include/rcl/wait.h
@@ -513,11 +513,11 @@ rcl_wait_set_resize_services(rcl_wait_set_t * wait_set, size_t size);
  * comes first.
  * Passing a timeout struct with uninitialized memory is undefined behavior.
  *
- * \TODO(wjwwood) this function should probably be thread-safe with itself but
- *                it's not clear to me what happens if the wait sets being
- *                waited on can be overlapping or not or if we can even check.
- * This function is not thread-safe and cannot be called concurrently, even if
- * the given wait sets are not the same and non-overlapping in contents.
+ * This function is thread-safe for unique wait sets with unique contents.
+ * This function cannot operate on the same wait set in multiple threads, and
+ * the wait sets may not share content.
+ * For example, calling rcl_wait in two threads on two different wait sets that
+ * both contain a single, shared guard condition is undefined behavior.
  *
  * \param[inout] wait_set the set of things to be waited on and to be pruned if not ready
  * \param[in] timeout the duration to wait for the wait set to be ready, in nanoseconds

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -505,8 +505,12 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
     RCL_SET_ERROR_MSG("wait set is invalid");
     return RCL_RET_WAIT_SET_INVALID;
   }
-  if (wait_set->size_of_subscriptions == 0 && wait_set->size_of_guard_conditions == 0 &&
-    wait_set->size_of_clients == 0 && wait_set->size_of_services == 0)
+  if (
+    wait_set->size_of_subscriptions == 0 &&
+    wait_set->size_of_guard_conditions == 0 &&
+    wait_set->size_of_timers == 0 &&
+    wait_set->size_of_clients == 0 &&
+    wait_set->size_of_services == 0)
   {
     RCL_SET_ERROR_MSG("wait set is empty");
     return RCL_RET_WAIT_SET_EMPTY;

--- a/rcl/test/rcl/test_wait.cpp
+++ b/rcl/test/rcl/test_wait.cpp
@@ -17,6 +17,7 @@
 #include <future>
 #include <sstream>
 #include <thread>
+#include <vector>
 
 #include "gtest/gtest.h"
 
@@ -148,7 +149,8 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), multi_wait_set_threaded)
   const size_t retry_limit = 100;  // number of times to retry when a timeout occurs waiting
   const uint64_t wait_period = RCL_MS_TO_NS(1);  // timeout passed to rcl_wait each try
   const std::chrono::milliseconds trigger_period(2);  // period between each round of triggers
-  struct TestSet {
+  struct TestSet
+  {
     std::atomic<size_t> wake_count;
     rcl_wait_set_t wait_set;
     rcl_guard_condition_t guard_condition;
@@ -157,6 +159,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), multi_wait_set_threaded)
   };
   std::vector<TestSet> test_sets(number_of_threads);
   // Setup common function for waiting on the triggered guard conditions.
+  // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
   auto wait_func_factory = [](TestSet & test_set)
   {
     return [&test_set]() {
@@ -206,6 +209,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), multi_wait_set_threaded)
       }
     };
   };
+  // *INDENT-ON*
   // Setup each test set.
   for (auto & test_set : test_sets) {
     rcl_ret_t ret;
@@ -241,6 +245,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), multi_wait_set_threaded)
     test_set.thread = std::thread(wait_func_factory(test_set));
   }
   // Loop, triggering every trigger_period until the threads are done.
+  // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
   auto loop_test = [&test_sets]() -> bool {
     for (const auto & test_set : test_sets) {
       if (test_set.wake_count.load() < count_target) {
@@ -249,6 +254,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), multi_wait_set_threaded)
     }
     return false;
   };
+  // *INDENT-ON*
   // auto print_state = [&test_sets](std::string prefix) {
   //   std::stringstream ss;
   //   ss << prefix << "[";
@@ -264,8 +270,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), multi_wait_set_threaded)
   //   printf("%s\n", ss.str().c_str());
   // };
   size_t loop_count = 0;
-  while (loop_test())
-  {
+  while (loop_test()) {
     loop_count++;
     // print_state("triggering, current states: ");
     for (const auto & test_set : test_sets) {
@@ -283,7 +288,10 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), multi_wait_set_threaded)
   for (auto & test_set : test_sets) {
     ASSERT_EQ(count_target, test_set.wake_count.load());
   }
-  // printf("number of loops to get '%zu' wake ups on all threads: %zu\n", count_target, loop_count);
+  // printf(
+  //   "number of loops to get '%zu' wake ups on all threads: %zu\n",
+  //   count_target,
+  //   loop_count);
 }
 
 // Check the interaction of a guard condition and a negative timeout by

--- a/rcl/test/rcl/test_wait.cpp
+++ b/rcl/test/rcl/test_wait.cpp
@@ -42,7 +42,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), test_resize_to_zero) {
   ret = rcl_wait_set_resize_subscriptions(&wait_set, 0);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 
-  EXPECT_EQ(wait_set.size_of_subscriptions, 0);
+  EXPECT_EQ(wait_set.size_of_subscriptions, 0ull);
 
   ret = rcl_wait_set_fini(&wait_set);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
@@ -58,6 +58,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), finite_timeout) {
   std::chrono::steady_clock::time_point before_sc = std::chrono::steady_clock::now();
   ret = rcl_wait(&wait_set, timeout);
   std::chrono::steady_clock::time_point after_sc = std::chrono::steady_clock::now();
+  ASSERT_EQ(RCL_RET_TIMEOUT, ret) << rcl_get_error_string_safe();
   // Check time
   int64_t diff = std::chrono::duration_cast<std::chrono::nanoseconds>(after_sc - before_sc).count();
   EXPECT_LE(diff, timeout + TOLERANCE);
@@ -123,8 +124,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), zero_timeout) {
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
     ret = rcl_wait_set_fini(&wait_set);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
-  }
-    );
+  });
 
 
   // Time spent during wait should be negligible.
@@ -155,8 +155,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), guard_condition) {
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
     ret = rcl_guard_condition_fini(&guard_cond);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
-  }
-    );
+  });
 
   std::promise<rcl_ret_t> p;
 
@@ -171,8 +170,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), guard_condition) {
     trigger_diff = std::chrono::duration_cast<std::chrono::nanoseconds>(
       after_trigger - before_trigger);
     p.set_value(ret);
-  }
-  );
+  });
   auto f = p.get_future();
 
   std::chrono::steady_clock::time_point before_sc = std::chrono::steady_clock::now();

--- a/rcl/test/rcl/test_wait.cpp
+++ b/rcl/test/rcl/test_wait.cpp
@@ -160,9 +160,9 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), multi_wait_set_threaded)
   std::vector<TestSet> test_sets(number_of_threads);
   // Setup common function for waiting on the triggered guard conditions.
   // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
-  auto wait_func_factory = [](TestSet & test_set)
+  auto wait_func_factory = [count_target, retry_limit, wait_period](TestSet & test_set)
   {
-    return [&test_set]() {
+    return [&test_set, count_target, retry_limit, wait_period]() {
       while (test_set.wake_count < count_target) {
         bool change_detected = false;
         size_t wake_try_count = 0;
@@ -246,7 +246,7 @@ TEST(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), multi_wait_set_threaded)
   }
   // Loop, triggering every trigger_period until the threads are done.
   // *INDENT-OFF* (prevent uncrustify from making unnecessary indents here)
-  auto loop_test = [&test_sets]() -> bool {
+  auto loop_test = [&test_sets, count_target]() -> bool {
     for (const auto & test_set : test_sets) {
       if (test_set.wake_count.load() < count_target) {
         return true;


### PR DESCRIPTION
Previously the thread-safety rules around `rcl_wait` were unclear.

I categorically eliminated "thread-safe, even for the same rcl_wait_set_t instance", since it would mean concurrent read and write to the contents. 

I tested "thread-safe for different wait sets, but with shared content". I created two wait sets and one guard condition, added the guard condition to both, and waited on the wait sets each in their own thread while I triggered the guard condition in the main thread. I observed (with opensplice) that only one of the wait's would wake up per trigger, i.e. equivalent to `notify_one()` versus `notify_all()`. So that's a problem we can't work around. Another issue is that `rcl_wait` will reset any triggered guard conditions after waking up from the underlying DDS implementation. So the only way to know if a particular guard condition was triggered is to check to see if the pointer to it is null or not after `rcl_wait` wakes up. The problem is that when the guard condition is shared, there is a race condition between the DDS wait waking up and the implementation of `rmw_wait` checking to see if the condition is set. Based on those issues, and in favor of simplicity I excluded this as an option for the rule too.

That left me with "thread-safe for unique wait set instances and unique contents". `rcl_wait` does not guarantee that the wait sets are unique (that's left up to the caller to ensure), but waiting on more than one wait set concurrently which share state is declared as undefined behavior.

This pr, states this in the API documentation for `rcl_wait` and adds a test to see if that actually works as well (waiting concurrently on multiple wait sets, each with their own guard conditions).

The ramification of this is that the `rcl_node_get_graph_guard_condition` will probably need to return more than one graph guard condition object so that multiple locations can wait on their own copy. When the graph changes, each guard condition out on loan will need to be triggered. The other option is to just return the one, but make the client libraries only use one at a time. My impression is that will be overly constraining for at least rclcpp. In particular if you want to be able to wait on graph state changes without spinning and at the same time as spinning (in that case both the executor and the wait function would need their own graph guard condition).

I'll look into that tomorrow, but either way, in my opinion, this pr is still valid and ready for review.