### PR TITLE
Label skipped tests

### DIFF
--- a/rcl/test/memory_tools/CMakeLists.txt
+++ b/rcl/test/memory_tools/CMakeLists.txt
@@ -23,15 +23,18 @@ target_compile_definitions(${PROJECT_NAME}_memory_tools
 list(APPEND extra_test_libraries ${PROJECT_NAME}_memory_tools)
 
 # Create tests for the memory tools library.
-if(NOT WIN32)  # (memory tools doesn't do anything on Windows)
-  include(../rcl_add_custom_gtest.cmake)
-
-  rcl_add_custom_gtest(test_memory_tools
-    SRCS test_memory_tools.cpp
-    ENV ${extra_test_env}
-    LIBRARIES ${extra_test_libraries}
-  )
+set(SKIP_TEST "")
+if(WIN32)  # (memory tools doesn't do anything on Windows)
+  set(SKIP_TEST "SKIP_TEST")
 endif()
+
+include(../rcl_add_custom_gtest.cmake)
+rcl_add_custom_gtest(test_memory_tools
+  SRCS test_memory_tools.cpp
+  ENV ${extra_test_env}
+  LIBRARIES ${extra_test_libraries}
+  ${SKIP_TEST}
+)
 
 set(extra_test_libraries ${extra_test_libraries} PARENT_SCOPE)
 set(extra_test_env ${extra_test_env} PARENT_SCOPE)


### PR DESCRIPTION
memory_tools is not tested on Windows because it is not implemented on Windows (listed as a TODO): https://github.com/ros2/rcl/blob/226c39a8af1b6e2082a0cdb4f84028def7f7be2e/rcl/test/memory_tools/memory_tools.cpp#L102

Depending on how you look at it, this PR can be seen as either: redundant because the todo is there, or useful for reminding us that memory tools has not been implemented on windows. Thoughts?