### PR TITLE
Fix memory problems in rcl.

### DIFF
--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -323,11 +323,21 @@ rcl_node_fini(rcl_node_t * node)
   }
   rcl_allocator_t allocator = node->impl->options.allocator;
   rcl_ret_t result = RCL_RET_OK;
-  rmw_ret_t ret = rmw_destroy_node(node->impl->rmw_node_handle);
-  if (ret != RMW_RET_OK) {
+  rmw_ret_t rmw_ret = rmw_destroy_node(node->impl->rmw_node_handle);
+  if (rmw_ret != RMW_RET_OK) {
     RCL_SET_ERROR_MSG(rmw_get_error_string_safe(), allocator);
     result = RCL_RET_ERROR;
   }
+  rcl_ret_t rcl_ret = rcl_guard_condition_fini(node->impl->graph_guard_condition);
+  if (rcl_ret != RCL_RET_OK) {
+    if (result != RCL_RET_OK) {
+      // Here, we are overwriting a previous error; log it
+      fprintf(stderr, "overwriting error in rcl_node_fini: previous error was '%s'\n", rcl_get_error_string_safe());
+    }
+    RCL_SET_ERROR_MSG(rmw_get_error_string_safe(), allocator);
+    result = RCL_RET_ERROR;
+  }
+  allocator.deallocate(node->impl->graph_guard_condition, allocator.state);
   // assuming that allocate and deallocate are ok since they are checked in init
   allocator.deallocate(node->impl, allocator.state);
   node->impl = NULL;

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -330,10 +330,6 @@ rcl_node_fini(rcl_node_t * node)
   }
   rcl_ret_t rcl_ret = rcl_guard_condition_fini(node->impl->graph_guard_condition);
   if (rcl_ret != RCL_RET_OK) {
-    if (result != RCL_RET_OK) {
-      // Here, we are overwriting a previous error; log it
-      fprintf(stderr, "overwriting error in rcl_node_fini: previous error was '%s'\n", rcl_get_error_string_safe());
-    }
     RCL_SET_ERROR_MSG(rmw_get_error_string_safe(), allocator);
     result = RCL_RET_ERROR;
   }


### PR DESCRIPTION
There are actually two problems here.  In one of the problems,
we were sometimes taking an rcl_guard_condition that we did *not*
allocate, and trying to deallocate it.  This was leading to
double frees.

The second problem was forgetting to call guard_condition_fini
during node_fini.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

connects to ros2/ros2#387

CI jobs are in the above issue