### PR TITLE
Changed RCL_RET_SUBSCRIPTION_TAKE_FAILED to 401

### DIFF
--- a/rcl/include/rcl/types.h
+++ b/rcl/include/rcl/types.h
@@ -33,7 +33,7 @@ typedef rmw_ret_t rcl_ret_t;
 #define RCL_RET_PUBLISHER_INVALID 300
 // rcl subscription specific ret codes in 4XX
 #define RCL_RET_SUBSCRIPTION_INVALID 400
-#define RCL_RET_SUBSCRIPTION_TAKE_FAILED 501
+#define RCL_RET_SUBSCRIPTION_TAKE_FAILED 401
 // rcl service client specific ret codes in 5XX
 #define RCL_RET_CLIENT_INVALID 500
 #define RCL_RET_CLIENT_TAKE_FAILED 501


### PR DESCRIPTION
Changed RCL_RET_SUBSCRIPTION_TAKE_FAILED to 401 instead of 501. Seems to be a copy&paste error: https://github.com/ros2/rcl/issues/71