### PR TITLE
dependency order

### DIFF
--- a/rcl_lifecycle/CMakeLists.txt
+++ b/rcl_lifecycle/CMakeLists.txt
@@ -29,8 +29,8 @@ macro(targets)
     ${rcl_lifecycle_sources})
 
   ament_target_dependencies(rcl_lifecycle${target_suffix}
-    "rcl${target_suffix}"
-    "lifecycle_msgs")
+    "lifecycle_msgs"
+    "rcl${target_suffix}")
 
   # Causes the visibility macros to use dllexport rather than dllimport,
   # which is appropriate when building the dll but not consuming it.


### PR DESCRIPTION
now that the typesupport refactor is done (https://github.com/ros2/ros2/issues/253#issuecomment-270202324) we can reorder dependencies properly

see https://github.com/ros2/demos/pull/104 for CI