### PR TITLE
remove todo that doesnt seem necessary anymore

### DIFF
--- a/rcl/test/rcl/test_publisher.cpp
+++ b/rcl/test/rcl/test_publisher.cpp
@@ -127,9 +127,7 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_nomin
   std_msgs__msg__String__init(&msg);
   ASSERT_TRUE(rosidl_generator_c__String__assign(&msg.data, "testing"));
   ret = rcl_publish(&publisher, &msg);
-  // TODO(wjwwood): re-enable this fini when ownership of the string is resolved.
-  //                currently with Connext we will spuriously get a double free here.
-  // std_msgs__msg__String__fini(&msg);
+  std_msgs__msg__String__fini(&msg);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 }
 

--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -212,9 +212,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
     std_msgs__msg__String__init(&msg);
     ASSERT_TRUE(rosidl_generator_c__String__assign(&msg.data, test_string));
     ret = rcl_publish(&publisher, &msg);
-    // TODO(wjwwood): re-enable this fini when ownership of the string is resolved.
-    //                currently with Connext we will spuriously get a double free here.
-    // std_msgs__msg__String__fini(&msg);
+    std_msgs__msg__String__fini(&msg);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
   }
   bool success;


### PR DESCRIPTION
I saw that when writing tests based on a copy of test_publisher.cpp
Not sure if this was a Connext or Connext Dynamic issue. @wjwwood can you confirm whether or not we should remove this?

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3106)](http://ci.ros2.org/job/ci_linux/3106/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=477)](http://ci.ros2.org/job/ci_linux-aarch64/477/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2483)](http://ci.ros2.org/job/ci_osx/2483/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3170)](http://ci.ros2.org/job/ci_windows/3170/)