### PR TITLE
Avoid overflow on 32-bit machines when working with large ns values

### DIFF
--- a/rcl/src/rcl/time_unix.c
+++ b/rcl/src/rcl/time_unix.c
@@ -66,7 +66,7 @@ rcl_system_time_now(rcl_time_point_value_t * now)
     RCL_SET_ERROR_MSG("unexpected negative time");
     return RCL_RET_ERROR;
   }
-  *now = RCL_S_TO_NS(timespec_now.tv_sec) + timespec_now.tv_nsec;
+  *now = RCL_S_TO_NS((uint64_t)timespec_now.tv_sec) + timespec_now.tv_nsec;
   return RCL_RET_OK;
 }
 
@@ -97,7 +97,7 @@ rcl_steady_time_now(rcl_time_point_value_t * now)
     RCL_SET_ERROR_MSG("unexpected negative time");
     return RCL_RET_ERROR;
   }
-  *now = RCL_S_TO_NS(timespec_now.tv_sec) + timespec_now.tv_nsec;
+  *now = RCL_S_TO_NS((uint64_t)timespec_now.tv_sec) + timespec_now.tv_nsec;
   return RCL_RET_OK;
 }
 


### PR DESCRIPTION
During the investigation of ros2/rclcpp#248, I found that the underlying clock functions weren't working properly. It turns out that we're experiencing overflow in the step where we combine the `timespec` fields into a single large ns value. The fields in `timespec` are signed longs and it seems that, at least on 32-bit ARM, that type allowed for integer overflow to occur, which results in crazy clock values.

Without this change, lots of things fail, at least intermittently, including comparisons between our time functions and `std::chrono`, like this:

https://github.com/ros2/rcl/blob/master/rcl/test/rcl/test_time.cpp#L76-L87

In other words, we already have the tests for this problem, but we haven't been running them on the architecture where it presents itself.

Life is hard when you can't figure out what time it is.