### PR TITLE
Implementing `rcl_*_is_valid` tests.

### DIFF
--- a/rcl/include/rcl/client.h
+++ b/rcl/include/rcl/client.h
@@ -389,6 +389,7 @@ rcl_client_get_rmw_handle(const rcl_client_t * client);
  * \param[in] client pointer to the rcl client
  * \return `true` if `client` is valid, otherwise `false`
  */
+RCL_PUBLIC
 bool
 rcl_client_is_valid(const rcl_client_t * client);
 

--- a/rcl/include/rcl/publisher.h
+++ b/rcl/include/rcl/publisher.h
@@ -353,7 +353,7 @@ rcl_publisher_get_rmw_handle(const rcl_publisher_t * publisher);
  * Lock-Free          | Yes
  *
  * \param[in] publisher pointer to the rcl publisher
- * \return `true` if the publisher is valid, otherwise `false`
+ * \return `true` if `publisher` is valid, otherwise `false`
  */
 RCL_PUBLIC
 bool

--- a/rcl/include/rcl/publisher.h
+++ b/rcl/include/rcl/publisher.h
@@ -355,7 +355,7 @@ rcl_publisher_get_rmw_handle(const rcl_publisher_t * publisher);
  * \param[in] publisher pointer to the rcl publisher
  * \return `true` if the publisher is valid, otherwise `false`
  */
-
+RCL_PUBLIC
 bool
 rcl_publisher_is_valid(const rcl_publisher_t * publisher);
 

--- a/rcl/include/rcl/service.h
+++ b/rcl/include/rcl/service.h
@@ -401,6 +401,7 @@ rcl_service_get_rmw_handle(const rcl_service_t * service);
  * \param[in] service pointer to the rcl service
  * \return `true` if `service` is valid, otherwise `false`
  */
+RCL_PUBLIC
 bool
 rcl_service_is_valid(const rcl_service_t * service);
 

--- a/rcl/include/rcl/subscription.h
+++ b/rcl/include/rcl/subscription.h
@@ -358,6 +358,7 @@ rcl_subscription_get_rmw_handle(const rcl_subscription_t * subscription);
  * \param[in] subscription pointer to the rcl subscription
  * \return `true` if `subscription` is valid, otherwise `false`
  */
+RCL_PUBLIC
 bool
 rcl_subscription_is_valid(const rcl_subscription_t * subscription);
 

--- a/rcl/test/rcl/test_client.cpp
+++ b/rcl/test/rcl/test_client.cpp
@@ -130,18 +130,18 @@ TEST_F(TestClientFixture, test_client_init_fini) {
   rcl_reset_error();
 
   // Check if null publisher is valid
-  EXPECT_EQ(rcl_client_is_valid(nullptr), false);
+  EXPECT_FALSE(rcl_client_is_valid(nullptr));
   rcl_reset_error();
 
   // Check if zero initialized client is valid
   client = rcl_get_zero_initialized_client();
-  EXPECT_EQ(rcl_client_is_valid(&client), false);
+  EXPECT_FALSE(rcl_client_is_valid(&client));
   rcl_reset_error();
 
-  // Chek that a valid client is valid
+  // Check that a valid client is valid
   client = rcl_get_zero_initialized_client();
   ret = rcl_client_init(&client, this->node_ptr, ts, topic_name, &default_client_options);
-  EXPECT_EQ(rcl_client_is_valid(&client), true);
+  EXPECT_TRUE(rcl_client_is_valid(&client));
   rcl_reset_error();
 
   // Try passing an invalid (uninitialized) node in init.

--- a/rcl/test/rcl/test_client.cpp
+++ b/rcl/test/rcl/test_client.cpp
@@ -141,6 +141,7 @@ TEST_F(TestClientFixture, test_client_init_fini) {
   // Check that a valid client is valid
   client = rcl_get_zero_initialized_client();
   ret = rcl_client_init(&client, this->node_ptr, ts, topic_name, &default_client_options);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
   EXPECT_TRUE(rcl_client_is_valid(&client));
   rcl_reset_error();
 

--- a/rcl/test/rcl/test_client.cpp
+++ b/rcl/test/rcl/test_client.cpp
@@ -133,16 +133,22 @@ TEST_F(TestClientFixture, test_client_init_fini) {
   EXPECT_EQ(rcl_client_is_valid(nullptr), false);
   rcl_reset_error();
 
+  // Check if zero initialized client is valid
+  client = rcl_get_zero_initialized_client();
+  EXPECT_EQ(rcl_client_is_valid(&client), false);
+  rcl_reset_error();
+
+  // Chek that a valid client is valid
+  client = rcl_get_zero_initialized_client();
+  ret = rcl_client_init(&client, this->node_ptr, ts, topic_name, &default_client_options);
+  EXPECT_EQ(rcl_client_is_valid(&client), true);
+  rcl_reset_error();
+
   // Try passing an invalid (uninitialized) node in init.
   client = rcl_get_zero_initialized_client();
   rcl_node_t invalid_node = rcl_get_zero_initialized_node();
   ret = rcl_client_init(&client, &invalid_node, ts, topic_name, &default_client_options);
   EXPECT_EQ(RCL_RET_NODE_INVALID, ret) << rcl_get_error_string_safe();
-  rcl_reset_error();
-
-  // Check if zero initialized client is valid
-  rcl_client_t zero_client = rcl_get_zero_initialized_client();
-  EXPECT_EQ(rcl_client_is_valid(&zero_client), false);
   rcl_reset_error();
 
   // Try passing null for the type support in init.

--- a/rcl/test/rcl/test_client.cpp
+++ b/rcl/test/rcl/test_client.cpp
@@ -129,11 +129,20 @@ TEST_F(TestClientFixture, test_client_init_fini) {
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string_safe();
   rcl_reset_error();
 
+  // Check if null publisher is valid
+  EXPECT_EQ(rcl_client_is_valid(nullptr), false);
+  rcl_reset_error();
+
   // Try passing an invalid (uninitialized) node in init.
   client = rcl_get_zero_initialized_client();
   rcl_node_t invalid_node = rcl_get_zero_initialized_node();
   ret = rcl_client_init(&client, &invalid_node, ts, topic_name, &default_client_options);
   EXPECT_EQ(RCL_RET_NODE_INVALID, ret) << rcl_get_error_string_safe();
+  rcl_reset_error();
+
+  // Check if zero initialized client is valid
+  rcl_client_t zero_client = rcl_get_zero_initialized_client();
+  EXPECT_EQ(rcl_client_is_valid(&zero_client), false);
   rcl_reset_error();
 
   // Try passing null for the type support in init.

--- a/rcl/test/rcl/test_publisher.cpp
+++ b/rcl/test/rcl/test_publisher.cpp
@@ -155,6 +155,9 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_init_
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string_safe();
   rcl_reset_error();
 
+  // Check if null publisher is valid
+  EXPECT_EQ(rcl_publisher_is_valid(nullptr), false);
+
   // Try passing an invalid (uninitialized) node in init.
   publisher = rcl_get_zero_initialized_publisher();
   rcl_node_t invalid_node = rcl_get_zero_initialized_node();
@@ -162,16 +165,15 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_init_
   EXPECT_EQ(RCL_RET_NODE_INVALID, ret) << rcl_get_error_string_safe();
   rcl_reset_error();
 
+  // Check if zero initialized node is valid
+  publisher = rcl_get_zero_initialized_publisher();
+  EXPECT_EQ(rcl_publisher_is_valid(&publisher), false);
+  rcl_reset_error();
+
   // Try passing null for the type support in init.
   publisher = rcl_get_zero_initialized_publisher();
   ret = rcl_publisher_init(
     &publisher, this->node_ptr, nullptr, topic_name, &default_publisher_options);
-  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string_safe();
-  rcl_reset_error();
-
-  // Try passing null for the topic name in init.
-  publisher = rcl_get_zero_initialized_publisher();
-  ret = rcl_publisher_init(&publisher, this->node_ptr, ts, nullptr, &default_publisher_options);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string_safe();
   rcl_reset_error();
 

--- a/rcl/test/rcl/test_publisher.cpp
+++ b/rcl/test/rcl/test_publisher.cpp
@@ -155,6 +155,7 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_init_
   // Check that valid publisher is valid
   publisher = rcl_get_zero_initialized_publisher();
   ret = rcl_publisher_init(&publisher, this->node_ptr, ts, topic_name, &default_publisher_options);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
   EXPECT_TRUE(rcl_publisher_is_valid(&publisher));
   rcl_reset_error();
 

--- a/rcl/test/rcl/test_publisher.cpp
+++ b/rcl/test/rcl/test_publisher.cpp
@@ -144,6 +144,14 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_init_
   const char * topic_name = "chatter";
   rcl_publisher_options_t default_publisher_options = rcl_publisher_get_default_options();
 
+  // Check if null publisher is valid
+  EXPECT_EQ(rcl_publisher_is_valid(nullptr), false);
+
+  // Check if zero initialized node is valid
+  publisher = rcl_get_zero_initialized_publisher();
+  EXPECT_EQ(rcl_publisher_is_valid(&publisher), false);
+  rcl_reset_error();
+
   // Try passing null for publisher in init.
   ret = rcl_publisher_init(nullptr, this->node_ptr, ts, topic_name, &default_publisher_options);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string_safe();
@@ -155,9 +163,6 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_init_
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string_safe();
   rcl_reset_error();
 
-  // Check if null publisher is valid
-  EXPECT_EQ(rcl_publisher_is_valid(nullptr), false);
-
   // Try passing an invalid (uninitialized) node in init.
   publisher = rcl_get_zero_initialized_publisher();
   rcl_node_t invalid_node = rcl_get_zero_initialized_node();
@@ -165,15 +170,16 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_init_
   EXPECT_EQ(RCL_RET_NODE_INVALID, ret) << rcl_get_error_string_safe();
   rcl_reset_error();
 
-  // Check if zero initialized node is valid
-  publisher = rcl_get_zero_initialized_publisher();
-  EXPECT_EQ(rcl_publisher_is_valid(&publisher), false);
-  rcl_reset_error();
-
   // Try passing null for the type support in init.
   publisher = rcl_get_zero_initialized_publisher();
   ret = rcl_publisher_init(
     &publisher, this->node_ptr, nullptr, topic_name, &default_publisher_options);
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string_safe();
+  rcl_reset_error();
+
+  // Try passing null for the topic name in init.
+  publisher = rcl_get_zero_initialized_publisher();
+  ret = rcl_publisher_init(&publisher, this->node_ptr, ts, nullptr, &default_publisher_options);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string_safe();
   rcl_reset_error();
 

--- a/rcl/test/rcl/test_publisher.cpp
+++ b/rcl/test/rcl/test_publisher.cpp
@@ -145,17 +145,17 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_init_
   rcl_publisher_options_t default_publisher_options = rcl_publisher_get_default_options();
 
   // Check if null publisher is valid
-  EXPECT_EQ(rcl_publisher_is_valid(nullptr), false);
+  EXPECT_FALSE(rcl_publisher_is_valid(nullptr));
 
   // Check if zero initialized node is valid
   publisher = rcl_get_zero_initialized_publisher();
-  EXPECT_EQ(rcl_publisher_is_valid(&publisher), false);
+  EXPECT_FALSE(rcl_publisher_is_valid(&publisher));
   rcl_reset_error();
 
-  // Chek that valid publisher is valid
+  // Check that valid publisher is valid
   publisher = rcl_get_zero_initialized_publisher();
   ret = rcl_publisher_init(&publisher, this->node_ptr, ts, topic_name, &default_publisher_options);
-  EXPECT_EQ(rcl_publisher_is_valid(&publisher), true);
+  EXPECT_TRUE(rcl_publisher_is_valid(&publisher));
   rcl_reset_error();
 
   // Try passing null for publisher in init.

--- a/rcl/test/rcl/test_publisher.cpp
+++ b/rcl/test/rcl/test_publisher.cpp
@@ -152,6 +152,12 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_init_
   EXPECT_EQ(rcl_publisher_is_valid(&publisher), false);
   rcl_reset_error();
 
+  // Chek that valid publisher is valid
+  publisher = rcl_get_zero_initialized_publisher();
+  ret = rcl_publisher_init(&publisher, this->node_ptr, ts, topic_name, &default_publisher_options);
+  EXPECT_EQ(rcl_publisher_is_valid(&publisher), true);
+  rcl_reset_error();
+
   // Try passing null for publisher in init.
   ret = rcl_publisher_init(nullptr, this->node_ptr, ts, topic_name, &default_publisher_options);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string_safe();

--- a/rcl/test/rcl/test_service.cpp
+++ b/rcl/test/rcl/test_service.cpp
@@ -128,18 +128,18 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_service_nominal) 
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 
   // Check if null service is valid
-  EXPECT_EQ(rcl_service_is_valid(nullptr), false);
+  EXPECT_FALSE(rcl_service_is_valid(nullptr));
   rcl_reset_error();
 
   // Check if zero initialized client is valid
   service = rcl_get_zero_initialized_service();
-  EXPECT_EQ(rcl_service_is_valid(&service), false);
+  EXPECT_FALSE(rcl_service_is_valid(&service));
   rcl_reset_error();
 
-  // Chek that a valid service is valid
+  // Check that a valid service is valid
   service = rcl_get_zero_initialized_service();
   ret = rcl_service_init(&service, this->node_ptr, ts, topic, &service_options);
-  EXPECT_EQ(rcl_service_is_valid(&service), true);
+  EXPECT_TRUE(rcl_service_is_valid(&service));
   rcl_reset_error();
 
   // Check that the service name matches what we assigned.

--- a/rcl/test/rcl/test_service.cpp
+++ b/rcl/test/rcl/test_service.cpp
@@ -127,6 +127,11 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_service_nominal) 
   ret = rcl_service_init(&service, this->node_ptr, ts, topic, &service_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 
+
+  // Check if null service is valid
+  EXPECT_EQ(rcl_service_is_valid(nullptr), false);
+  rcl_reset_error();
+
   // Check that the service name matches what we assigned.
   EXPECT_EQ(strcmp(rcl_service_get_service_name(&service), expected_topic), 0);
   auto service_exit = make_scope_exit(
@@ -147,6 +152,10 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_service_nominal) 
       EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
     });
 
+  // Check if zero initialized node is valid
+  service = rcl_get_zero_initialized_service();
+  EXPECT_EQ(rcl_service_is_valid(&service), false);
+  rcl_reset_error();
 
   // TODO(wjwwood): add logic to wait for the connection to be established
   //                use count_services busy wait mechanism

--- a/rcl/test/rcl/test_service.cpp
+++ b/rcl/test/rcl/test_service.cpp
@@ -154,6 +154,7 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_service_nominal) 
 
   // Check if zero initialized node is valid
   service = rcl_get_zero_initialized_service();
+  service.impl = nullptr;
   EXPECT_EQ(rcl_service_is_valid(&service), false);
   rcl_reset_error();
 

--- a/rcl/test/rcl/test_service.cpp
+++ b/rcl/test/rcl/test_service.cpp
@@ -153,9 +153,9 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_service_nominal) 
     });
 
   // Check if zero initialized node is valid
-  service = rcl_get_zero_initialized_service();
-  service.impl = nullptr;
-  EXPECT_EQ(rcl_service_is_valid(&service), false);
+  rcl_service_t bad_option = rcl_get_zero_initialized_service();
+  bad_option.impl = nullptr;
+  EXPECT_EQ(rcl_service_is_valid(&bad_option), false);
   rcl_reset_error();
 
   // TODO(wjwwood): add logic to wait for the connection to be established

--- a/rcl/test/rcl/test_service.cpp
+++ b/rcl/test/rcl/test_service.cpp
@@ -127,9 +127,19 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_service_nominal) 
   ret = rcl_service_init(&service, this->node_ptr, ts, topic, &service_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
 
-
   // Check if null service is valid
   EXPECT_EQ(rcl_service_is_valid(nullptr), false);
+  rcl_reset_error();
+
+  // Check if zero initialized client is valid
+  service = rcl_get_zero_initialized_service();
+  EXPECT_EQ(rcl_service_is_valid(&service), false);
+  rcl_reset_error();
+
+  // Chek that a valid service is valid
+  service = rcl_get_zero_initialized_service();
+  ret = rcl_service_init(&service, this->node_ptr, ts, topic, &service_options);
+  EXPECT_EQ(rcl_service_is_valid(&service), true);
   rcl_reset_error();
 
   // Check that the service name matches what we assigned.
@@ -151,12 +161,6 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_service_nominal) 
       rcl_ret_t ret = rcl_client_fini(&client, this->node_ptr);
       EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
     });
-
-  // Check if zero initialized node is valid
-  rcl_service_t bad_option = rcl_get_zero_initialized_service();
-  bad_option.impl = nullptr;
-  EXPECT_EQ(rcl_service_is_valid(&bad_option), false);
-  rcl_reset_error();
 
   // TODO(wjwwood): add logic to wait for the connection to be established
   //                use count_services busy wait mechanism

--- a/rcl/test/rcl/test_service.cpp
+++ b/rcl/test/rcl/test_service.cpp
@@ -139,6 +139,7 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_service_nominal) 
   // Check that a valid service is valid
   service = rcl_get_zero_initialized_service();
   ret = rcl_service_init(&service, this->node_ptr, ts, topic, &service_options);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
   EXPECT_TRUE(rcl_service_is_valid(&service));
   rcl_reset_error();
 

--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -158,8 +158,14 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
   rcl_reset_error();
 
   // Test is_valid for zero initialized subscription
-  rcl_subscription_t zero_sub = rcl_get_zero_initialized_subscription();
-  EXPECT_EQ(rcl_subscription_is_valid(&zero_sub), false);
+  subscription = rcl_get_zero_initialized_subscription();
+  EXPECT_EQ(rcl_subscription_is_valid(&subscription), false);
+  rcl_reset_error();
+
+  // Chek that valid subscriber is valid
+  subscription = rcl_get_zero_initialized_subscription();
+  ret = rcl_subscription_init(&subscription, this->node_ptr, ts, topic, &subscription_options);
+  EXPECT_EQ(rcl_subscription_is_valid(&subscription), true);
   rcl_reset_error();
 
   // TODO(wjwwood): add logic to wait for the connection to be established

--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -154,18 +154,18 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
   EXPECT_EQ(strcmp(rcl_subscription_get_topic_name(&subscription), expected_topic), 0);
 
   // Test is_valid for subscription with nullptr
-  EXPECT_EQ(rcl_subscription_is_valid(nullptr), false);
+  EXPECT_FALSE(rcl_subscription_is_valid(nullptr));
   rcl_reset_error();
 
   // Test is_valid for zero initialized subscription
   subscription = rcl_get_zero_initialized_subscription();
-  EXPECT_EQ(rcl_subscription_is_valid(&subscription), false);
+  EXPECT_FALSE(rcl_subscription_is_valid(&subscription));
   rcl_reset_error();
 
-  // Chek that valid subscriber is valid
+  // Check that valid subscriber is valid
   subscription = rcl_get_zero_initialized_subscription();
   ret = rcl_subscription_init(&subscription, this->node_ptr, ts, topic, &subscription_options);
-  EXPECT_EQ(rcl_subscription_is_valid(&subscription), true);
+  EXPECT_TRUE(rcl_subscription_is_valid(&subscription));
   rcl_reset_error();
 
   // TODO(wjwwood): add logic to wait for the connection to be established

--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -165,6 +165,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
   // Check that valid subscriber is valid
   subscription = rcl_get_zero_initialized_subscription();
   ret = rcl_subscription_init(&subscription, this->node_ptr, ts, topic, &subscription_options);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
   EXPECT_TRUE(rcl_subscription_is_valid(&subscription));
   rcl_reset_error();
 

--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -152,6 +152,10 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
       EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
     });
   EXPECT_EQ(strcmp(rcl_subscription_get_topic_name(&subscription), expected_topic), 0);
+
+  // Test is valid for subscription with nullptr
+  EXPECT_EQ(rcl_subscription_is_valid(nullptr), false);
+
   // TODO(wjwwood): add logic to wait for the connection to be established
   //                probably using the count_subscriptions busy wait mechanism
   //                until then we will sleep for a short period of time

--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -153,8 +153,14 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
     });
   EXPECT_EQ(strcmp(rcl_subscription_get_topic_name(&subscription), expected_topic), 0);
 
-  // Test is valid for subscription with nullptr
+  // Test is_valid for subscription with nullptr
   EXPECT_EQ(rcl_subscription_is_valid(nullptr), false);
+  rcl_reset_error();
+
+  // Test is_valid for zero initialized subscription
+  rcl_subscription_t zero_sub = rcl_get_zero_initialized_subscription();
+  EXPECT_EQ(rcl_subscription_is_valid(&zero_sub), false);
+  rcl_reset_error();
 
   // TODO(wjwwood): add logic to wait for the connection to be established
   //                probably using the count_subscriptions busy wait mechanism


### PR DESCRIPTION
Opening for visibility and feedback as this is under way.

I'd like to ask whether or not these tests should be in one, self-contained, `rcl_x_is_valid.c` file, or if they should be in the file to which the `x` is valued (`rcl_publisher_is_valid` is tested in the `test_publisher.cpp` file). @wjwwood thoughts?

connects to ros2/rcl#150 