### PR TITLE
Control shared/static linking via BUILD_SHARED_LIBS and ament_cmake_ros

### DIFF
--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rcl)
 
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 find_package(rcl_interfaces REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rmw_implementation REQUIRED)
@@ -32,7 +32,7 @@ set(${PROJECT_NAME}_sources
   src/rcl/wait.c
 )
 
-add_library(${PROJECT_NAME} SHARED ${${PROJECT_NAME}_sources})
+add_library(${PROJECT_NAME} ${${PROJECT_NAME}_sources})
 ament_target_dependencies(${PROJECT_NAME}
   "rcl_interfaces"
   "rmw"

--- a/rcl/package.xml
+++ b/rcl/package.xml
@@ -9,7 +9,7 @@
   <maintainer email="william@osrfoundation.org">William Woodall</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <build_export_depend>rmw</build_export_depend>
 


### PR DESCRIPTION
Reverts #114 

@dirk-thomas I got the `rcl` tests passing locally with this PR, ament/gtest_vendor#4 and ament/gmock_vendor#3