### PR TITLE
Require C11

### DIFF
--- a/rcl_lifecycle/CMakeLists.txt
+++ b/rcl_lifecycle/CMakeLists.txt
@@ -47,6 +47,7 @@ call_for_each_rmw_implementation(targets GENERATE_DEFAULT)
 if(BUILD_TESTING)
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-std=c++14")
+    set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} "-std=c11")
     add_compile_options(-Wall -Wextra -Wpedantic)
   endif()
 

--- a/rcl_lifecycle/CMakeLists.txt
+++ b/rcl_lifecycle/CMakeLists.txt
@@ -46,8 +46,8 @@ call_for_each_rmw_implementation(targets GENERATE_DEFAULT)
 
 if(BUILD_TESTING)
   if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-std=c++14")
     set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} "-std=c11")
+    set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-std=c++14")
     add_compile_options(-Wall -Wextra -Wpedantic)
   endif()
 


### PR DESCRIPTION
This is the first Gentoo patch for ROS2. This really just allows compilation with the C-89 standard (I believe the C++-style for-loop declarations was added to C in the C-99 standard, and the default for GCC-5 is C-11).

I didn't actually have to change all that much! There's another patch that will be coming for one of the demos (there's an include that needs GCC-5 or later -- `experimental/filesystem`). This just effects the console demo, though.