### PR TITLE
pass along link flags, remove obsolete link flags

### DIFF
--- a/rcl/cmake/get_rcl_information.cmake
+++ b/rcl/cmake/get_rcl_information.cmake
@@ -15,8 +15,8 @@
 #
 # Get all information about rcl for a specific RMW implementation.
 #
-# It sets the common variables _DEFINITIONS, _INCLUDE_DIRS and _LIBRARIES
-# with the given prefix.
+# It sets the common variables _DEFINITIONS, _INCLUDE_DIRS, _LIBRARIES,
+# and _LINK_FLAGS with the given prefix.
 #
 # :param rmw_implementation: the RMW implementation name
 # :type target: string
@@ -81,6 +81,9 @@ macro(get_rcl_information rmw_implementation var_prefix)
     endif()
     if(${_dep}_LIBRARIES)
       list(APPEND _libs "${${_dep}_LIBRARIES}")
+    endif()
+    if(${_dep}_LINK_FLAGS)
+      list_append_unique(${var_prefix}_LINK_FLAGS "${${_dep}_LINK_FLAGS}")
     endif()
   endforeach()
   if(_libs)

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -135,13 +135,6 @@ function(test_target_function)
     AMENT_DEPENDENCIES ${rmw_implementation} "example_interfaces"
   )
 
-  # TODO remove this once connext declares libdl dependency in libnddscore again
-  # See https://github.com/ros2/rcl/issues/52
-  if(rmw_implementation STREQUAL "rmw_connext_cpp")
-    connext_workaround(client_fixture${target_suffix})
-    connext_workaround(service_fixture${target_suffix})
-  endif()
-
   rcl_add_custom_launch_test(test_services
     service_fixture
     client_fixture
@@ -150,16 +143,5 @@ function(test_target_function)
     TIMEOUT 15
   )
 endfunction()
-
-macro(connext_workaround target)
-  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    get_target_property(_current_link_flags ${target} LINK_FLAGS)
-    set(_link_flags "-Wl,--no-as-needed")
-    if(_current_link_flags)
-      set(_link_flags ${_current_link_flags} ${_link_flags})
-    endif()
-    set_target_properties(${target} PROPERTIES LINK_FLAGS "${_link_flags}")
-  endif()
-endmacro()
 
 call_for_each_rmw_implementation(test_target)


### PR DESCRIPTION
Connect to ros2/rmw_connext#173

This reverts the workaround from #55 which is not necessary anymore.