### PR TITLE
Explicitly set C11 and C++14 via the CMake variables

### DIFF
--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -23,8 +23,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(NOT WIN32)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+  add_compile_options("-Wall -Wextra")
 endif()
 
 set(${PROJECT_NAME}_sources

--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -23,7 +23,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options("-Wall -Wextra")
+  add_compile_options(-Wall -Wextra)
 endif()
 
 set(${PROJECT_NAME}_sources

--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -12,8 +12,15 @@ find_package(rosidl_generator_c REQUIRED)
 
 include_directories(include)
 
-set(CMAKE_C_STANDARD 99)
-set(CMAKE_CXX_STANDARD 14)
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
 if(NOT WIN32)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")

--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -12,9 +12,9 @@ find_package(rosidl_generator_c REQUIRED)
 
 include_directories(include)
 
-# Default to C99
+# Default to C11
 if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
+  set(CMAKE_C_STANDARD 11)
 endif()
 
 # Default to C++14

--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
-if(NOT WIN32)
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options("-Wall -Wextra")
 endif()
 

--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -12,9 +12,12 @@ find_package(rosidl_generator_c REQUIRED)
 
 include_directories(include)
 
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_CXX_STANDARD 14)
+
 if(NOT WIN32)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
 endif()
 
 set(${PROJECT_NAME}_sources

--- a/rcl_lifecycle/CMakeLists.txt
+++ b/rcl_lifecycle/CMakeLists.txt
@@ -11,8 +11,15 @@ find_package(rmw REQUIRED)
 
 include_directories(include)
 
-set(CMAKE_C_STANDARD 99)
-set(CMAKE_CXX_STANDARD 14)
+# Default to C99
+if(NOT CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
+endif()
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
 
 if(NOT WIN32)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wpedantic")

--- a/rcl_lifecycle/CMakeLists.txt
+++ b/rcl_lifecycle/CMakeLists.txt
@@ -11,6 +11,14 @@ find_package(rmw REQUIRED)
 
 include_directories(include)
 
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_CXX_STANDARD 14)
+
+if(NOT WIN32)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wpedantic")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+endif()
+
 set(rcl_lifecycle_sources
   src/com_interface.c
   src/default_state_machine.c
@@ -43,12 +51,6 @@ install(TARGETS rcl_lifecycle
   RUNTIME DESTINATION bin)
 
 if(BUILD_TESTING)
-  if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-    add_compile_options(-Wall -Wextra -Wpedantic)
-  endif()
-
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   find_package(rcl REQUIRED)

--- a/rcl_lifecycle/CMakeLists.txt
+++ b/rcl_lifecycle/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options("-Wall -Wextra -Wpedantic")
+  add_compile_options(-Wall -Wextra -Wpedantic)
 endif()
 
 set(rcl_lifecycle_sources

--- a/rcl_lifecycle/CMakeLists.txt
+++ b/rcl_lifecycle/CMakeLists.txt
@@ -11,9 +11,9 @@ find_package(rmw REQUIRED)
 
 include_directories(include)
 
-# Default to C99
+# Default to C11
 if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
+  set(CMAKE_C_STANDARD 11)
 endif()
 
 # Default to C++14

--- a/rcl_lifecycle/CMakeLists.txt
+++ b/rcl_lifecycle/CMakeLists.txt
@@ -21,9 +21,8 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 14)
 endif()
 
-if(NOT WIN32)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wpedantic")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options("-Wall -Wextra -Wpedantic")
 endif()
 
 set(rcl_lifecycle_sources


### PR DESCRIPTION
This PR uses `CMAKE_C_STANDARD` and `CMAKE_CXX_STANDARD` to set C11 and C++14 respectively.