### PR TITLE
reset expected error msg to avoid warning

### DIFF
--- a/rcl_lifecycle/test/test_default_state_machine.cpp
+++ b/rcl_lifecycle/test/test_default_state_machine.cpp
@@ -95,6 +95,7 @@ test_trigger_transition(
 TEST_F(TestDefaultStateMachine, zero_init) {
   rcl_lifecycle_state_machine_t state_machine = rcl_lifecycle_get_zero_initialized_state_machine();
   ASSERT_EQ(rcl_lifecycle_state_machine_is_initialized(&state_machine), RCL_RET_ERROR);
+  rcl_reset_error();
   const rcl_lifecycle_transition_map_t * transition_map = &state_machine.transition_map;
   ASSERT_EQ(transition_map->states_size, (unsigned int)0);
   ASSERT_EQ(transition_map->states, nullptr);


### PR DESCRIPTION
Fixes #155.

While the error is expected it is not being reset. In the following other errors are expected but triggered the warning seen in the output.