### PR TITLE
memory leak issues

### DIFF
--- a/rcl/include/rcl/error_handling.h
+++ b/rcl/include/rcl/error_handling.h
@@ -39,7 +39,8 @@ typedef rcutils_error_state_t rcl_error_state_t;
 
 #define RCL_SET_ERROR_MSG(msg, allocator) RCUTILS_SET_ERROR_MSG(msg, allocator)
 
-#define rcl_set_formatted_error rcutils_set_formatted_error
+#define RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(allocator, fmt_str, ...) \
+  RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(allocator, fmt_str, __VA_ARGS__)
 
 #define rcl_error_is_set rcutils_error_is_set
 

--- a/rcl/include/rcl/error_handling.h
+++ b/rcl/include/rcl/error_handling.h
@@ -39,6 +39,8 @@ typedef rcutils_error_state_t rcl_error_state_t;
 
 #define RCL_SET_ERROR_MSG(msg, allocator) RCUTILS_SET_ERROR_MSG(msg, allocator)
 
+#define rcl_set_formatted_error rcutils_set_formatted_error
+
 #define rcl_error_is_set rcutils_error_is_set
 
 #define rcl_get_error_state rcutils_get_error_state

--- a/rcl/src/rcl/expand_topic_name.c
+++ b/rcl/src/rcl/expand_topic_name.c
@@ -167,14 +167,14 @@ rcl_expand_topic_name(
           *output_topic_name = NULL;
           char * unmatched_substitution =
             rcutils_strndup(next_opening_brace, substitution_substr_len, allocator);
-          char * allocated_msg = NULL;
           if (unmatched_substitution) {
-            allocated_msg = rcutils_format_string(
+            RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
               allocator,
               "unknown substitution: %s", unmatched_substitution);
-            rcl_set_formatted_error(allocated_msg, allocator);
           } else {
             SAFE_FWRITE_TO_STDERR("failed to allocate memory for unmatched substitution\n");
+            RCL_SET_ERROR_MSG("unknown substitution: allocation failed when reporting error",
+              allocator);
           }
           allocator.deallocate(unmatched_substitution, allocator.state);
           allocator.deallocate(local_output, allocator.state);

--- a/rcl/src/rcl/expand_topic_name.c
+++ b/rcl/src/rcl/expand_topic_name.c
@@ -168,19 +168,15 @@ rcl_expand_topic_name(
           char * unmatched_substitution =
             rcutils_strndup(next_opening_brace, substitution_substr_len, allocator);
           char * allocated_msg = NULL;
-          char * msg = NULL;
           if (unmatched_substitution) {
             allocated_msg = rcutils_format_string(
               allocator,
               "unknown substitution: %s", unmatched_substitution);
-            msg = allocated_msg;
+            rcl_set_formatted_error(allocated_msg, allocator);
           } else {
-            SAFE_FWRITE_TO_STDERR("failed to allocate memory for error message\n");
-            msg = "unknown substitution: allocation failed when reporting error";
+            SAFE_FWRITE_TO_STDERR("failed to allocate memory for unmatched substitution\n");
           }
-          RCL_SET_ERROR_MSG(msg, allocator)
           allocator.deallocate(unmatched_substitution, allocator.state);
-          allocator.deallocate(allocated_msg, allocator.state);
           allocator.deallocate(local_output, allocator.state);
           return RCL_RET_UNKNOWN_SUBSTITUTION;
         }

--- a/rcl/src/rcl/expand_topic_name.c
+++ b/rcl/src/rcl/expand_topic_name.c
@@ -173,8 +173,6 @@ rcl_expand_topic_name(
               "unknown substitution: %s", unmatched_substitution);
           } else {
             SAFE_FWRITE_TO_STDERR("failed to allocate memory for unmatched substitution\n");
-            RCL_SET_ERROR_MSG("unknown substitution: allocation failed when reporting error",
-              allocator);
           }
           allocator.deallocate(unmatched_substitution, allocator.state);
           allocator.deallocate(local_output, allocator.state);

--- a/rcl/src/rcl/expand_topic_name.c
+++ b/rcl/src/rcl/expand_topic_name.c
@@ -34,7 +34,7 @@ extern "C"
 #include "rmw/validate_namespace.h"
 #include "rmw/validate_node_name.h"
 
-#define SAFE_FWRITE_TO_STDERR(msg) fwrite(msg, sizeof(char), sizeof(msg), stderr)
+#define RCL_SAFE_FWRITE_TO_STDERR(msg) fwrite(msg, sizeof(char), sizeof(msg), stderr)
 
 // built-in substitution strings
 #define SUBSTITUION_NODE_NAME "{node}"
@@ -172,7 +172,7 @@ rcl_expand_topic_name(
               allocator,
               "unknown substitution: %s", unmatched_substitution);
           } else {
-            SAFE_FWRITE_TO_STDERR("failed to allocate memory for unmatched substitution\n");
+            RCL_SAFE_FWRITE_TO_STDERR("failed to allocate memory for unmatched substitution\n");
           }
           allocator.deallocate(unmatched_substitution, allocator.state);
           allocator.deallocate(local_output, allocator.state);

--- a/rcl_lifecycle/src/transition_map.c
+++ b/rcl_lifecycle/src/transition_map.c
@@ -77,9 +77,8 @@ rcl_lifecycle_register_state(
   const rcutils_allocator_t * allocator)
 {
   if (rcl_lifecycle_get_state(transition_map, state.id) != NULL) {
-    char * error_msg = rcutils_format_string(rcutils_get_default_allocator(),
+    RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(rcutils_get_default_allocator(),
         "state %u is already registered\n", state.id);
-    rcl_set_formatted_error(error_msg, rcutils_get_default_allocator());
     return RCL_RET_ERROR;
   }
 
@@ -115,9 +114,8 @@ rcl_lifecycle_register_transition(
 
   rcl_lifecycle_state_t * state = rcl_lifecycle_get_state(transition_map, transition.start->id);
   if (!state) {
-    char * error_msg = rcutils_format_string(rcl_get_default_allocator(),
+    RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(rcl_get_default_allocator(),
         "state %u is not registered\n", transition.start->id);
-    rcl_set_formatted_error(error_msg, rcl_get_default_allocator());
     return RCL_RET_ERROR;
   }
 

--- a/rcl_lifecycle/src/transition_map.c
+++ b/rcl_lifecycle/src/transition_map.c
@@ -78,7 +78,7 @@ rcl_lifecycle_register_state(
 {
   if (rcl_lifecycle_get_state(transition_map, state.id) != NULL) {
     RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(rcutils_get_default_allocator(),
-        "state %u is already registered\n", state.id);
+      "state %u is already registered\n", state.id);
     return RCL_RET_ERROR;
   }
 
@@ -115,7 +115,7 @@ rcl_lifecycle_register_transition(
   rcl_lifecycle_state_t * state = rcl_lifecycle_get_state(transition_map, transition.start->id);
   if (!state) {
     RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(rcl_get_default_allocator(),
-        "state %u is not registered\n", transition.start->id);
+      "state %u is not registered\n", transition.start->id);
     return RCL_RET_ERROR;
   }
 

--- a/rcl_lifecycle/src/transition_map.c
+++ b/rcl_lifecycle/src/transition_map.c
@@ -79,7 +79,7 @@ rcl_lifecycle_register_state(
   if (rcl_lifecycle_get_state(transition_map, state.id) != NULL) {
     char * error_msg = rcutils_format_string(rcutils_get_default_allocator(),
         "state %u is already registered\n", state.id);
-    RCL_SET_ERROR_MSG(error_msg, rcutils_get_default_allocator());
+    rcl_set_formatted_error(error_msg, rcutils_get_default_allocator());
     return RCL_RET_ERROR;
   }
 
@@ -117,7 +117,7 @@ rcl_lifecycle_register_transition(
   if (!state) {
     char * error_msg = rcutils_format_string(rcl_get_default_allocator(),
         "state %u is not registered\n", transition.start->id);
-    RCL_SET_ERROR_MSG(error_msg, rcl_get_default_allocator());
+    rcl_set_formatted_error(error_msg, rcl_get_default_allocator());
     return RCL_RET_ERROR;
   }
 


### PR DESCRIPTION
address those memory leak issues with the API
`rcutils_set_formatted_error()` which is defined
in `rcutils`

Signed-off-by: Ethan Gao <ethan.gao@linux.intel.com>