### PR TITLE
Canceled timers

### DIFF
--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -534,8 +534,17 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
       if (!wait_set->timers[i]) {
         continue;  // Skip NULL timers.
       }
+      bool is_canceled = false;
+      rcl_ret_t ret = rcl_timer_is_canceled(wait_set->timers[i], &is_canceled);
+      if (ret != RCL_RET_OK) {
+        return ret;  // The rcl error state should already be set.
+      }
+      if (is_canceled) {
+        continue;  // Skip canceled timers.
+      }
+
       int64_t timer_timeout = INT64_MAX;
-      rcl_ret_t ret = rcl_timer_get_time_until_next_call(wait_set->timers[i], &timer_timeout);
+      ret = rcl_timer_get_time_until_next_call(wait_set->timers[i], &timer_timeout);
       if (ret != RCL_RET_OK) {
         return ret;  // The rcl error state should already be set.
       }


### PR DESCRIPTION
Currently `rcl_wait` wakes up on every timer (even the disabled/canceled ones) that has a negative `time_until_next_call`.
With this PR, `rcl_wait` ignores canceled timers when calculating minimum time before next wakeup

Linux: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2034)](http://ci.ros2.org/job/ci_linux/2034)
OSX: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1563)](http://ci.ros2.org/job/ci_osx/1563/)
Windows: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2023)](http://ci.ros2.org/job/ci_windows/2023)