### PR TITLE
ensure node is valid before using it

### DIFF
--- a/rcl/src/rcl/client.c
+++ b/rcl/src/rcl/client.c
@@ -173,8 +173,11 @@ rcl_client_fini(rcl_client_t * client, rcl_node_t * node)
   RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   if (client->impl) {
     rcl_allocator_t allocator = client->impl->options.allocator;
-    rmw_ret_t ret =
-      rmw_destroy_client(rcl_node_get_rmw_handle(node), client->impl->rmw_handle);
+    rmw_node_t * rmw_node = rcl_node_get_rmw_handle(node);
+    if (!rmw_node) {
+      return RCL_RET_INVALID_ARGUMENT;
+    }
+    rmw_ret_t ret = rmw_destroy_client(rmw_node, client->impl->rmw_handle);
     if (ret != RMW_RET_OK) {
       RCL_SET_ERROR_MSG(rmw_get_error_string_safe(), allocator);
       result = RCL_RET_ERROR;

--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -170,8 +170,12 @@ rcl_publisher_fini(rcl_publisher_t * publisher, rcl_node_t * node)
   RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   if (publisher->impl) {
     rcl_allocator_t allocator = publisher->impl->options.allocator;
+    rmw_node_t * rmw_node = rcl_node_get_rmw_handle(node);
+    if (!rmw_node) {
+      return RCL_RET_INVALID_ARGUMENT;
+    }
     rmw_ret_t ret =
-      rmw_destroy_publisher(rcl_node_get_rmw_handle(node), publisher->impl->rmw_handle);
+      rmw_destroy_publisher(rmw_node, publisher->impl->rmw_handle);
     if (ret != RMW_RET_OK) {
       RCL_SET_ERROR_MSG(rmw_get_error_string_safe(), allocator);
       result = RCL_RET_ERROR;

--- a/rcl/src/rcl/service.c
+++ b/rcl/src/rcl/service.c
@@ -174,8 +174,11 @@ rcl_service_fini(rcl_service_t * service, rcl_node_t * node)
   RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   if (service->impl) {
     rcl_allocator_t allocator = service->impl->options.allocator;
-    rmw_ret_t ret =
-      rmw_destroy_service(rcl_node_get_rmw_handle(node), service->impl->rmw_handle);
+    rmw_node_t * rmw_node = rcl_node_get_rmw_handle(node);
+    if (!rmw_node) {
+      return RCL_RET_INVALID_ARGUMENT;
+    }
+    rmw_ret_t ret = rmw_destroy_service(rmw_node, service->impl->rmw_handle);
     if (ret != RMW_RET_OK) {
       RCL_SET_ERROR_MSG(rmw_get_error_string_safe(), allocator);
       result = RCL_RET_ERROR;

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -165,8 +165,12 @@ rcl_subscription_fini(rcl_subscription_t * subscription, rcl_node_t * node)
   RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   if (subscription->impl) {
     rcl_allocator_t allocator = subscription->impl->options.allocator;
+    rmw_node_t * rmw_node = rcl_node_get_rmw_handle(node);
+    if (!rmw_node) {
+      return RCL_RET_INVALID_ARGUMENT;
+    }
     rmw_ret_t ret =
-      rmw_destroy_subscription(rcl_node_get_rmw_handle(node), subscription->impl->rmw_handle);
+      rmw_destroy_subscription(rmw_node, subscription->impl->rmw_handle);
     if (ret != RMW_RET_OK) {
       RCL_SET_ERROR_MSG(rmw_get_error_string_safe(), allocator);
       result = RCL_RET_ERROR;


### PR DESCRIPTION
Otherwise `rcl_node_get_rmw_handle` is being called, sets an error, returns null, and the next function like `rmw_destroy_*` is being called with `NULL` as the rmw node.

I didn't trigger CI since there is currently no test which has this case.

Ready for review.