### PR TITLE
fix no data handling

### DIFF
--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -142,7 +142,6 @@ rcl_take(
     return RCL_RET_ERROR;
   }
   if (!taken) {
-    RCL_SET_ERROR_MSG(rmw_get_error_string_safe());
     return RCL_RET_SUBSCRIPTION_TAKE_FAILED;
   }
   return RCL_RET_OK;


### PR DESCRIPTION
When no data is available that is not an error case.

See error messages in http://ci.ros2.org/view/nightly/job/nightly_linux_release/197/consoleFull when searching for "subscription.c:145".

Linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=1723)](http://ci.ros2.org/job/ci_linux/1723/)