### PR TITLE
time OS-specific implementation chosen by CMakeLists.txt

### DIFF
--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -16,6 +16,12 @@ if(NOT WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra")
 endif()
 
+if(WIN32)
+  set(time_impl_c src/rcl/time_win32.c)
+else()
+  set(time_impl_c src/rcl/time_unix.c)
+endif()
+
 set(${PROJECT_NAME}_sources
   src/rcl/allocator.c
   src/rcl/client.c
@@ -29,6 +35,7 @@ set(${PROJECT_NAME}_sources
   src/rcl/service.c
   src/rcl/subscription.c
   src/rcl/time.c
+  ${time_impl_c}
   src/rcl/timer.c
   src/rcl/wait.c
 )

--- a/rcl/src/rcl/time.c
+++ b/rcl/src/rcl/time.c
@@ -12,16 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "rcl/time.h"
+
 #include <stdbool.h>
 #include <stdlib.h>
 
-#if defined(WIN32)
-#include "./time_win32.c"
-#else  // defined(WIN32)
-#include "./time_unix.c"
-#endif  // defined(WIN32)
-
+#include "./common.h"
 #include "./stdatomic_helper.h"
+#include "rcl/error_handling.h"
 
 // Process default ROS time sources
 static rcl_time_source_t * rcl_default_ros_time_source;


### PR DESCRIPTION
This could enable users to port RCL to an other OS without modifying `time.c`
And other people could also say it's better to not include `.c` files ? ^^