### PR TITLE
add concept of node namespace to rcl API

### DIFF
--- a/rcl/include/rcl/node.h
+++ b/rcl/include/rcl/node.h
@@ -89,19 +89,18 @@ rcl_get_zero_initialized_node(void);
  * The name of the node cannot coincide with another node of the same name.
  * If a node of the same name is already in the domain, it will be shutdown.
  *
- * The namespace of the node should not be NULL and should also follow the
- * rules for topics, see:
+ * The namespace of the node should not be NULL and should also pass the
+ * rmw_validate_namespace() function's rules.
  *
- *   http://design.ros2.org/articles/topic_and_service_names.html
- *
- * And therefore the namespace should pass validation of the
- * rmw_validate_topic_name() function.
- * The namespace should be absolute, i.e. it should begin with a forward slash.
- * Even though this is a namespace, with additional relative namespace and/or
- * a basename to follow, the namespace string passed here should not include
- * a trailing forward slash.
- * For an empty namespace, an empty string, i.e. "", should be used.
- * The namespace "/" is considered invalid.
+ * Additionally this function allows namespaces which lack a leading forward
+ * slash.
+ * Because there is no notion of a relative namespace, there is no difference
+ * between a namespace which lacks a forward and the same namespace with a
+ * leasing forward slash.
+ * Therefore, a namespace like ``"foo/bar"`` is automatically changed to
+ * ``"/foo/bar"`` by this function.
+ * Similarly, the namespace ``""`` will implicitly become ``"/"`` which is a
+ * valid namespace.
  *
  * \todo TODO(wjwwood):
  *   Parameter infrastructure is currently initialized in the language specific

--- a/rcl/include/rcl/node.h
+++ b/rcl/include/rcl/node.h
@@ -81,15 +81,16 @@ rcl_get_zero_initialized_node(void);
  * After calling, the ROS node object can be used to create other middleware
  * primitives like publishers, services, parameters, etc.
  *
- * The name of the node must adhere to naming restrictions, see the
- * rmw_validate_node_name() function for rules.
+ * The name of the node must not be NULL and adhere to naming restrictions,
+ * see the rmw_validate_node_name() function for rules.
  *
  * \todo TODO(wjwwood): node name uniqueness is no yet enforced
  *
  * The name of the node cannot coincide with another node of the same name.
  * If a node of the same name is already in the domain, it will be shutdown.
  *
- * The namespace of the node should follow the rules for topics, see:
+ * The namespace of the node should not be NULL and should also follow the
+ * rules for topics, see:
  *
  *   http://design.ros2.org/articles/topic_and_service_names.html
  *
@@ -143,8 +144,8 @@ rcl_get_zero_initialized_node(void);
  * \post the node handle is valid and can be used in other `rcl_*` functions
  *
  * \param[inout] node a preallocated rcl_node_t
- * \param[in] name the name of the node
- * \param[in] namespace_ the namespace of the node
+ * \param[in] name the name of the node, must be a valid c-string
+ * \param[in] namespace_ the namespace of the node, must be a valid c-string
  * \param[in] options the node options
  * \return `RCL_RET_OK` if the node was initialized successfully, or
  * \return `RCL_RET_ALREADY_INIT` if the node has already be initialized, or

--- a/rcl/include/rcl/node.h
+++ b/rcl/include/rcl/node.h
@@ -44,9 +44,12 @@ typedef struct rcl_node_t
 typedef struct rcl_node_options_t
 {
   // bool anonymous_name;
+
   // rmw_qos_profile_t parameter_qos;
+
   /// If true, no parameter infrastructure will be setup.
   // bool no_parameters;
+
   /// If set, then this value overrides the ROS_DOMAIN_ID environment variable.
   /**
    * It defaults to RCL_NODE_OPTIONS_DEFAULT_DOMAIN_ID, which will cause the
@@ -59,6 +62,7 @@ typedef struct rcl_node_options_t
    *   (currently max size_t)
    */
   size_t domain_id;
+
   /// Custom allocator used for internal allocations.
   rcl_allocator_t allocator;
 } rcl_node_options_t;
@@ -77,10 +81,26 @@ rcl_get_zero_initialized_node(void);
  * After calling, the ROS node object can be used to create other middleware
  * primitives like publishers, services, parameters, etc.
  *
+ * The name of the node must adhere to naming restrictions, see the
+ * rmw_validate_node_name() function for rules.
+ *
  * \todo TODO(wjwwood): node name uniqueness is no yet enforced
  *
  * The name of the node cannot coincide with another node of the same name.
  * If a node of the same name is already in the domain, it will be shutdown.
+ *
+ * The namespace of the node should follow the rules for topics, see:
+ *
+ *   http://design.ros2.org/articles/topic_and_service_names.html
+ *
+ * And therefore the namespace should pass validation of the
+ * rmw_validate_topic_name() function.
+ * The namespace should be absolute, i.e. it should begin with a forward slash.
+ * Even though this is a namespace, with additional relative namespace and/or
+ * a basename to follow, the namespace string passed here should not include
+ * a trailing forward slash.
+ * For an empty namespace, an empty string, i.e. "", should be used.
+ * The namespace "/" is considered invalid.
  *
  * \todo TODO(wjwwood):
  *   Parameter infrastructure is currently initialized in the language specific
@@ -104,7 +124,7 @@ rcl_get_zero_initialized_node(void);
  * rcl_node_t node = rcl_get_zero_initialized_node();
  * rcl_node_options_t * node_ops = rcl_node_get_default_options();
  * // ... node options customization
- * rcl_ret_t ret = rcl_node_init(&node, "node_name", node_ops);
+ * rcl_ret_t ret = rcl_node_init(&node, "node_name", "/node_ns", node_ops);
  * // ... error handling and then use the node, but eventually deinitialize it:
  * ret = rcl_node_fini(&node);
  * // ... error handling for rcl_node_fini()
@@ -124,17 +144,24 @@ rcl_get_zero_initialized_node(void);
  *
  * \param[inout] node a preallocated rcl_node_t
  * \param[in] name the name of the node
+ * \param[in] name_space the namespace of the node
  * \param[in] options the node options
  * \return `RCL_RET_OK` if the node was initialized successfully, or
  * \return `RCL_RET_ALREADY_INIT` if the node has already be initialized, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
  * \return `RCL_RET_BAD_ALLOC` if allocating memory failed, or
+ * \return `RCL_RET_NODE_INVALID_NAME` if the name is invalid, or
+ * \return `RCL_RET_NODE_INVALID_NAMESPACE` if the name_space is invalid, or
  * \return `RCL_RET_ERROR` if an unspecified error occurs.
  */
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
-rcl_node_init(rcl_node_t * node, const char * name, const rcl_node_options_t * options);
+rcl_node_init(
+  rcl_node_t * node,
+  const char * name,
+  const char * name_space,
+  const rcl_node_options_t * options);
 
 /// Finalized a rcl_node_t.
 /**
@@ -239,6 +266,33 @@ RCL_PUBLIC
 RCL_WARN_UNUSED
 const char *
 rcl_node_get_name(const rcl_node_t * node);
+
+/// Return the namespace of the node.
+/**
+ * This function returns the node's internal namespace string.
+ * This function can fail, and therefore return `NULL`, if:
+ *   - node is `NULL`
+ *   - node has not been initialized (the implementation is invalid)
+ *
+ * The returned string is only valid as long as the given rcl_node_t is valid.
+ * The value of the string may change if the value in the rcl_node_t changes,
+ * and therefore copying the string is recommended if this is a concern.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] node pointer to the node
+ * \return name string if successful, otherwise `NULL`
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+const char *
+rcl_node_get_namespace(const rcl_node_t * node);
 
 /// Return the rcl node options.
 /**

--- a/rcl/include/rcl/node.h
+++ b/rcl/include/rcl/node.h
@@ -144,14 +144,14 @@ rcl_get_zero_initialized_node(void);
  *
  * \param[inout] node a preallocated rcl_node_t
  * \param[in] name the name of the node
- * \param[in] name_space the namespace of the node
+ * \param[in] namespace_ the namespace of the node
  * \param[in] options the node options
  * \return `RCL_RET_OK` if the node was initialized successfully, or
  * \return `RCL_RET_ALREADY_INIT` if the node has already be initialized, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
  * \return `RCL_RET_BAD_ALLOC` if allocating memory failed, or
  * \return `RCL_RET_NODE_INVALID_NAME` if the name is invalid, or
- * \return `RCL_RET_NODE_INVALID_NAMESPACE` if the name_space is invalid, or
+ * \return `RCL_RET_NODE_INVALID_NAMESPACE` if the namespace_ is invalid, or
  * \return `RCL_RET_ERROR` if an unspecified error occurs.
  */
 RCL_PUBLIC
@@ -160,7 +160,7 @@ rcl_ret_t
 rcl_node_init(
   rcl_node_t * node,
   const char * name,
-  const char * name_space,
+  const char * namespace_,
   const rcl_node_options_t * options);
 
 /// Finalized a rcl_node_t.

--- a/rcl/include/rcl/types.h
+++ b/rcl/include/rcl/types.h
@@ -24,22 +24,24 @@ typedef rmw_ret_t rcl_ret_t;
 #define RCL_RET_ERROR RMW_RET_ERROR
 /// Timeout occurred return code.
 #define RCL_RET_TIMEOUT RMW_RET_TIMEOUT
+/// Failed to allocate memory return code.
+#define RCL_RET_BAD_ALLOC RMW_RET_BAD_ALLOC
+/// Invalid argument return code.
+#define RCL_RET_INVALID_ARGUMENT RMW_RET_INVALID_ARGUMENT
 
 // rcl specific ret codes start at 100
 /// rcl_init() already called return code.
 #define RCL_RET_ALREADY_INIT 100
 /// rcl_init() not yet called return code.
 #define RCL_RET_NOT_INIT 101
-/// Failed to allocate memory return code.
-#define RCL_RET_BAD_ALLOC 102
-/// Invalid argument return code.
-#define RCL_RET_INVALID_ARGUMENT 103
 /// Mismatched rmw identifier return code.
-#define RCL_RET_MISMATCHED_RMW_ID 104
+#define RCL_RET_MISMATCHED_RMW_ID 102
 
 // rcl node specific ret codes in 2XX
 /// Invalid rcl_node_t given return code.
 #define RCL_RET_NODE_INVALID 200
+#define RCL_RET_NODE_INVALID_NAME 201
+#define RCL_RET_NODE_INVALID_NAMESPACE 202
 
 // rcl publisher specific ret codes in 3XX
 /// Invalid rcl_publisher_t given return code.

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -36,7 +36,7 @@ extern "C"
   #define LOCAL_SNPRINTF snprintf
 #else
   #define LOCAL_SNPRINTF(buffer, buffer_size, format, ...) \
-    _snprintf_s(buffer, buffer_size, _TRUNCATE, format, __VA_ARGS__)
+  _snprintf_s(buffer, buffer_size, _TRUNCATE, format, __VA_ARGS__)
 #endif
 
 typedef struct rcl_node_impl_t

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -82,8 +82,7 @@ rcl_node_init(
     allocator->deallocate, "deallocate not set", return RCL_RET_INVALID_ARGUMENT);
   // Make sure the node name is valid before allocating memory.
   int validation_result = 0;
-  size_t invalid_index = 0;
-  ret = rmw_validate_node_name(name, &validation_result, &invalid_index);
+  ret = rmw_validate_node_name(name, &validation_result, NULL);
   if (ret != RMW_RET_OK) {
     RCL_SET_ERROR_MSG(rmw_get_error_string_safe());
     return ret;

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -51,7 +51,7 @@ rcl_ret_t
 rcl_node_init(
   rcl_node_t * node,
   const char * name,
-  const char * name_space,
+  const char * namespace_,
   const rcl_node_options_t * options)
 {
   size_t domain_id = 0;
@@ -62,7 +62,7 @@ rcl_node_init(
   rcl_ret_t ret;
   rcl_ret_t fail_ret = RCL_RET_ERROR;
   RCL_CHECK_ARGUMENT_FOR_NULL(name, RCL_RET_INVALID_ARGUMENT);
-  RCL_CHECK_ARGUMENT_FOR_NULL(name_space, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(namespace_, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(options, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_INVALID_ARGUMENT);
   if (node->impl) {
@@ -96,10 +96,10 @@ rcl_node_init(
     return RCL_RET_NODE_INVALID_NAME;
   }
   // Make sure the node namespace is valid too, but only if it is not an empty string.
-  if (strlen(name_space) > 0) {
+  if (strlen(namespace_) > 0) {
     validation_result = 0;
     invalid_index = 0;
-    ret = rmw_validate_topic_name(name_space, &validation_result, &invalid_index);
+    ret = rmw_validate_topic_name(namespace_, &validation_result, &invalid_index);
     if (ret != RMW_RET_OK) {
       RCL_SET_ERROR_MSG(rmw_get_error_string_safe());
       return ret;
@@ -141,7 +141,7 @@ rcl_node_init(
   }
   // actual domain id
   node->impl->actual_domain_id = domain_id;
-  node->impl->rmw_node_handle = rmw_create_node(name, name_space, domain_id);
+  node->impl->rmw_node_handle = rmw_create_node(name, namespace_, domain_id);
   RCL_CHECK_FOR_NULL_WITH_MSG(
     node->impl->rmw_node_handle, rmw_get_error_string_safe(), goto fail);
   // instance id
@@ -256,7 +256,7 @@ rcl_node_get_namespace(const rcl_node_t * node)
   if (!rcl_node_is_valid(node)) {
     return NULL;
   }
-  return node->impl->rmw_node_handle->name_space;
+  return node->impl->rmw_node_handle->namespace_;
 }
 
 const rcl_node_options_t *

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -35,7 +35,8 @@ extern "C"
 #ifndef _WIN32
   #define LOCAL_SNPRINTF snprintf
 #else
-  #define LOCAL_SNPRINTF _snprintf
+  #define LOCAL_SNPRINTF(buffer, buffer_size, format, ...) \
+    _snprintf_s(buffer, buffer_size, _TRUNCATE, format, __VA_ARGS__)
 #endif
 
 typedef struct rcl_node_impl_t

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -32,6 +32,12 @@ extern "C"
 
 #include "./common.h"
 
+#ifndef _WIN32
+  #define LOCAL_SNPRINTF snprintf
+#else
+  #define LOCAL_SNPRINTF _snprintf
+#endif
+
 typedef struct rcl_node_impl_t
 {
   rcl_node_options_t options;
@@ -126,9 +132,14 @@ rcl_node_init(
   if (validation_result != RMW_NAMESPACE_VALID) {
     const char * msg = rmw_namespace_validation_result_string(validation_result);
     if (!msg) {
-      msg = "unknown validation_result, this should not happen";
+      char fixed_msg[256];
+      LOCAL_SNPRINTF(
+        fixed_msg, sizeof(fixed_msg),
+        "unknown validation_result '%d', this should not happen", validation_result);
+      RCL_SET_ERROR_MSG(fixed_msg);
+    } else {
+      RCL_SET_ERROR_MSG(msg);
     }
-    RCL_SET_ERROR_MSG(msg);
     return RCL_RET_NODE_INVALID_NAMESPACE;
   }
 

--- a/rcl/test/rcl/client_fixture.cpp
+++ b/rcl/test/rcl/client_fixture.cpp
@@ -109,7 +109,7 @@ int main(int argc, char ** argv)
     rcl_node_t node = rcl_get_zero_initialized_node();
     const char * name = "node_name";
     rcl_node_options_t node_options = rcl_node_get_default_options();
-    if (rcl_node_init(&node, name, &node_options) != RCL_RET_OK) {
+    if (rcl_node_init(&node, name, "", &node_options) != RCL_RET_OK) {
       fprintf(stderr, "Error in node init: %s\n", rcl_get_error_string_safe());
       return -1;
     }

--- a/rcl/test/rcl/service_fixture.cpp
+++ b/rcl/test/rcl/service_fixture.cpp
@@ -83,7 +83,7 @@ int main(int argc, char ** argv)
     rcl_node_t node = rcl_get_zero_initialized_node();
     const char * name = "node_name";
     rcl_node_options_t node_options = rcl_node_get_default_options();
-    if (rcl_node_init(&node, name, &node_options) != RCL_RET_OK) {
+    if (rcl_node_init(&node, name, "", &node_options) != RCL_RET_OK) {
       fprintf(stderr, "Error in node init: %s\n", rcl_get_error_string_safe());
       return -1;
     }

--- a/rcl/test/rcl/test_client.cpp
+++ b/rcl/test/rcl/test_client.cpp
@@ -39,7 +39,7 @@ public:
     *this->node_ptr = rcl_get_zero_initialized_node();
     const char * name = "node_name";
     rcl_node_options_t node_options = rcl_node_get_default_options();
-    ret = rcl_node_init(this->node_ptr, name, &node_options);
+    ret = rcl_node_init(this->node_ptr, name, "", &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
     set_on_unexpected_malloc_callback([]() {ASSERT_FALSE(true) << "UNEXPECTED MALLOC";});
     set_on_unexpected_realloc_callback([]() {ASSERT_FALSE(true) << "UNEXPECTED REALLOC";});

--- a/rcl/test/rcl/test_get_node_names.cpp
+++ b/rcl/test/rcl/test_get_node_names.cpp
@@ -63,14 +63,14 @@ TEST_F(CLASSNAME(TestGetNodeNames, RMW_IMPLEMENTATION), test_rcl_get_node_names)
   *node1_ptr = rcl_get_zero_initialized_node();
   const char * node1_name = "node1";
   rcl_node_options_t node1_options = rcl_node_get_default_options();
-  ret = rcl_node_init(node1_ptr, node1_name, &node1_options);
+  ret = rcl_node_init(node1_ptr, node1_name, "", &node1_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 
   auto node2_ptr = new rcl_node_t;
   *node2_ptr = rcl_get_zero_initialized_node();
   const char * node2_name = "node2";
   rcl_node_options_t node2_options = rcl_node_get_default_options();
-  ret = rcl_node_init(node2_ptr, node2_name, &node2_options);
+  ret = rcl_node_init(node2_ptr, node2_name, "", &node2_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 
   std::this_thread::sleep_for(1s);

--- a/rcl/test/rcl/test_graph.cpp
+++ b/rcl/test/rcl/test_graph.cpp
@@ -63,7 +63,7 @@ public:
     *this->old_node_ptr = rcl_get_zero_initialized_node();
     const char * old_name = "old_node_name";
     rcl_node_options_t node_options = rcl_node_get_default_options();
-    ret = rcl_node_init(this->old_node_ptr, old_name, &node_options);
+    ret = rcl_node_init(this->old_node_ptr, old_name, "", &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
     ret = rcl_shutdown();  // after this, the old_node_ptr should be invalid
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
@@ -73,7 +73,7 @@ public:
     this->node_ptr = new rcl_node_t;
     *this->node_ptr = rcl_get_zero_initialized_node();
     const char * name = "node_name";
-    ret = rcl_node_init(this->node_ptr, name, &node_options);
+    ret = rcl_node_init(this->node_ptr, name, "", &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 
     this->wait_set_ptr = new rcl_wait_set_t;

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -73,16 +73,16 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   // Create an invalid node (rcl_shutdown).
   rcl_node_t invalid_node = rcl_get_zero_initialized_node();
   const char * name = "node_name";
-  const char * name_space = "/ns";
+  const char * namespace_ = "/ns";
   rcl_node_options_t default_options = rcl_node_get_default_options();
   default_options.domain_id = 42;  // Set the domain id to something explicit.
-  ret = rcl_node_init(&invalid_node, name, name_space, &default_options);
+  ret = rcl_node_init(&invalid_node, name, namespace_, &default_options);
   if (is_windows && is_opensplice) {
     // On Windows with OpenSplice, setting the domain id is not expected to work.
     ASSERT_NE(RCL_RET_OK, ret);
     // So retry with the default domain id setting (uses the environment as is).
     default_options.domain_id = rcl_node_get_default_options().domain_id;
-    ret = rcl_node_init(&invalid_node, name, name_space, &default_options);
+    ret = rcl_node_init(&invalid_node, name, namespace_, &default_options);
     ASSERT_EQ(RCL_RET_OK, ret);
   } else {
     // This is the normal check (not windows and windows if not opensplice)
@@ -106,7 +106,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   rcl_node_t zero_node = rcl_get_zero_initialized_node();
   // Create a normal node.
   rcl_node_t node = rcl_get_zero_initialized_node();
-  ret = rcl_node_init(&node, name, name_space, &default_options);
+  ret = rcl_node_init(&node, name, namespace_, &default_options);
   ASSERT_EQ(RCL_RET_OK, ret);
   auto rcl_node_exit = make_scope_exit([&node]() {
     stop_memory_checking();
@@ -173,7 +173,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   stop_memory_checking();
   EXPECT_TRUE(actual_node_namespace ? true : false);
   if (actual_node_namespace) {
-    EXPECT_EQ(std::string(name_space), std::string(actual_node_namespace));
+    EXPECT_EQ(std::string(namespace_), std::string(actual_node_namespace));
   }
   // Test rcl_node_get_options().
   const rcl_node_options_t * actual_options;
@@ -303,7 +303,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_life_cycle)
   rcl_ret_t ret;
   rcl_node_t node = rcl_get_zero_initialized_node();
   const char * name = "node_name";
-  const char * name_space = "/ns";
+  const char * namespace_ = "/ns";
   rcl_node_options_t default_options = rcl_node_get_default_options();
   // Trying to init before rcl_init() should fail.
   ret = rcl_node_init(&node, name, "", &default_options);
@@ -317,16 +317,16 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_life_cycle)
     ASSERT_EQ(RCL_RET_OK, ret);
   });
   // Try invalid arguments.
-  ret = rcl_node_init(nullptr, name, name_space, &default_options);
+  ret = rcl_node_init(nullptr, name, namespace_, &default_options);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
   rcl_reset_error();
-  ret = rcl_node_init(&node, nullptr, name_space, &default_options);
+  ret = rcl_node_init(&node, nullptr, namespace_, &default_options);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
   rcl_reset_error();
   ret = rcl_node_init(&node, name, nullptr, &default_options);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
   rcl_reset_error();
-  ret = rcl_node_init(&node, name, name_space, nullptr);
+  ret = rcl_node_init(&node, name, namespace_, nullptr);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
   rcl_reset_error();
   // Try with invalid allocator.
@@ -334,7 +334,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_life_cycle)
   options_with_invalid_allocator.allocator.allocate = nullptr;
   options_with_invalid_allocator.allocator.deallocate = nullptr;
   options_with_invalid_allocator.allocator.reallocate = nullptr;
-  ret = rcl_node_init(&node, name, name_space, &options_with_invalid_allocator);
+  ret = rcl_node_init(&node, name, namespace_, &options_with_invalid_allocator);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << "Expected RCL_RET_INVALID_ARGUMENT";
   rcl_reset_error();
   // Try with failing allocator.
@@ -342,7 +342,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_life_cycle)
   options_with_failing_allocator.allocator.allocate = failing_malloc;
   options_with_failing_allocator.allocator.deallocate = failing_free;
   options_with_failing_allocator.allocator.reallocate = failing_realloc;
-  ret = rcl_node_init(&node, name, name_space, &options_with_failing_allocator);
+  ret = rcl_node_init(&node, name, namespace_, &options_with_failing_allocator);
   EXPECT_EQ(RCL_RET_BAD_ALLOC, ret) << "Expected RCL_RET_BAD_ALLOC";
   rcl_reset_error();
   // Try fini with invalid arguments.
@@ -353,14 +353,14 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_life_cycle)
   ret = rcl_node_fini(&node);
   EXPECT_EQ(RCL_RET_OK, ret);
   // Try a normal init and fini.
-  ret = rcl_node_init(&node, name, name_space, &default_options);
+  ret = rcl_node_init(&node, name, namespace_, &default_options);
   EXPECT_EQ(RCL_RET_OK, ret);
   ret = rcl_node_fini(&node);
   EXPECT_EQ(RCL_RET_OK, ret);
   // Try repeated init and fini calls.
-  ret = rcl_node_init(&node, name, name_space, &default_options);
+  ret = rcl_node_init(&node, name, namespace_, &default_options);
   EXPECT_EQ(RCL_RET_OK, ret);
-  ret = rcl_node_init(&node, name, name_space, &default_options);
+  ret = rcl_node_init(&node, name, namespace_, &default_options);
   EXPECT_EQ(RCL_RET_ALREADY_INIT, ret) << "Expected RCL_RET_ALREADY_INIT";
   ret = rcl_node_fini(&node);
   EXPECT_EQ(RCL_RET_OK, ret);
@@ -369,7 +369,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_life_cycle)
   // Try with a specific domain id.
   rcl_node_options_t options_with_custom_domain_id = rcl_node_get_default_options();
   options_with_custom_domain_id.domain_id = 42;
-  ret = rcl_node_init(&node, name, name_space, &options_with_custom_domain_id);
+  ret = rcl_node_init(&node, name, namespace_, &options_with_custom_domain_id);
   if (is_windows && is_opensplice) {
     // A custom domain id is not expected to work on Windows with Opensplice.
     EXPECT_NE(RCL_RET_OK, ret);
@@ -395,13 +395,13 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_name_restri
     ASSERT_EQ(RCL_RET_OK, ret);
   });
 
-  const char * name_space = "/ns";
+  const char * namespace_ = "/ns";
   rcl_node_options_t default_options = rcl_node_get_default_options();
 
   // First do a normal node name.
   {
     rcl_node_t node = rcl_get_zero_initialized_node();
-    ret = rcl_node_init(&node, "my_node_42", name_space, &default_options);
+    ret = rcl_node_init(&node, "my_node_42", namespace_, &default_options);
     ASSERT_EQ(RCL_RET_OK, ret);
     rcl_ret_t ret = rcl_node_fini(&node);
     EXPECT_EQ(RCL_RET_OK, ret);
@@ -410,7 +410,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_name_restri
   // Node name with invalid characters.
   {
     rcl_node_t node = rcl_get_zero_initialized_node();
-    ret = rcl_node_init(&node, "my_node_42$", name_space, &default_options);
+    ret = rcl_node_init(&node, "my_node_42$", namespace_, &default_options);
     ASSERT_EQ(RCL_RET_NODE_INVALID_NAME, ret);
     rcl_ret_t ret = rcl_node_fini(&node);
     EXPECT_EQ(RCL_RET_OK, ret);
@@ -419,7 +419,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_name_restri
   // Node name with /, which is valid in a topic, but not a node name.
   {
     rcl_node_t node = rcl_get_zero_initialized_node();
-    ret = rcl_node_init(&node, "my/node_42", name_space, &default_options);
+    ret = rcl_node_init(&node, "my/node_42", namespace_, &default_options);
     ASSERT_EQ(RCL_RET_NODE_INVALID_NAME, ret);
     rcl_ret_t ret = rcl_node_fini(&node);
     EXPECT_EQ(RCL_RET_OK, ret);
@@ -428,7 +428,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_name_restri
   // Node name with {}, which is valid in a topic, but not a node name.
   {
     rcl_node_t node = rcl_get_zero_initialized_node();
-    ret = rcl_node_init(&node, "my_{node}_42", name_space, &default_options);
+    ret = rcl_node_init(&node, "my_{node}_42", namespace_, &default_options);
     ASSERT_EQ(RCL_RET_NODE_INVALID_NAME, ret);
     rcl_ret_t ret = rcl_node_fini(&node);
     EXPECT_EQ(RCL_RET_OK, ret);

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -466,15 +466,16 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_namespace_r
     rcl_node_t node = rcl_get_zero_initialized_node();
     ret = rcl_node_init(&node, name, "", &default_options);
     ASSERT_EQ(RCL_RET_OK, ret);
+    ASSERT_STREQ("/", rcl_node_get_namespace(&node));
     rcl_ret_t ret = rcl_node_fini(&node);
     EXPECT_EQ(RCL_RET_OK, ret);
   }
 
-  // Node namespace which is just a forward slash, which is invalid.
+  // Node namespace which is just a forward slash, which is valid.
   {
     rcl_node_t node = rcl_get_zero_initialized_node();
     ret = rcl_node_init(&node, name, "/", &default_options);
-    ASSERT_EQ(RCL_RET_NODE_INVALID_NAMESPACE, ret);
+    ASSERT_EQ(RCL_RET_OK, ret);
     rcl_ret_t ret = rcl_node_fini(&node);
     EXPECT_EQ(RCL_RET_OK, ret);
   }
@@ -504,11 +505,12 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_namespace_r
     EXPECT_EQ(RCL_RET_OK, ret);
   }
 
-  // Node namespace which is not absolute.
+  // Node namespace which is not absolute, it should get / added automatically.
   {
     rcl_node_t node = rcl_get_zero_initialized_node();
     ret = rcl_node_init(&node, name, "ns", &default_options);
-    ASSERT_EQ(RCL_RET_NODE_INVALID_NAMESPACE, ret);
+    ASSERT_EQ(RCL_RET_OK, ret);
+    ASSERT_STREQ("/ns", rcl_node_get_namespace(&node));
     rcl_ret_t ret = rcl_node_fini(&node);
     EXPECT_EQ(RCL_RET_OK, ret);
   }

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -204,12 +204,15 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   size_t actual_domain_id;
   ret = rcl_node_get_domain_id(nullptr, &actual_domain_id);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
+  ASSERT_TRUE(rcl_error_is_set());
   rcl_reset_error();
   ret = rcl_node_get_domain_id(&zero_node, &actual_domain_id);
   EXPECT_EQ(RCL_RET_NODE_INVALID, ret);
+  ASSERT_TRUE(rcl_error_is_set());
   rcl_reset_error();
   ret = rcl_node_get_domain_id(&invalid_node, &actual_domain_id);
   EXPECT_EQ(RCL_RET_NODE_INVALID, ret);
+  ASSERT_TRUE(rcl_error_is_set());
   rcl_reset_error();
   start_memory_checking();
   assert_no_malloc_begin();
@@ -308,6 +311,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_life_cycle)
   // Trying to init before rcl_init() should fail.
   ret = rcl_node_init(&node, name, "", &default_options);
   ASSERT_EQ(RCL_RET_NOT_INIT, ret) << "Expected RCL_RET_NOT_INIT";
+  ASSERT_TRUE(rcl_error_is_set());
   rcl_reset_error();
   // Initialize rcl with rcl_init().
   ret = rcl_init(0, nullptr, rcl_get_default_allocator());
@@ -319,15 +323,19 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_life_cycle)
   // Try invalid arguments.
   ret = rcl_node_init(nullptr, name, namespace_, &default_options);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
+  ASSERT_TRUE(rcl_error_is_set());
   rcl_reset_error();
   ret = rcl_node_init(&node, nullptr, namespace_, &default_options);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
+  ASSERT_TRUE(rcl_error_is_set());
   rcl_reset_error();
   ret = rcl_node_init(&node, name, nullptr, &default_options);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
+  ASSERT_TRUE(rcl_error_is_set());
   rcl_reset_error();
   ret = rcl_node_init(&node, name, namespace_, nullptr);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
+  ASSERT_TRUE(rcl_error_is_set());
   rcl_reset_error();
   // Try with invalid allocator.
   rcl_node_options_t options_with_invalid_allocator = rcl_node_get_default_options();
@@ -336,6 +344,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_life_cycle)
   options_with_invalid_allocator.allocator.reallocate = nullptr;
   ret = rcl_node_init(&node, name, namespace_, &options_with_invalid_allocator);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << "Expected RCL_RET_INVALID_ARGUMENT";
+  ASSERT_TRUE(rcl_error_is_set());
   rcl_reset_error();
   // Try with failing allocator.
   rcl_node_options_t options_with_failing_allocator = rcl_node_get_default_options();
@@ -344,10 +353,12 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_life_cycle)
   options_with_failing_allocator.allocator.reallocate = failing_realloc;
   ret = rcl_node_init(&node, name, namespace_, &options_with_failing_allocator);
   EXPECT_EQ(RCL_RET_BAD_ALLOC, ret) << "Expected RCL_RET_BAD_ALLOC";
+  ASSERT_TRUE(rcl_error_is_set());
   rcl_reset_error();
   // Try fini with invalid arguments.
   ret = rcl_node_fini(nullptr);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << "Expected RCL_RET_INVALID_ARGUMENT";
+  ASSERT_TRUE(rcl_error_is_set());
   rcl_reset_error();
   // Try fini with an uninitialized node.
   ret = rcl_node_fini(&node);
@@ -362,6 +373,8 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_life_cycle)
   EXPECT_EQ(RCL_RET_OK, ret);
   ret = rcl_node_init(&node, name, namespace_, &default_options);
   EXPECT_EQ(RCL_RET_ALREADY_INIT, ret) << "Expected RCL_RET_ALREADY_INIT";
+  ASSERT_TRUE(rcl_error_is_set());
+  rcl_reset_error();
   ret = rcl_node_fini(&node);
   EXPECT_EQ(RCL_RET_OK, ret);
   ret = rcl_node_fini(&node);
@@ -412,6 +425,8 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_name_restri
     rcl_node_t node = rcl_get_zero_initialized_node();
     ret = rcl_node_init(&node, "my_node_42$", namespace_, &default_options);
     ASSERT_EQ(RCL_RET_NODE_INVALID_NAME, ret);
+    ASSERT_TRUE(rcl_error_is_set());
+    rcl_reset_error();
     rcl_ret_t ret = rcl_node_fini(&node);
     EXPECT_EQ(RCL_RET_OK, ret);
   }
@@ -421,6 +436,8 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_name_restri
     rcl_node_t node = rcl_get_zero_initialized_node();
     ret = rcl_node_init(&node, "my/node_42", namespace_, &default_options);
     ASSERT_EQ(RCL_RET_NODE_INVALID_NAME, ret);
+    ASSERT_TRUE(rcl_error_is_set());
+    rcl_reset_error();
     rcl_ret_t ret = rcl_node_fini(&node);
     EXPECT_EQ(RCL_RET_OK, ret);
   }
@@ -430,6 +447,8 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_name_restri
     rcl_node_t node = rcl_get_zero_initialized_node();
     ret = rcl_node_init(&node, "my_{node}_42", namespace_, &default_options);
     ASSERT_EQ(RCL_RET_NODE_INVALID_NAME, ret);
+    ASSERT_TRUE(rcl_error_is_set());
+    rcl_reset_error();
     rcl_ret_t ret = rcl_node_fini(&node);
     EXPECT_EQ(RCL_RET_OK, ret);
   }
@@ -485,6 +504,8 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_namespace_r
     rcl_node_t node = rcl_get_zero_initialized_node();
     ret = rcl_node_init(&node, name, "/ns/{name}", &default_options);
     ASSERT_EQ(RCL_RET_NODE_INVALID_NAMESPACE, ret);
+    ASSERT_TRUE(rcl_error_is_set());
+    rcl_reset_error();
     rcl_ret_t ret = rcl_node_fini(&node);
     EXPECT_EQ(RCL_RET_OK, ret);
   }
@@ -492,6 +513,8 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_namespace_r
     rcl_node_t node = rcl_get_zero_initialized_node();
     ret = rcl_node_init(&node, name, "/~/", &default_options);
     ASSERT_EQ(RCL_RET_NODE_INVALID_NAMESPACE, ret);
+    ASSERT_TRUE(rcl_error_is_set());
+    rcl_reset_error();
     rcl_ret_t ret = rcl_node_fini(&node);
     EXPECT_EQ(RCL_RET_OK, ret);
   }
@@ -501,6 +524,8 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_namespace_r
     rcl_node_t node = rcl_get_zero_initialized_node();
     ret = rcl_node_init(&node, name, "/ns/foo/", &default_options);
     ASSERT_EQ(RCL_RET_NODE_INVALID_NAMESPACE, ret);
+    ASSERT_TRUE(rcl_error_is_set());
+    rcl_reset_error();
     rcl_ret_t ret = rcl_node_fini(&node);
     EXPECT_EQ(RCL_RET_OK, ret);
   }
@@ -520,6 +545,8 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_namespace_r
     rcl_node_t node = rcl_get_zero_initialized_node();
     ret = rcl_node_init(&node, name, "/starts/with/42number", &default_options);
     ASSERT_EQ(RCL_RET_NODE_INVALID_NAMESPACE, ret);
+    ASSERT_TRUE(rcl_error_is_set());
+    rcl_reset_error();
     rcl_ret_t ret = rcl_node_fini(&node);
     EXPECT_EQ(RCL_RET_OK, ret);
   }

--- a/rcl/test/rcl/test_publisher.cpp
+++ b/rcl/test/rcl/test_publisher.cpp
@@ -46,7 +46,7 @@ public:
     *this->node_ptr = rcl_get_zero_initialized_node();
     const char * name = "node_name";
     rcl_node_options_t node_options = rcl_node_get_default_options();
-    ret = rcl_node_init(this->node_ptr, name, &node_options);
+    ret = rcl_node_init(this->node_ptr, name, "", &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
     set_on_unexpected_malloc_callback([]() {ASSERT_FALSE(true) << "UNEXPECTED MALLOC";});
     set_on_unexpected_realloc_callback([]() {ASSERT_FALSE(true) << "UNEXPECTED REALLOC";});

--- a/rcl/test/rcl/test_service.cpp
+++ b/rcl/test/rcl/test_service.cpp
@@ -49,7 +49,7 @@ public:
     *this->node_ptr = rcl_get_zero_initialized_node();
     const char * name = "node_name";
     rcl_node_options_t node_options = rcl_node_get_default_options();
-    ret = rcl_node_init(this->node_ptr, name, &node_options);
+    ret = rcl_node_init(this->node_ptr, name, "", &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
     set_on_unexpected_malloc_callback([]() {ASSERT_FALSE(true) << "UNEXPECTED MALLOC";});
     set_on_unexpected_realloc_callback([]() {ASSERT_FALSE(true) << "UNEXPECTED REALLOC";});

--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -50,7 +50,7 @@ public:
     *this->node_ptr = rcl_get_zero_initialized_node();
     const char * name = "node_name";
     rcl_node_options_t node_options = rcl_node_get_default_options();
-    ret = rcl_node_init(this->node_ptr, name, &node_options);
+    ret = rcl_node_init(this->node_ptr, name, "", &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
     set_on_unexpected_malloc_callback([]() {ASSERT_FALSE(true) << "UNEXPECTED MALLOC";});
     set_on_unexpected_realloc_callback([]() {ASSERT_FALSE(true) << "UNEXPECTED REALLOC";});

--- a/rcl_lifecycle/test/test_default_state_machine.cpp
+++ b/rcl_lifecycle/test/test_default_state_machine.cpp
@@ -42,7 +42,7 @@ protected:
     *this->node_ptr = rcl_get_zero_initialized_node();
     const char * name = "node_name";
     rcl_node_options_t node_options = rcl_node_get_default_options();
-    ret = rcl_node_init(this->node_ptr, name, &node_options);
+    ret = rcl_node_init(this->node_ptr, name, "", &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
   }
 

--- a/rcl_lifecycle/test/test_multiple_instances.cpp
+++ b/rcl_lifecycle/test/test_multiple_instances.cpp
@@ -42,7 +42,7 @@ protected:
     *this->node_ptr = rcl_get_zero_initialized_node();
     const char * name = "node_name";
     rcl_node_options_t node_options = rcl_node_get_default_options();
-    ret = rcl_node_init(this->node_ptr, name, &node_options);
+    ret = rcl_node_init(this->node_ptr, name, "", &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
   }
 


### PR DESCRIPTION
This not only exposes the node namespace in the API (via the `rcl_node_init()` and `rcl_node_get_namespace()` functions), but it also validates the node name and the new namespace arguments.

This also relies on https://github.com/ros2/rmw/pull/93 to help validate the node namespace.

Connects to ros2/rmw#95