### PR TITLE
reenable tests for rcl_node_get_graph_guard_condition for all rmw impl

### DIFF
--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -64,10 +64,9 @@ function(test_target_function)
   )
 
   set(SKIP_TEST "")
-  # TODO(wjwwood): remove this when the graph API works properly for FastRTPS
+  # TODO(wjwwood): remove this when the graph API works properly for connext dynamic
   if(
-    rmw_implementation STREQUAL "rmw_connext_dynamic_cpp" OR
-    rmw_implementation STREQUAL "rmw_fastrtps_cpp"
+    rmw_implementation STREQUAL "rmw_connext_dynamic_cpp"
   )
     message(STATUS "Skipping test_graph${target_suffix} test.")
     set(SKIP_TEST "SKIP_TEST")

--- a/rcl/test/rcl/test_graph.cpp
+++ b/rcl/test/rcl/test_graph.cpp
@@ -263,7 +263,7 @@ check_graph_state(
     rcl_reset_error();
     is_in_tnat = false;
     for (size_t i = 0; RCL_RET_OK == ret && i < tnat.topic_count; ++i) {
-      if (topic_name == std::string(tnat.topic_names[i])) {
+      if (topic_name == tnat.topic_names[i]) {
         ASSERT_FALSE(is_in_tnat) << "duplicates in the tnat";  // Found it more than once!
         is_in_tnat = true;
       }
@@ -288,6 +288,16 @@ check_graph_state(
     {
       printf("  state correct!\n");
       break;
+    } else {
+      if (expected_publisher_count != publisher_count) {
+        printf("    pub count incorrect!\n");
+      }
+      if (expected_subscriber_count != subscriber_count) {
+        printf("    sub count incorrect!\n");
+      }
+      if (expected_in_tnat != is_in_tnat) {
+        printf("    in tnat incorrect!\n");
+      }
     }
     // Wait for graph change before trying again.
     if ((i + 1) == number_of_tries) {

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -272,31 +272,26 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   stop_memory_checking();
   EXPECT_NE(0u, instance_id);
   // Test rcl_node_get_graph_guard_condition
-  std::string rmw_id(rmw_get_implementation_identifier());
-  if (rmw_id.find("opensplice") != std::string::npos) {
-    // Only test with opensplice for now, as connext and fastrtps are not working.
-    // TODO(wjwwood): remove this check when more middlewares implement this
-    const rcl_guard_condition_t * graph_guard_condition = nullptr;
-    graph_guard_condition = rcl_node_get_graph_guard_condition(nullptr);
-    EXPECT_EQ(nullptr, graph_guard_condition);
-    rcl_reset_error();
-    graph_guard_condition = rcl_node_get_graph_guard_condition(&zero_node);
-    EXPECT_EQ(nullptr, graph_guard_condition);
-    rcl_reset_error();
-    graph_guard_condition = rcl_node_get_graph_guard_condition(&invalid_node);
-    EXPECT_EQ(nullptr, graph_guard_condition);
-    rcl_reset_error();
-    start_memory_checking();
-    assert_no_malloc_begin();
-    assert_no_realloc_begin();
-    assert_no_free_begin();
-    graph_guard_condition = rcl_node_get_graph_guard_condition(&node);
-    assert_no_malloc_end();
-    assert_no_realloc_end();
-    assert_no_free_end();
-    stop_memory_checking();
-    EXPECT_NE(nullptr, graph_guard_condition);
-  }
+  const rcl_guard_condition_t * graph_guard_condition = nullptr;
+  graph_guard_condition = rcl_node_get_graph_guard_condition(nullptr);
+  EXPECT_EQ(nullptr, graph_guard_condition);
+  rcl_reset_error();
+  graph_guard_condition = rcl_node_get_graph_guard_condition(&zero_node);
+  EXPECT_EQ(nullptr, graph_guard_condition);
+  rcl_reset_error();
+  graph_guard_condition = rcl_node_get_graph_guard_condition(&invalid_node);
+  EXPECT_EQ(nullptr, graph_guard_condition);
+  rcl_reset_error();
+  start_memory_checking();
+  assert_no_malloc_begin();
+  assert_no_realloc_begin();
+  assert_no_free_begin();
+  graph_guard_condition = rcl_node_get_graph_guard_condition(&node);
+  assert_no_malloc_end();
+  assert_no_realloc_end();
+  assert_no_free_end();
+  stop_memory_checking();
+  EXPECT_NE(nullptr, graph_guard_condition);
 }
 
 /* Tests the node life cycle, including rcl_node_init() and rcl_node_fini().


### PR DESCRIPTION
I noticed this while doing some changes in `rcl`. I believe this should be reenabled already, I must have just overlooked it at the time.