### PR TITLE
nullify canceled timers

### DIFF
--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -548,6 +548,7 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
         return ret;  // The rcl error state should already be set.
       }
       if (is_canceled) {
+        wait_set->timers[i] = NULL;
         continue;  // Skip canceled timers.
       }
 


### PR DESCRIPTION
Opening this for bookkeeping, I'll provide a more detailed description once I have time to investigate.

Right now `rcl_wait` returns a non-null pointer for timers that passed the deadline but are canceled. Forcing functions processing the waitset values to check if they are actually ready (e.g. [here](https://github.com/ros2/rclpy/blob/master/rclpy/rclpy/__init__.py#L94)). The current fix sets the cancelled timers to null before passing them to the rmw waitset

Needs some investigation to find out if this is the right fix and if it's the good thing to do to not update cancel timer and skip them in the waitset. Feedback in that matter is welcome!