### PR TITLE
cast timing at macro expansion

### DIFF
--- a/rcl/include/rcl/time.h
+++ b/rcl/include/rcl/time.h
@@ -24,9 +24,9 @@ extern "C"
 #include "rcl/types.h"
 #include "rcl/visibility_control.h"
 
-#define RCL_S_TO_NS(seconds) (seconds * (1000 * 1000 * 1000))
-#define RCL_MS_TO_NS(milliseconds) (milliseconds * (1000 * 1000))
-#define RCL_US_TO_NS(microseconds) (microseconds * 1000)
+#define RCL_S_TO_NS(seconds) ((int64_t)seconds * (1000 * 1000 * 1000))
+#define RCL_MS_TO_NS(milliseconds) ((int64_t)milliseconds * (1000 * 1000))
+#define RCL_US_TO_NS(microseconds) ((int64_t)microseconds * 1000)
 
 #define RCL_NS_TO_S(nanoseconds) (nanoseconds / (1000 * 1000 * 1000))
 #define RCL_NS_TO_MS(nanoseconds) (nanoseconds / (1000 * 1000))

--- a/rcl/src/rcl/time_unix.c
+++ b/rcl/src/rcl/time_unix.c
@@ -66,7 +66,7 @@ rcl_system_time_now(rcl_time_point_value_t * now)
     RCL_SET_ERROR_MSG("unexpected negative time");
     return RCL_RET_ERROR;
   }
-  *now = RCL_S_TO_NS((uint64_t)timespec_now.tv_sec) + timespec_now.tv_nsec;
+  *now = RCL_S_TO_NS(timespec_now.tv_sec) + timespec_now.tv_nsec;
   return RCL_RET_OK;
 }
 
@@ -97,7 +97,7 @@ rcl_steady_time_now(rcl_time_point_value_t * now)
     RCL_SET_ERROR_MSG("unexpected negative time");
     return RCL_RET_ERROR;
   }
-  *now = RCL_S_TO_NS((uint64_t)timespec_now.tv_sec) + timespec_now.tv_nsec;
+  *now = RCL_S_TO_NS(timespec_now.tv_sec) + timespec_now.tv_nsec;
   return RCL_RET_OK;
 }
 


### PR DESCRIPTION
Without a cast at macro expansion we get the following warning as soon as we want to wait for more that 2 seconds
```c
warning: integer overflow in expression [-Woverflow]
 #define RCL_S_TO_NS(seconds) (seconds * (1000 * 1000 * 1000))
```