### PR TITLE
Removed RCL_RET_CLIENT_INVALID from documentation for rcl_send_response

### DIFF
--- a/rcl/include/rcl/service.h
+++ b/rcl/include/rcl/service.h
@@ -235,6 +235,7 @@ rcl_take_request(
  * \param[in] ros_response type-erased pointer to the ROS response message
  * \return RCL_RET_OK if the response was sent successfully, or
  *         RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or
+ *         RCL_RET_SERVICE_INVALID if the service is invalid, or
  *         RCL_RET_ERROR if an unspecified error occurs.
  */
 RCL_PUBLIC

--- a/rcl/include/rcl/service.h
+++ b/rcl/include/rcl/service.h
@@ -235,7 +235,6 @@ rcl_take_request(
  * \param[in] ros_response type-erased pointer to the ROS response message
  * \return RCL_RET_OK if the response was sent successfully, or
  *         RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or
- *         RCL_RET_CLIENT_INVALID if the service is invalid, or
  *         RCL_RET_ERROR if an unspecified error occurs.
  */
 RCL_PUBLIC


### PR DESCRIPTION
See: https://github.com/ros2/rcl/issues/78
I simply removed the RCL_RET_CLIENT_INVALID documentation entry from the rcl_send_response  function because the function doesn't return RCL_RET_CLIENT_INVALID. 