### PR TITLE
Restructure the time source and clock methods in rcl

### DIFF
--- a/rcl/include/rcl/time.h
+++ b/rcl/include/rcl/time.h
@@ -237,43 +237,6 @@ RCL_WARN_UNUSED
 rcl_ret_t
 rcl_system_clock_fini(rcl_clock_t * clock);
 
-/// Initialize a time point using the clock.
-/**
- * This function will initialize the time_point using the clock
- * as a reference.
- * If the clock is null it will use the system default clock.
- *
- * This will allocate all necessary internal structures, and initialize variables.
- * The clock may be of types `RCL_ROS_TIME`, `RCL_STEADY_TIME`, or
- * `RCL_SYSTEM_TIME`.
- *
- * \param[in] time_point the handle to the clock which is being initialized.
- * \param[in] clock_type the type of the clock that clock will be used for reference.
- * \return `RCL_RET_OK` if the last call time was retrieved successfully, or
- * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
- * \return `RCL_RET_ERROR` an unspecified error occur.
- */
-RCL_PUBLIC
-RCL_WARN_UNUSED
-rcl_ret_t
-rcl_time_point_init(rcl_time_point_t * time_point, rcl_clock_type_t * clock_type);
-
-/// Finalize a time_point
-/**
- * Finalize the time_point such that it is ready for deallocation.
- *
- * This will deallocate all necessary internal structures, and clean up any variables.
- *
- * \param[in] time_point the handle to the time_point which is being finalized.
- * \return `RCL_RET_OK` if the last call time was retrieved successfully, or
- * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
- * \return `RCL_RET_ERROR` an unspecified error occur.
- */
-RCL_PUBLIC
-RCL_WARN_UNUSED
-rcl_ret_t
-rcl_time_point_fini(rcl_time_point_t * time_point);
-
 /// Initialize a duration using the clock.
 /**
  * This function will initialize the duration using the clock as a reference.
@@ -344,7 +307,7 @@ rcl_difference_times(
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
-rcl_time_point_get_now(rcl_clock_t * clock, rcl_time_point_t * time_point);
+rcl_clock_get_now(rcl_clock_t * clock, rcl_time_point_t * time_point);
 
 
 /// Enable the ROS time abstraction override.
@@ -396,7 +359,7 @@ RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
 rcl_is_enabled_ros_time_override(
-  rcl_time_source_t * time_source, bool * is_enabled);
+  rcl_clock_t * time_source, bool * is_enabled);
 
 /// Set the current time for this `RCL_ROS_TIME` time source.
 /**
@@ -415,7 +378,7 @@ RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
 rcl_set_ros_time_override(
-  rcl_time_source_t * time_source, rcl_time_point_value_t time_value);
+  rcl_clock_t * time_source, rcl_time_point_value_t time_value);
 
 #if __cplusplus
 }

--- a/rcl/include/rcl/time.h
+++ b/rcl/include/rcl/time.h
@@ -77,7 +77,6 @@ typedef struct rcl_time_point_t
 typedef struct rcl_duration_t
 {
   rcl_duration_value_t nanoseconds;
-  rcl_clock_type_t clock_type;
 } rcl_duration_t;
 
 // typedef struct rcl_rate_t
@@ -119,7 +118,7 @@ RCL_WARN_UNUSED
 rcl_ret_t
 rcl_clock_init(
   enum rcl_clock_type_t clock_type, rcl_clock_t * clock,
-  const rcl_allocator_t * allocator);
+  rcl_allocator_t * allocator);
 
 /// Finalize a clock.
 /**
@@ -156,7 +155,7 @@ RCL_WARN_UNUSED
 rcl_ret_t
 rcl_ros_clock_init(
   rcl_clock_t * clock,
-  const rcl_allocator_t * allocator);
+  rcl_allocator_t * allocator);
 
 /// Finalize a clock as a `RCL_ROS_TIME` time source.
 /**
@@ -191,7 +190,7 @@ RCL_WARN_UNUSED
 rcl_ret_t
 rcl_steady_clock_init(
   rcl_clock_t * clock,
-  const rcl_allocator_t * allocator);
+  rcl_allocator_t * allocator);
 
 /// Finalize a clock as a `RCL_STEADY_TIME` time source.
 /**
@@ -230,7 +229,7 @@ RCL_WARN_UNUSED
 rcl_ret_t
 rcl_system_clock_init(
   rcl_clock_t * clock,
-  const rcl_allocator_t * allocator);
+  rcl_allocator_t * allocator);
 
 /// Finalize a clock as a `RCL_SYSTEM_TIME` time source.
 /**
@@ -250,41 +249,6 @@ RCL_WARN_UNUSED
 rcl_ret_t
 rcl_system_clock_fini(
   rcl_clock_t * clock);
-
-/// Initialize a duration using the clock.
-/**
- * This function will initialize the duration using the clock as a reference.
- * If the clock is null it will use the system default clock.
- *
- * This will allocate all necessary internal structures, and initialize variables.
- * The clock may be of types ros, steady, or system.
- *
- * \param[in] duration the handle to the duration which is being initialized.
- * \param[in] clock_type The type of the clock will be used for reference.
- * \return `RCL_RET_OK` if the last call time was retrieved successfully, or
- * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
- * \return `RCL_RET_ERROR` an unspecified error occur.
- */
-RCL_PUBLIC
-RCL_WARN_UNUSED
-rcl_ret_t
-rcl_duration_init(rcl_duration_t * duration, rcl_clock_type_t * clock_type);
-
-/// Finalize a duration
-/**
- * Finalize the duration such that it is ready for deallocation.
- *
- * This will deallocate all necessary internal structures, and clean up any variables.
- *
- * \param[in] duration the handle to the duration which is being finalized.
- * \return `RCL_RET_OK` if the last call time was retrieved successfully, or
- * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
- * \return `RCL_RET_ERROR` an unspecified error occur.
- */
-RCL_PUBLIC
-RCL_WARN_UNUSED
-rcl_ret_t
-rcl_duration_fini(rcl_duration_t * duration);
 
 /// Compute the difference between two time points
 /**
@@ -373,7 +337,7 @@ RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
 rcl_is_enabled_ros_time_override(
-  rcl_clock_t * time_source, bool * is_enabled);
+  rcl_clock_t * clock, bool * is_enabled);
 
 /// Set the current time for this `RCL_ROS_TIME` time source.
 /**
@@ -392,7 +356,7 @@ RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
 rcl_set_ros_time_override(
-  rcl_clock_t * time_source, rcl_time_point_value_t time_value);
+  rcl_clock_t * clock, rcl_time_point_value_t time_value);
 
 #if __cplusplus
 }

--- a/rcl/include/rcl/time.h
+++ b/rcl/include/rcl/time.h
@@ -20,6 +20,7 @@ extern "C"
 {
 #endif
 
+#include "rcl/allocator.h"
 #include "rcl/macros.h"
 #include "rcl/types.h"
 #include "rcl/visibility_control.h"
@@ -62,9 +63,8 @@ typedef struct rcl_clock_t
   rcl_ret_t (* get_now)(void * data, rcl_time_point_value_t * now);
   // void (*set_now) (rcl_time_point_value_t);
   void * data;
+  rcl_allocator_t * allocator;
 } rcl_clock_t;
-
-struct rcl_ros_clock_storage_t;
 
 /// A single point in time, measured in nanoseconds, the reference point is based on the source.
 typedef struct rcl_time_point_t
@@ -109,6 +109,7 @@ rcl_clock_valid(rcl_clock_t * clock);
  *
  * \param[in] clock_type the type identifying the time source to provide
  * \param[in] clock the handle to the clock which is being initialized
+ * \param[in] allocator The allocator to use for allocations
  * \return `RCL_RET_OK` if the time source was successfully initialized, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
  * \return `RCL_RET_ERROR` an unspecified error occur.
@@ -117,8 +118,8 @@ RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
 rcl_clock_init(
-  enum rcl_clock_type_t clock_type, rcl_clock_t * clock
-);
+  enum rcl_clock_type_t clock_type, rcl_clock_t * clock,
+  const rcl_allocator_t * allocator);
 
 /// Finalize a clock.
 /**
@@ -136,7 +137,8 @@ rcl_clock_init(
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
-rcl_clock_fini(rcl_clock_t * clock);
+rcl_clock_fini(
+  rcl_clock_t * clock);
 
 /// Initialize a clock as a RCL_ROS_TIME time source.
 /**
@@ -144,6 +146,7 @@ rcl_clock_fini(rcl_clock_t * clock);
  * It is specifically setting up a RCL_ROS_TIME time source.
  *
  * \param[in] clock the handle to the clock which is being initialized
+ * \param[in] allocator The allocator to use for allocations
  * \return `RCL_RET_OK` if the time source was successfully initialized, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
  * \return `RCL_RET_ERROR` an unspecified error occur.
@@ -151,7 +154,9 @@ rcl_clock_fini(rcl_clock_t * clock);
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
-rcl_ros_clock_init(rcl_clock_t * clock);
+rcl_ros_clock_init(
+  rcl_clock_t * clock,
+  const rcl_allocator_t * allocator);
 
 /// Finalize a clock as a `RCL_ROS_TIME` time source.
 /**
@@ -167,7 +172,8 @@ rcl_ros_clock_init(rcl_clock_t * clock);
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
-rcl_ros_clock_fini(rcl_clock_t * clock);
+rcl_ros_clock_fini(
+  rcl_clock_t * clock);
 
 /// Initialize a clock as a `RCL_STEADY_TIME` time source.
 /**
@@ -175,6 +181,7 @@ rcl_ros_clock_fini(rcl_clock_t * clock);
  * It is specifically setting up a `RCL_STEADY_TIME` time source.
  *
  * \param[in] clock the handle to the clock which is being initialized
+ * \param[in] allocator The allocator to use for allocations
  * \return `RCL_RET_OK` if the time source was successfully initialized, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
  * \return `RCL_RET_ERROR` an unspecified error occur.
@@ -182,7 +189,9 @@ rcl_ros_clock_fini(rcl_clock_t * clock);
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
-rcl_steady_clock_init(rcl_clock_t * clock);
+rcl_steady_clock_init(
+  rcl_clock_t * clock,
+  const rcl_allocator_t * allocator);
 
 /// Finalize a clock as a `RCL_STEADY_TIME` time source.
 /**
@@ -200,7 +209,8 @@ rcl_steady_clock_init(rcl_clock_t * clock);
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
-rcl_steady_clock_fini(rcl_clock_t * clock);
+rcl_steady_clock_fini(
+  rcl_clock_t * clock);
 
 /// Initialize a clock as a `RCL_SYSTEM_TIME` time source.
 /**
@@ -210,6 +220,7 @@ rcl_steady_clock_fini(rcl_clock_t * clock);
  * It is specifically setting up a system time source.
  *
  * \param[in] clock the handle to the clock which is being initialized
+ * \param[in] allocator The allocator to use for allocations
  * \return `RCL_RET_OK` if the time source was successfully initialized, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
  * \return `RCL_RET_ERROR` an unspecified error occur.
@@ -217,7 +228,9 @@ rcl_steady_clock_fini(rcl_clock_t * clock);
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
-rcl_system_clock_init(rcl_clock_t * clock);
+rcl_system_clock_init(
+  rcl_clock_t * clock,
+  const rcl_allocator_t * allocator);
 
 /// Finalize a clock as a `RCL_SYSTEM_TIME` time source.
 /**
@@ -235,7 +248,8 @@ rcl_system_clock_init(rcl_clock_t * clock);
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
-rcl_system_clock_fini(rcl_clock_t * clock);
+rcl_system_clock_fini(
+  rcl_clock_t * clock);
 
 /// Initialize a duration using the clock.
 /**

--- a/rcl/src/rcl/time.c
+++ b/rcl/src/rcl/time.c
@@ -86,7 +86,7 @@ rcl_clock_valid(rcl_clock_t * clock)
 rcl_ret_t
 rcl_clock_init(
   enum rcl_clock_type_t clock_type, rcl_clock_t * clock,
-  const rcl_allocator_t * allocator)
+  rcl_allocator_t * allocator)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(allocator, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   switch (clock_type) {
@@ -127,7 +127,7 @@ rcl_clock_fini(
 rcl_ret_t
 rcl_ros_clock_init(
   rcl_clock_t * clock,
-  const rcl_allocator_t * allocator)
+  rcl_allocator_t * allocator)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   RCL_CHECK_ARGUMENT_FOR_NULL(allocator, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
@@ -157,7 +157,7 @@ rcl_ros_clock_fini(
 rcl_ret_t
 rcl_steady_clock_init(
   rcl_clock_t * clock,
-  const rcl_allocator_t * allocator)
+  rcl_allocator_t * allocator)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   RCL_CHECK_ARGUMENT_FOR_NULL(allocator, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
@@ -183,7 +183,7 @@ rcl_steady_clock_fini(
 rcl_ret_t
 rcl_system_clock_init(
   rcl_clock_t * clock,
-  const rcl_allocator_t * allocator)
+  rcl_allocator_t * allocator)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   RCL_CHECK_ARGUMENT_FOR_NULL(allocator, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
@@ -205,25 +205,6 @@ rcl_system_clock_fini(
   }
   return RCL_RET_OK;
 }
-
-rcl_ret_t
-rcl_duration_init(rcl_duration_t * duration, rcl_clock_type_t * clock_type)
-{
-  RCL_CHECK_ARGUMENT_FOR_NULL(duration, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  RCL_CHECK_ARGUMENT_FOR_NULL(clock_type, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  duration->clock_type = *clock_type;
-
-  return RCL_RET_OK;
-}
-
-rcl_ret_t
-rcl_duration_fini(rcl_duration_t * duration)
-{
-  RCL_CHECK_ARGUMENT_FOR_NULL(duration, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  (void)duration;
-  return RCL_RET_OK;
-}
-
 
 rcl_ret_t
 rcl_difference_times(

--- a/rcl/src/rcl/time.c
+++ b/rcl/src/rcl/time.c
@@ -189,24 +189,6 @@ rcl_system_clock_fini(rcl_clock_t * clock)
 }
 
 rcl_ret_t
-rcl_time_point_init(rcl_time_point_t * time_point, rcl_clock_type_t * clock_type)
-{
-  RCL_CHECK_ARGUMENT_FOR_NULL(time_point, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  RCL_CHECK_ARGUMENT_FOR_NULL(clock_type, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  time_point->clock_type = *clock_type;
-
-  return RCL_RET_OK;
-}
-
-rcl_ret_t
-rcl_time_point_fini(rcl_time_point_t * time_point)
-{
-  RCL_CHECK_ARGUMENT_FOR_NULL(time_point, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  (void)time_point;
-  return RCL_RET_OK;
-}
-
-rcl_ret_t
 rcl_duration_init(rcl_duration_t * duration, rcl_clock_type_t * clock_type)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(duration, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
@@ -238,17 +220,18 @@ rcl_difference_times(
   if (finish->nanoseconds < start->nanoseconds) {
     rcl_time_point_value_t intermediate = start->nanoseconds - finish->nanoseconds;
     delta->nanoseconds = -1 * (int) intermediate;
+  } else {
+    delta->nanoseconds = (int)(finish->nanoseconds - start->nanoseconds);
   }
-  delta->nanoseconds = (int)(finish->nanoseconds - start->nanoseconds);
   return RCL_RET_OK;
 }
 
 rcl_ret_t
-rcl_time_point_get_now(rcl_clock_t * clock, rcl_time_point_t * time_point)
+rcl_clock_get_now(rcl_clock_t * clock, rcl_time_point_t * time_point)
 {
   // TODO(tfoote) switch to use external time source
   RCL_CHECK_ARGUMENT_FOR_NULL(time_point, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  if (time_point->clock_type && clock->get_now) {
+  if (clock->type && clock->get_now) {
     return clock->get_now(clock->data,
              &(time_point->nanoseconds));
   }

--- a/rcl/src/rcl/time.c
+++ b/rcl/src/rcl/time.c
@@ -29,7 +29,6 @@ typedef struct rcl_ros_clock_storage_t
 {
   atomic_uint_least64_t current_time;
   bool active;
-  // TODO(tfoote): store subscription here
 } rcl_ros_clock_storage_t;
 
 // Implementation only
@@ -86,9 +85,10 @@ rcl_clock_valid(rcl_clock_t * clock)
 
 rcl_ret_t
 rcl_clock_init(
-  enum rcl_clock_type_t clock_type, rcl_clock_t * clock
-)
+  enum rcl_clock_type_t clock_type, rcl_clock_t * clock,
+  const rcl_allocator_t * allocator)
 {
+  RCL_CHECK_ARGUMENT_FOR_NULL(allocator, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   switch (clock_type) {
     case RCL_CLOCK_UNINITIALIZED:
       RCL_CHECK_ARGUMENT_FOR_NULL(
@@ -96,18 +96,19 @@ rcl_clock_init(
       rcl_init_generic_clock(clock);
       return RCL_RET_OK;
     case RCL_ROS_TIME:
-      return rcl_ros_clock_init(clock);
+      return rcl_ros_clock_init(clock, allocator);
     case RCL_SYSTEM_TIME:
-      return rcl_system_clock_init(clock);
+      return rcl_system_clock_init(clock, allocator);
     case RCL_STEADY_TIME:
-      return rcl_steady_clock_init(clock);
+      return rcl_steady_clock_init(clock, allocator);
     default:
       return RCL_RET_INVALID_ARGUMENT;
   }
 }
 
 rcl_ret_t
-rcl_clock_fini(rcl_clock_t * clock)
+rcl_clock_fini(
+  rcl_clock_t * clock)
 {
   switch (clock->type) {
     case RCL_ROS_TIME:
@@ -124,40 +125,52 @@ rcl_clock_fini(rcl_clock_t * clock)
 }
 
 rcl_ret_t
-rcl_ros_clock_init(rcl_clock_t * clock)
+rcl_ros_clock_init(
+  rcl_clock_t * clock,
+  const rcl_allocator_t * allocator)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
+  RCL_CHECK_ARGUMENT_FOR_NULL(allocator, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   rcl_init_generic_clock(clock);
-  clock->data = calloc(1, sizeof(rcl_ros_clock_storage_t));
+  clock->data = allocator->allocate(sizeof(rcl_ros_clock_storage_t), allocator->state);
+  rcl_ros_clock_storage_t * storage = (rcl_ros_clock_storage_t *)clock->data;
+  storage->active = false;
   clock->get_now = rcl_get_ros_time;
   clock->type = RCL_ROS_TIME;
+  clock->allocator = allocator;
   return RCL_RET_OK;
 }
 
 rcl_ret_t
-rcl_ros_clock_fini(rcl_clock_t * clock)
+rcl_ros_clock_fini(
+  rcl_clock_t * clock)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   if (clock->type != RCL_ROS_TIME) {
     RCL_SET_ERROR_MSG("clock not of type RCL_ROS_TIME", rcl_get_default_allocator());
     return RCL_RET_ERROR;
   }
-  free((rcl_ros_clock_storage_t *)clock->data);
+  clock->allocator->deallocate((rcl_ros_clock_storage_t *)clock->data, clock->allocator->state);
   return RCL_RET_OK;
 }
 
 rcl_ret_t
-rcl_steady_clock_init(rcl_clock_t * clock)
+rcl_steady_clock_init(
+  rcl_clock_t * clock,
+  const rcl_allocator_t * allocator)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
+  RCL_CHECK_ARGUMENT_FOR_NULL(allocator, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   rcl_init_generic_clock(clock);
   clock->get_now = rcl_get_steady_time;
   clock->type = RCL_STEADY_TIME;
+  clock->allocator = allocator;
   return RCL_RET_OK;
 }
 
 rcl_ret_t
-rcl_steady_clock_fini(rcl_clock_t * clock)
+rcl_steady_clock_fini(
+  rcl_clock_t * clock)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   if (clock->type != RCL_STEADY_TIME) {
@@ -168,17 +181,22 @@ rcl_steady_clock_fini(rcl_clock_t * clock)
 }
 
 rcl_ret_t
-rcl_system_clock_init(rcl_clock_t * clock)
+rcl_system_clock_init(
+  rcl_clock_t * clock,
+  const rcl_allocator_t * allocator)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
+  RCL_CHECK_ARGUMENT_FOR_NULL(allocator, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   rcl_init_generic_clock(clock);
   clock->get_now = rcl_get_system_time;
   clock->type = RCL_SYSTEM_TIME;
+  clock->allocator = allocator;
   return RCL_RET_OK;
 }
 
 rcl_ret_t
-rcl_system_clock_fini(rcl_clock_t * clock)
+rcl_system_clock_fini(
+  rcl_clock_t * clock)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   if (clock->type != RCL_SYSTEM_TIME) {
@@ -229,7 +247,6 @@ rcl_difference_times(
 rcl_ret_t
 rcl_clock_get_now(rcl_clock_t * clock, rcl_time_point_t * time_point)
 {
-  // TODO(tfoote) switch to use external time source
   RCL_CHECK_ARGUMENT_FOR_NULL(time_point, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   if (clock->type && clock->get_now) {
     return clock->get_now(clock->data,
@@ -250,8 +267,7 @@ rcl_enable_ros_time_override(rcl_clock_t * clock)
       "Time source is not RCL_ROS_TIME cannot enable override.", rcl_get_default_allocator())
     return RCL_RET_ERROR;
   }
-  rcl_ros_clock_storage_t * storage = \
-    (rcl_ros_clock_storage_t *)clock->data;
+  rcl_ros_clock_storage_t * storage = (rcl_ros_clock_storage_t *)clock->data;
   if (!storage) {
     RCL_SET_ERROR_MSG("Storage not initialized, cannot enable.", rcl_get_default_allocator())
     return RCL_RET_ERROR;

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -56,7 +56,11 @@ public:
 
 // Tests the rcl_set_ros_time_override() function.
 TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_ros_time_set_override) {
-  rcl_time_source_t * ros_time_source = rcl_get_default_ros_time_source();
+  rcl_clock_t * ros_clock =
+    reinterpret_cast<rcl_clock_t *>(calloc(1, sizeof(rcl_clock_t)));
+  rcl_ret_t retval = rcl_ros_clock_init(ros_clock);
+  EXPECT_EQ(retval, RCL_RET_OK) << rcl_get_error_string_safe();
+
   assert_no_realloc_begin();
   rcl_ret_t ret;
   // Check for invalid argument error condition (allowed to alloc).
@@ -67,7 +71,7 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_ros_time_set_ove
   ret = rcl_is_enabled_ros_time_override(nullptr, &result);
   EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT) << rcl_get_error_string_safe();
   rcl_reset_error();
-  ret = rcl_is_enabled_ros_time_override(ros_time_source, nullptr);
+  ret = rcl_is_enabled_ros_time_override(ros_clock, nullptr);
   EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT) << rcl_get_error_string_safe();
   rcl_reset_error();
   ret = rcl_is_enabled_ros_time_override(nullptr, nullptr);
@@ -75,15 +79,15 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_ros_time_set_ove
   rcl_reset_error();
   rcl_time_point_t query_now;
   bool is_enabled;
-  ret = rcl_is_enabled_ros_time_override(ros_time_source, &is_enabled);
+  ret = rcl_is_enabled_ros_time_override(ros_clock, &is_enabled);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   EXPECT_EQ(is_enabled, false);
-  ret = rcl_time_point_init(&query_now, ros_time_source);
+  ret = rcl_time_point_init(&query_now, &(ros_clock->type));
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   assert_no_malloc_begin();
   assert_no_free_begin();
   // Check for normal operation (not allowed to alloc).
-  ret = rcl_time_point_get_now(&query_now);
+  ret = rcl_time_point_get_now(ros_clock, &query_now);
   assert_no_malloc_end();
   assert_no_realloc_end();
   assert_no_free_end();
@@ -91,7 +95,7 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_ros_time_set_ove
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   EXPECT_NE(query_now.nanoseconds, 0u);
   // Compare to std::chrono::system_clock time (within a second).
-  ret = rcl_time_point_get_now(&query_now);
+  ret = rcl_time_point_get_now(ros_clock, &query_now);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   {
     std::chrono::system_clock::time_point now_sc = std::chrono::system_clock::now();
@@ -104,18 +108,18 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_ros_time_set_ove
   // Test ros time specific APIs
   rcl_time_point_value_t set_point = 1000000000ull;
   // Check initialized state
-  ret = rcl_is_enabled_ros_time_override(ros_time_source, &is_enabled);
+  ret = rcl_is_enabled_ros_time_override(ros_clock, &is_enabled);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   EXPECT_EQ(is_enabled, false);
   // set the time point
-  ret = rcl_set_ros_time_override(ros_time_source, set_point);
+  ret = rcl_set_ros_time_override(ros_clock, set_point);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   // check still disabled
-  ret = rcl_is_enabled_ros_time_override(ros_time_source, &is_enabled);
+  ret = rcl_is_enabled_ros_time_override(ros_clock, &is_enabled);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   EXPECT_EQ(is_enabled, false);
   // get real
-  ret = rcl_time_point_get_now(&query_now);
+  ret = rcl_time_point_get_now(ros_clock, &query_now);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   {
     std::chrono::system_clock::time_point now_sc = std::chrono::system_clock::now();
@@ -126,25 +130,25 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_ros_time_set_ove
     EXPECT_LE(llabs(now_diff), RCL_MS_TO_NS(k_tolerance_ms)) << "ros_clock differs";
   }
   // enable
-  ret = rcl_enable_ros_time_override(ros_time_source);
+  ret = rcl_enable_ros_time_override(ros_clock);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   // check enabled
-  ret = rcl_is_enabled_ros_time_override(ros_time_source, &is_enabled);
+  ret = rcl_is_enabled_ros_time_override(ros_clock, &is_enabled);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   EXPECT_EQ(is_enabled, true);
   // get sim
-  ret = rcl_time_point_get_now(&query_now);
+  ret = rcl_time_point_get_now(ros_clock, &query_now);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   EXPECT_EQ(query_now.nanoseconds, set_point);
   // disable
-  ret = rcl_disable_ros_time_override(ros_time_source);
+  ret = rcl_disable_ros_time_override(ros_clock);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   // check disabled
-  ret = rcl_is_enabled_ros_time_override(ros_time_source, &is_enabled);
+  ret = rcl_is_enabled_ros_time_override(ros_clock, &is_enabled);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   EXPECT_EQ(is_enabled, false);
   // get real
-  ret = rcl_time_point_get_now(&query_now);
+  ret = rcl_time_point_get_now(ros_clock, &query_now);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   {
     std::chrono::system_clock::time_point now_sc = std::chrono::system_clock::now();
@@ -156,24 +160,29 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_ros_time_set_ove
   }
 }
 
-TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_init_for_time_source_and_point) {
+TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_init_for_clock_and_point) {
   assert_no_realloc_begin();
   rcl_ret_t ret;
   // Check for invalid argument error condition (allowed to alloc).
-  ret = rcl_ros_time_source_init(nullptr);
+  ret = rcl_ros_clock_init(nullptr);
   EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT) << rcl_get_error_string_safe();
   rcl_reset_error();
   // Check for normal operation (not allowed to alloc).
-  rcl_time_source_t source;
-  ret = rcl_ros_time_source_init(&source);
+  rcl_clock_t source;
+  ret = rcl_ros_clock_init(&source);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
 
   rcl_time_point_t a_time;
-  ret = rcl_time_point_init(&a_time, &source);
+  ret = rcl_time_point_init(&a_time, &(source.type));
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
 
+  rcl_clock_t * ros_clock =
+    reinterpret_cast<rcl_clock_t *>(calloc(1, sizeof(rcl_clock_t)));
+  rcl_ret_t retval = rcl_ros_clock_init(ros_clock);
+  EXPECT_EQ(retval, RCL_RET_OK) << rcl_get_error_string_safe();
+
   rcl_time_point_t default_time;
-  ret = rcl_time_point_init(&default_time, nullptr);
+  ret = rcl_time_point_init(&default_time, &(ros_clock->type));
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
 
   // assert_no_malloc_begin();
@@ -198,98 +207,112 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_init_for_time_so
   // }
   ret = rcl_time_point_fini(&a_time);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
-  ret = rcl_ros_time_source_fini(&source);
+  ret = rcl_ros_clock_fini(&source);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
 }
 
-TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), time_source_validation) {
-  ASSERT_FALSE(rcl_time_source_valid(NULL));
-  rcl_time_source_t uninitialized;
+TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), clock_validation) {
+  ASSERT_FALSE(rcl_clock_valid(NULL));
+  rcl_clock_t uninitialized;
   // Not reliably detectable due to random values.
-  // ASSERT_FALSE(rcl_time_source_valid(&uninitialized));
+  // ASSERT_FALSE(rcl_clock_valid(&uninitialized));
   rcl_ret_t ret;
-  ret = rcl_ros_time_source_init(&uninitialized);
+  ret = rcl_ros_clock_init(&uninitialized);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
 }
 
-TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), default_time_source_instanciation) {
-  rcl_time_source_t * ros_time_source = rcl_get_default_ros_time_source();
-  ASSERT_TRUE(rcl_time_source_valid(ros_time_source));
-  rcl_time_source_t * steady_time_source = rcl_get_default_steady_time_source();
-  ASSERT_TRUE(rcl_time_source_valid(steady_time_source));
-  rcl_time_source_t * system_time_source = rcl_get_default_system_time_source();
-  ASSERT_TRUE(rcl_time_source_valid(system_time_source));
+TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), default_clock_instanciation) {
+  rcl_clock_t * ros_clock =
+    reinterpret_cast<rcl_clock_t *>(calloc(1, sizeof(rcl_clock_t)));
+  rcl_ret_t retval = rcl_ros_clock_init(ros_clock);
+  EXPECT_EQ(retval, RCL_RET_OK) << rcl_get_error_string_safe();
+  ASSERT_TRUE(rcl_clock_valid(ros_clock));
+
+  rcl_clock_t * steady_clock =
+    reinterpret_cast<rcl_clock_t *>(calloc(1, sizeof(rcl_clock_t)));
+  retval = rcl_steady_clock_init(steady_clock);
+  EXPECT_EQ(retval, RCL_RET_OK) << rcl_get_error_string_safe();
+  ASSERT_TRUE(rcl_clock_valid(steady_clock));
+
+  rcl_clock_t * system_clock =
+    reinterpret_cast<rcl_clock_t *>(calloc(1, sizeof(rcl_clock_t)));
+  retval = rcl_system_clock_init(system_clock);
+  EXPECT_EQ(retval, RCL_RET_OK) << rcl_get_error_string_safe();
+  ASSERT_TRUE(rcl_clock_valid(system_clock));
 }
 
-TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), specific_time_source_instantiation) {
+TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), specific_clock_instantiation) {
   {
-    rcl_time_source_t uninitialized_time_source;
-    rcl_ret_t ret = rcl_time_source_init(
-      RCL_TIME_SOURCE_UNINITIALIZED, &uninitialized_time_source);
+    rcl_clock_t uninitialized_clock;
+    rcl_ret_t ret = rcl_clock_init(
+      RCL_CLOCK_UNINITIALIZED, &uninitialized_clock);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
-    EXPECT_EQ(uninitialized_time_source.type, RCL_TIME_SOURCE_UNINITIALIZED) <<
-      "Expected time source of type RCL_TIME_SOURCE_UNINITIALIZED";
+    EXPECT_EQ(uninitialized_clock.type, RCL_CLOCK_UNINITIALIZED) <<
+      "Expected time source of type RCL_CLOCK_UNINITIALIZED";
   }
   {
-    rcl_time_source_t ros_time_source;
-    rcl_ret_t ret = rcl_time_source_init(RCL_ROS_TIME, &ros_time_source);
+    rcl_clock_t ros_clock;
+    rcl_ret_t ret = rcl_clock_init(RCL_ROS_TIME, &ros_clock);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
-    EXPECT_EQ(ros_time_source.type, RCL_ROS_TIME) <<
+    EXPECT_EQ(ros_clock.type, RCL_ROS_TIME) <<
       "Expected time source of type RCL_ROS_TIME";
-    ret = rcl_time_source_fini(&ros_time_source);
+    ret = rcl_clock_fini(&ros_clock);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   }
   {
-    rcl_time_source_t system_time_source;
-    rcl_ret_t ret = rcl_time_source_init(RCL_SYSTEM_TIME, &system_time_source);
+    rcl_clock_t system_clock;
+    rcl_ret_t ret = rcl_clock_init(RCL_SYSTEM_TIME, &system_clock);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
-    EXPECT_EQ(system_time_source.type, RCL_SYSTEM_TIME) <<
+    EXPECT_EQ(system_clock.type, RCL_SYSTEM_TIME) <<
       "Expected time source of type RCL_SYSTEM_TIME";
-    ret = rcl_time_source_fini(&system_time_source);
+    ret = rcl_clock_fini(&system_clock);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   }
   {
-    rcl_time_source_t steady_time_source;
-    rcl_ret_t ret = rcl_time_source_init(RCL_STEADY_TIME, &steady_time_source);
+    rcl_clock_t steady_clock;
+    rcl_ret_t ret = rcl_clock_init(RCL_STEADY_TIME, &steady_clock);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
-    EXPECT_EQ(steady_time_source.type, RCL_STEADY_TIME) <<
+    EXPECT_EQ(steady_clock.type, RCL_STEADY_TIME) <<
       "Expected time source of type RCL_STEADY_TIME";
-    ret = rcl_time_source_fini(&steady_time_source);
+    ret = rcl_clock_fini(&steady_clock);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   }
 }
 
 TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_difference) {
+  rcl_clock_t * ros_clock =
+    reinterpret_cast<rcl_clock_t *>(calloc(1, sizeof(rcl_clock_t)));
+  rcl_ret_t retval = rcl_ros_clock_init(ros_clock);
+  EXPECT_EQ(retval, RCL_RET_OK) << rcl_get_error_string_safe();
+  EXPECT_TRUE(ros_clock != nullptr);
+
   rcl_ret_t ret;
   rcl_time_point_t a, b;
-  ret = rcl_time_point_init(&a, nullptr);
+  ret = rcl_time_point_init(&a, &(ros_clock->type));
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
-  ret = rcl_time_point_init(&b, nullptr);
+  ret = rcl_time_point_init(&b, &(ros_clock->type));
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
 
   a.nanoseconds = 1000;
   b.nanoseconds = 2000;
 
   rcl_duration_t d;
-  ret = rcl_duration_init(&d, nullptr);
+  ret = rcl_duration_init(&d, &(ros_clock->type));
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
 
   ret = rcl_difference_times(&a, &b, &d);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
 
   EXPECT_EQ(d.nanoseconds, 1000);
-  EXPECT_EQ(d.time_source->type, RCL_ROS_TIME);
+  EXPECT_EQ(d.clock_type, RCL_ROS_TIME);
 
   ret = rcl_difference_times(&b, &a, &d);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   EXPECT_EQ(d.nanoseconds, -1000);
-  EXPECT_EQ(d.time_source->type, RCL_ROS_TIME);
-
-  rcl_time_source_t * system_time_source = rcl_get_default_system_time_source();
-  EXPECT_TRUE(system_time_source != nullptr);
+  EXPECT_EQ(d.clock_type, RCL_ROS_TIME);
 
   rcl_time_point_t e;
-  ret = rcl_time_point_init(&e, system_time_source);
+  ret = rcl_time_point_init(&e, &(ros_clock->type));
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
 }
 
@@ -309,45 +332,48 @@ void post_callback(void)
 
 
 TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_update_callbacks) {
-  rcl_time_source_t * ros_time_source = rcl_get_default_ros_time_source();
+  rcl_clock_t * ros_clock =
+    reinterpret_cast<rcl_clock_t *>(calloc(1, sizeof(rcl_clock_t)));
+  rcl_ret_t retval = rcl_ros_clock_init(ros_clock);
+  EXPECT_EQ(retval, RCL_RET_OK) << rcl_get_error_string_safe();
   rcl_time_point_t query_now;
   rcl_ret_t ret;
   rcl_time_point_value_t set_point = 1000000000ull;
 
-  ret = rcl_time_point_init(&query_now, ros_time_source);
+  ret = rcl_time_point_init(&query_now, &(ros_clock->type));
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
 
   // set callbacks
-  ros_time_source->pre_update = pre_callback;
-  ros_time_source->post_update = post_callback;
+  ros_clock->pre_update = pre_callback;
+  ros_clock->post_update = post_callback;
 
 
   EXPECT_FALSE(pre_callback_called);
   EXPECT_FALSE(post_callback_called);
 
   // Query it to do something different. no changes expected
-  ret = rcl_time_point_get_now(&query_now);
+  ret = rcl_time_point_get_now(ros_clock, &query_now);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
 
   EXPECT_FALSE(pre_callback_called);
   EXPECT_FALSE(post_callback_called);
 
   // Set the time before it's enabled. Should be no callbacks
-  ret = rcl_set_ros_time_override(ros_time_source, set_point);
+  ret = rcl_set_ros_time_override(ros_clock, set_point);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
 
   EXPECT_FALSE(pre_callback_called);
   EXPECT_FALSE(post_callback_called);
 
   // enable
-  ret = rcl_enable_ros_time_override(ros_time_source);
+  ret = rcl_enable_ros_time_override(ros_clock);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
 
   EXPECT_FALSE(pre_callback_called);
   EXPECT_FALSE(post_callback_called);
 
   // Set the time now that it's enabled, now get callbacks
-  ret = rcl_set_ros_time_override(ros_time_source, set_point);
+  ret = rcl_set_ros_time_override(ros_clock, set_point);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
 
   EXPECT_TRUE(pre_callback_called);

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -56,9 +56,9 @@ public:
 
 // Tests the rcl_set_ros_time_override() function.
 TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_ros_time_set_override) {
-  rcl_clock_t * ros_clock =
-    reinterpret_cast<rcl_clock_t *>(calloc(1, sizeof(rcl_clock_t)));
-  rcl_ret_t retval = rcl_ros_clock_init(ros_clock);
+  rcl_clock_t ros_clock;
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  rcl_ret_t retval = rcl_ros_clock_init(&ros_clock, &allocator);
   EXPECT_EQ(retval, RCL_RET_OK) << rcl_get_error_string_safe();
 
   assert_no_realloc_begin();
@@ -71,7 +71,7 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_ros_time_set_ove
   ret = rcl_is_enabled_ros_time_override(nullptr, &result);
   EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT) << rcl_get_error_string_safe();
   rcl_reset_error();
-  ret = rcl_is_enabled_ros_time_override(ros_clock, nullptr);
+  ret = rcl_is_enabled_ros_time_override(&ros_clock, nullptr);
   EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT) << rcl_get_error_string_safe();
   rcl_reset_error();
   ret = rcl_is_enabled_ros_time_override(nullptr, nullptr);
@@ -79,13 +79,13 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_ros_time_set_ove
   rcl_reset_error();
   rcl_time_point_t query_now;
   bool is_enabled;
-  ret = rcl_is_enabled_ros_time_override(ros_clock, &is_enabled);
+  ret = rcl_is_enabled_ros_time_override(&ros_clock, &is_enabled);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   EXPECT_EQ(is_enabled, false);
   assert_no_malloc_begin();
   assert_no_free_begin();
   // Check for normal operation (not allowed to alloc).
-  ret = rcl_clock_get_now(ros_clock, &query_now);
+  ret = rcl_clock_get_now(&ros_clock, &query_now);
   assert_no_malloc_end();
   assert_no_realloc_end();
   assert_no_free_end();
@@ -93,7 +93,7 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_ros_time_set_ove
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   EXPECT_NE(query_now.nanoseconds, 0u);
   // Compare to std::chrono::system_clock time (within a second).
-  ret = rcl_clock_get_now(ros_clock, &query_now);
+  ret = rcl_clock_get_now(&ros_clock, &query_now);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   {
     std::chrono::system_clock::time_point now_sc = std::chrono::system_clock::now();
@@ -106,18 +106,18 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_ros_time_set_ove
   // Test ros time specific APIs
   rcl_time_point_value_t set_point = 1000000000ull;
   // Check initialized state
-  ret = rcl_is_enabled_ros_time_override(ros_clock, &is_enabled);
+  ret = rcl_is_enabled_ros_time_override(&ros_clock, &is_enabled);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   EXPECT_EQ(is_enabled, false);
   // set the time point
-  ret = rcl_set_ros_time_override(ros_clock, set_point);
+  ret = rcl_set_ros_time_override(&ros_clock, set_point);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   // check still disabled
-  ret = rcl_is_enabled_ros_time_override(ros_clock, &is_enabled);
+  ret = rcl_is_enabled_ros_time_override(&ros_clock, &is_enabled);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   EXPECT_EQ(is_enabled, false);
   // get real
-  ret = rcl_clock_get_now(ros_clock, &query_now);
+  ret = rcl_clock_get_now(&ros_clock, &query_now);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   {
     std::chrono::system_clock::time_point now_sc = std::chrono::system_clock::now();
@@ -128,25 +128,25 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_ros_time_set_ove
     EXPECT_LE(llabs(now_diff), RCL_MS_TO_NS(k_tolerance_ms)) << "ros_clock differs";
   }
   // enable
-  ret = rcl_enable_ros_time_override(ros_clock);
+  ret = rcl_enable_ros_time_override(&ros_clock);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   // check enabled
-  ret = rcl_is_enabled_ros_time_override(ros_clock, &is_enabled);
+  ret = rcl_is_enabled_ros_time_override(&ros_clock, &is_enabled);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   EXPECT_EQ(is_enabled, true);
   // get sim
-  ret = rcl_clock_get_now(ros_clock, &query_now);
+  ret = rcl_clock_get_now(&ros_clock, &query_now);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   EXPECT_EQ(query_now.nanoseconds, set_point);
   // disable
-  ret = rcl_disable_ros_time_override(ros_clock);
+  ret = rcl_disable_ros_time_override(&ros_clock);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   // check disabled
-  ret = rcl_is_enabled_ros_time_override(ros_clock, &is_enabled);
+  ret = rcl_is_enabled_ros_time_override(&ros_clock, &is_enabled);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   EXPECT_EQ(is_enabled, false);
   // get real
-  ret = rcl_clock_get_now(ros_clock, &query_now);
+  ret = rcl_clock_get_now(&ros_clock, &query_now);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   {
     std::chrono::system_clock::time_point now_sc = std::chrono::system_clock::now();
@@ -159,42 +159,25 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_ros_time_set_ove
 }
 
 TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_init_for_clock_and_point) {
-  assert_no_realloc_begin();
   rcl_ret_t ret;
+  rcl_allocator_t allocator = rcl_get_default_allocator();
   // Check for invalid argument error condition (allowed to alloc).
-  ret = rcl_ros_clock_init(nullptr);
+  ret = rcl_ros_clock_init(nullptr, &allocator);
+  EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT) << rcl_get_error_string_safe();
+  rcl_reset_error();
+  // Check for invalid argument error condition (allowed to alloc).
+  rcl_clock_t uninitialized_clock;
+  ret = rcl_ros_clock_init(&uninitialized_clock, nullptr);
   EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT) << rcl_get_error_string_safe();
   rcl_reset_error();
   // Check for normal operation (not allowed to alloc).
   rcl_clock_t source;
-  ret = rcl_ros_clock_init(&source);
+  ret = rcl_ros_clock_init(&source, &allocator);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
 
-  rcl_clock_t * ros_clock =
-    reinterpret_cast<rcl_clock_t *>(calloc(1, sizeof(rcl_clock_t)));
-  rcl_ret_t retval = rcl_ros_clock_init(ros_clock);
+  rcl_clock_t ros_clock;
+  rcl_ret_t retval = rcl_ros_clock_init(&ros_clock, &allocator);
   EXPECT_EQ(retval, RCL_RET_OK) << rcl_get_error_string_safe();
-
-  // assert_no_malloc_begin();
-  // assert_no_free_begin();
-  // // Do stuff in here
-  // assert_no_malloc_end();
-  // assert_no_realloc_end();
-  // assert_no_free_end();
-  // stop_memory_checking();
-  // EXPECT_NE(now.nanoseconds, 0u);
-  // // Compare to std::chrono::system_clock time (within a second).
-  // now = {0};
-  // ret = rcutils_system_time_now(&now);
-  // {
-  //   std::chrono::system_clock::time_point now_sc = std::chrono::system_clock::now();
-  //   auto now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(
-  // now_sc.time_since_epoch());
-  //   int64_t now_ns_int = now_ns.count();
-  //   int64_t now_diff = now.nanoseconds - now_ns_int;
-  //   const int k_tolerance_ms = 1000;
-  //   EXPECT_LE(llabs(now_diff), RCL_MS_TO_NS(k_tolerance_ms)) << "system_clock differs";
-  // }
 }
 
 TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), clock_validation) {
@@ -202,43 +185,45 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), clock_validation) {
   rcl_clock_t uninitialized;
   // Not reliably detectable due to random values.
   // ASSERT_FALSE(rcl_clock_valid(&uninitialized));
+  rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_ret_t ret;
-  ret = rcl_ros_clock_init(&uninitialized);
+  ret = rcl_ros_clock_init(&uninitialized, &allocator);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
 }
 
 TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), default_clock_instanciation) {
-  rcl_clock_t * ros_clock =
-    reinterpret_cast<rcl_clock_t *>(calloc(1, sizeof(rcl_clock_t)));
-  rcl_ret_t retval = rcl_ros_clock_init(ros_clock);
+  rcl_clock_t ros_clock;
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  rcl_ret_t retval = rcl_ros_clock_init(&ros_clock, &allocator);
   EXPECT_EQ(retval, RCL_RET_OK) << rcl_get_error_string_safe();
-  ASSERT_TRUE(rcl_clock_valid(ros_clock));
+  ASSERT_TRUE(rcl_clock_valid(&ros_clock));
 
   rcl_clock_t * steady_clock =
     reinterpret_cast<rcl_clock_t *>(calloc(1, sizeof(rcl_clock_t)));
-  retval = rcl_steady_clock_init(steady_clock);
+  retval = rcl_steady_clock_init(steady_clock, &allocator);
   EXPECT_EQ(retval, RCL_RET_OK) << rcl_get_error_string_safe();
   ASSERT_TRUE(rcl_clock_valid(steady_clock));
 
   rcl_clock_t * system_clock =
     reinterpret_cast<rcl_clock_t *>(calloc(1, sizeof(rcl_clock_t)));
-  retval = rcl_system_clock_init(system_clock);
+  retval = rcl_system_clock_init(system_clock, &allocator);
   EXPECT_EQ(retval, RCL_RET_OK) << rcl_get_error_string_safe();
   ASSERT_TRUE(rcl_clock_valid(system_clock));
 }
 
 TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), specific_clock_instantiation) {
+  rcl_allocator_t allocator = rcl_get_default_allocator();
   {
     rcl_clock_t uninitialized_clock;
     rcl_ret_t ret = rcl_clock_init(
-      RCL_CLOCK_UNINITIALIZED, &uninitialized_clock);
+      RCL_CLOCK_UNINITIALIZED, &uninitialized_clock, &allocator);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
     EXPECT_EQ(uninitialized_clock.type, RCL_CLOCK_UNINITIALIZED) <<
       "Expected time source of type RCL_CLOCK_UNINITIALIZED";
   }
   {
     rcl_clock_t ros_clock;
-    rcl_ret_t ret = rcl_clock_init(RCL_ROS_TIME, &ros_clock);
+    rcl_ret_t ret = rcl_clock_init(RCL_ROS_TIME, &ros_clock, &allocator);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
     EXPECT_EQ(ros_clock.type, RCL_ROS_TIME) <<
       "Expected time source of type RCL_ROS_TIME";
@@ -247,7 +232,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), specific_clock_instantiation) {
   }
   {
     rcl_clock_t system_clock;
-    rcl_ret_t ret = rcl_clock_init(RCL_SYSTEM_TIME, &system_clock);
+    rcl_ret_t ret = rcl_clock_init(RCL_SYSTEM_TIME, &system_clock, &allocator);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
     EXPECT_EQ(system_clock.type, RCL_SYSTEM_TIME) <<
       "Expected time source of type RCL_SYSTEM_TIME";
@@ -256,7 +241,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), specific_clock_instantiation) {
   }
   {
     rcl_clock_t steady_clock;
-    rcl_ret_t ret = rcl_clock_init(RCL_STEADY_TIME, &steady_clock);
+    rcl_ret_t ret = rcl_clock_init(RCL_STEADY_TIME, &steady_clock, &allocator);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
     EXPECT_EQ(steady_clock.type, RCL_STEADY_TIME) <<
       "Expected time source of type RCL_STEADY_TIME";
@@ -266,9 +251,10 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), specific_clock_instantiation) {
 }
 
 TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_difference) {
+  rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_clock_t * ros_clock =
-    reinterpret_cast<rcl_clock_t *>(calloc(1, sizeof(rcl_clock_t)));
-  rcl_ret_t retval = rcl_ros_clock_init(ros_clock);
+    reinterpret_cast<rcl_clock_t *>(allocator.allocate(sizeof(rcl_clock_t), allocator.state));
+  rcl_ret_t retval = rcl_ros_clock_init(ros_clock, &allocator);
   EXPECT_EQ(retval, RCL_RET_OK) << rcl_get_error_string_safe();
   EXPECT_TRUE(ros_clock != nullptr);
   EXPECT_TRUE(ros_clock->data != nullptr);
@@ -312,11 +298,17 @@ void post_callback(void)
   post_callback_called = true;
 }
 
+void reset_callback_triggers(void)
+{
+  pre_callback_called = false;
+  post_callback_called = false;
+}
 
 TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_update_callbacks) {
+  rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_clock_t * ros_clock =
-    reinterpret_cast<rcl_clock_t *>(calloc(1, sizeof(rcl_clock_t)));
-  rcl_ret_t retval = rcl_ros_clock_init(ros_clock);
+    reinterpret_cast<rcl_clock_t *>(allocator.allocate(sizeof(rcl_clock_t), allocator.state));
+  rcl_ret_t retval = rcl_ros_clock_init(ros_clock, &allocator);
   EXPECT_EQ(retval, RCL_RET_OK) << rcl_get_error_string_safe();
   rcl_time_point_t query_now;
   rcl_ret_t ret;
@@ -325,7 +317,6 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_update_callbacks) {
   // set callbacks
   ros_clock->pre_update = pre_callback;
   ros_clock->post_update = post_callback;
-
 
   EXPECT_FALSE(pre_callback_called);
   EXPECT_FALSE(post_callback_called);

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -269,19 +269,14 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_difference) {
   b.clock_type = RCL_ROS_TIME;
 
   rcl_duration_t d;
-  ret = rcl_duration_init(&d, &(ros_clock->type));
-  EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
-
   ret = rcl_difference_times(&a, &b, &d);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
 
   EXPECT_EQ(d.nanoseconds, 1000);
-  EXPECT_EQ(d.clock_type, RCL_ROS_TIME);
 
   ret = rcl_difference_times(&b, &a, &d);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   EXPECT_EQ(d.nanoseconds, -1000);
-  EXPECT_EQ(d.clock_type, RCL_ROS_TIME);
 }
 
 static bool pre_callback_called = false;


### PR DESCRIPTION
This primarily moves the internal references to the TimeSource from inside the Time objects.
It also renames the TimeSource objects to Clocks to follow the work in ros2/design#144

And it lastly remove the default TimeSource logic where now you will need to explicitly connect a TimeSource to a node as we don't want to have global state. 

This is the lowest layer of a larger sweeping change but specific feedback here would be helpful.