### PR TITLE
Debug info for test_rcl_get_node_names

### DIFF
--- a/rcl/test/rcl/client_fixture.cpp
+++ b/rcl/test/rcl/client_fixture.cpp
@@ -107,7 +107,7 @@ int main(int argc, char ** argv)
       return -1;
     }
     rcl_node_t node = rcl_get_zero_initialized_node();
-    const char * name = "node_name";
+    const char * name = "client_fixture_node";
     rcl_node_options_t node_options = rcl_node_get_default_options();
     if (rcl_node_init(&node, name, "", &node_options) != RCL_RET_OK) {
       fprintf(stderr, "Error in node init: %s\n", rcl_get_error_string_safe());

--- a/rcl/test/rcl/service_fixture.cpp
+++ b/rcl/test/rcl/service_fixture.cpp
@@ -81,7 +81,7 @@ int main(int argc, char ** argv)
       return -1;
     }
     rcl_node_t node = rcl_get_zero_initialized_node();
-    const char * name = "node_name";
+    const char * name = "service_fixture_node";
     rcl_node_options_t node_options = rcl_node_get_default_options();
     if (rcl_node_init(&node, name, "", &node_options) != RCL_RET_OK) {
       fprintf(stderr, "Error in node init: %s\n", rcl_get_error_string_safe());

--- a/rcl/test/rcl/test_client.cpp
+++ b/rcl/test/rcl/test_client.cpp
@@ -37,7 +37,7 @@ public:
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
     this->node_ptr = new rcl_node_t;
     *this->node_ptr = rcl_get_zero_initialized_node();
-    const char * name = "node_name";
+    const char * name = "test_client_node";
     rcl_node_options_t node_options = rcl_node_get_default_options();
     ret = rcl_node_init(this->node_ptr, name, "", &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();

--- a/rcl/test/rcl/test_get_node_names.cpp
+++ b/rcl/test/rcl/test_get_node_names.cpp
@@ -15,6 +15,8 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <iostream>
+#include <sstream>
 #include <thread>
 
 #include "rcutils/types.h"
@@ -81,7 +83,12 @@ TEST_F(CLASSNAME(TestGetNodeNames, RMW_IMPLEMENTATION), test_rcl_get_node_names)
   ret = rcl_get_node_names(node1_ptr, node1_options.allocator, &node_names);
   ASSERT_EQ(RCUTILS_RET_OK, ret) << rcl_get_error_string_safe();
 
-  EXPECT_EQ(size_t(2), node_names.size);
+  std::stringstream ss;
+  ss << "Found node names:" << std::endl;
+  for (size_t i = 0; i < node_names.size; ++i) {
+    ss << node_names.data[i] << std::endl;
+  }
+  EXPECT_EQ(size_t(2), node_names.size) << ss.str();
   EXPECT_EQ(0, strcmp(node1_name, node_names.data[0]));
   EXPECT_EQ(0, strcmp(node2_name, node_names.data[1]));
 

--- a/rcl/test/rcl/test_get_node_names.cpp
+++ b/rcl/test/rcl/test_get_node_names.cpp
@@ -84,7 +84,7 @@ TEST_F(CLASSNAME(TestGetNodeNames, RMW_IMPLEMENTATION), test_rcl_get_node_names)
   ASSERT_EQ(RCUTILS_RET_OK, ret) << rcl_get_error_string_safe();
 
   std::stringstream ss;
-  ss << "Found node names:" << std::endl;
+  ss << "[test_rcl_get_node_names]: Found node names:" << std::endl;
   for (size_t i = 0; i < node_names.size; ++i) {
     ss << node_names.data[i] << std::endl;
   }

--- a/rcl/test/rcl/test_graph.cpp
+++ b/rcl/test/rcl/test_graph.cpp
@@ -72,7 +72,7 @@ public:
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
     this->node_ptr = new rcl_node_t;
     *this->node_ptr = rcl_get_zero_initialized_node();
-    const char * name = "node_name";
+    const char * name = "test_graph_node";
     ret = rcl_node_init(this->node_ptr, name, "", &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -72,7 +72,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   ASSERT_EQ(RCL_RET_OK, ret);  // Shutdown later after invalid node.
   // Create an invalid node (rcl_shutdown).
   rcl_node_t invalid_node = rcl_get_zero_initialized_node();
-  const char * name = "node_name";
+  const char * name = "test_rcl_node_accessors_node";
   const char * namespace_ = "/ns";
   rcl_node_options_t default_options = rcl_node_get_default_options();
   default_options.domain_id = 42;  // Set the domain id to something explicit.
@@ -305,7 +305,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_life_cycle)
   stop_memory_checking();
   rcl_ret_t ret;
   rcl_node_t node = rcl_get_zero_initialized_node();
-  const char * name = "node_name";
+  const char * name = "test_rcl_node_life_cycle_node";
   const char * namespace_ = "/ns";
   rcl_node_options_t default_options = rcl_node_get_default_options();
   // Trying to init before rcl_init() should fail.

--- a/rcl/test/rcl/test_publisher.cpp
+++ b/rcl/test/rcl/test_publisher.cpp
@@ -44,7 +44,7 @@ public:
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
     this->node_ptr = new rcl_node_t;
     *this->node_ptr = rcl_get_zero_initialized_node();
-    const char * name = "node_name";
+    const char * name = "test_publisher_node";
     rcl_node_options_t node_options = rcl_node_get_default_options();
     ret = rcl_node_init(this->node_ptr, name, "", &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();

--- a/rcl/test/rcl/test_service.cpp
+++ b/rcl/test/rcl/test_service.cpp
@@ -47,7 +47,7 @@ public:
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
     this->node_ptr = new rcl_node_t;
     *this->node_ptr = rcl_get_zero_initialized_node();
-    const char * name = "node_name";
+    const char * name = "test_service_node";
     rcl_node_options_t node_options = rcl_node_get_default_options();
     ret = rcl_node_init(this->node_ptr, name, "", &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();

--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -48,7 +48,7 @@ public:
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
     this->node_ptr = new rcl_node_t;
     *this->node_ptr = rcl_get_zero_initialized_node();
-    const char * name = "node_name";
+    const char * name = "test_subscription_node";
     rcl_node_options_t node_options = rcl_node_get_default_options();
     ret = rcl_node_init(this->node_ptr, name, "", &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();

--- a/rcl_lifecycle/test/test_default_state_machine.cpp
+++ b/rcl_lifecycle/test/test_default_state_machine.cpp
@@ -40,7 +40,7 @@ protected:
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
     this->node_ptr = new rcl_node_t;
     *this->node_ptr = rcl_get_zero_initialized_node();
-    const char * name = "node_name";
+    const char * name = "test_state_machine_node";
     rcl_node_options_t node_options = rcl_node_get_default_options();
     ret = rcl_node_init(this->node_ptr, name, "", &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();

--- a/rcl_lifecycle/test/test_multiple_instances.cpp
+++ b/rcl_lifecycle/test/test_multiple_instances.cpp
@@ -40,7 +40,7 @@ protected:
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
     this->node_ptr = new rcl_node_t;
     *this->node_ptr = rcl_get_zero_initialized_node();
-    const char * name = "node_name";
+    const char * name = "test_multiple_instances_node";
     rcl_node_options_t node_options = rcl_node_get_default_options();
     ret = rcl_node_init(this->node_ptr, name, "", &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();


### PR DESCRIPTION
Print unexpected node names found during test and give test nodes unique names.

Motivated by `test_rcl_get_node_names` failing in some repeated nightlies (e.g. http://ci.ros2.org/job/nightly_osx_repeated/665/testReport/junit/(root)/TestGetNodeNames__rmw_connext_cpp/test_rcl_get_node_names/) without any debug output

Standard CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2568)](http://ci.ros2.org/job/ci_linux/2568/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=165)](http://ci.ros2.org/job/ci_linux-aarch64/165/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2038)](http://ci.ros2.org/job/ci_osx/2038/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2677)](http://ci.ros2.org/job/ci_windows/2677/) (flaky test)

Repeating rcl tests to get extra debug output:
http://ci.ros2.org/job/ci_osx/2024/testReport/junit/(root)/TestGetNodeNames__rmw_connext_cpp/test_rcl_get_node_names/