### PR TITLE
remove error msg from valid case

### DIFF
--- a/rcl/src/rcl/service.c
+++ b/rcl/src/rcl/service.c
@@ -169,7 +169,6 @@ rcl_take_request(
     return RCL_RET_ERROR;
   }
   if (!taken) {
-    RCL_SET_ERROR_MSG(rmw_get_error_string_safe());
     return RCL_RET_SERVICE_TAKE_FAILED;
   }
   return RCL_RET_OK;


### PR DESCRIPTION
Based on https://github.com/ros2/rcl/commit/534a49c480df9a45098b4b74e0390764f6f810f6#commitcomment-19763950

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=1908)](http://ci.ros2.org/job/ci_linux/1908/)
* OS X [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1458)](http://ci.ros2.org/job/ci_osx/1458/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=1852)](http://ci.ros2.org/job/ci_windows/1852/)

Connect to ros2/rclcpp#263.