### PR TITLE
create a macro RCL_CHECK_ALLOCATOR

### DIFF
--- a/rcl/include/rcl/allocator.h
+++ b/rcl/include/rcl/allocator.h
@@ -28,6 +28,12 @@ typedef rcutils_allocator_t rcl_allocator_t;
 
 #define rcl_reallocf rcutils_reallocf
 
+#define RCL_CHECK_ALLOCATOR(allocator, fail_statement) \
+  RCUTILS_CHECK_ALLOCATOR(allocator, fail_statement)
+
+#define RCL_CHECK_ALLOCATOR_WITH_MSG(allocator, msg, fail_statement) \
+  RCUTILS_CHECK_ALLOCATOR_WITH_MSG(allocator, msg, fail_statement)
+
 #if __cplusplus
 }
 #endif

--- a/rcl/include/rcl/error_handling.h
+++ b/rcl/include/rcl/error_handling.h
@@ -37,6 +37,12 @@ typedef rcutils_error_state_t rcl_error_state_t;
 
 #define rcl_set_error_state rcutils_set_error_state
 
+#define RCL_CHECK_ARGUMENT_FOR_NULL(argument, error_return_type, allocator) \
+  RCUTILS_CHECK_ARGUMENT_FOR_NULL(argument, error_return_type, allocator)
+
+#define RCL_CHECK_FOR_NULL_WITH_MSG(value, msg, error_statement, allocator) \
+  RCUTILS_CHECK_FOR_NULL_WITH_MSG(value, msg, error_statement, allocator)
+
 #define RCL_SET_ERROR_MSG(msg, allocator) RCUTILS_SET_ERROR_MSG(msg, allocator)
 
 #define rcl_error_is_set rcutils_error_is_set

--- a/rcl/src/rcl/client.c
+++ b/rcl/src/rcl/client.c
@@ -58,13 +58,7 @@ rcl_client_init(
   // check the options and allocator first, so the allocator can be passed to errors
   RCL_CHECK_ARGUMENT_FOR_NULL(options, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   const rcl_allocator_t * allocator = &options->allocator;
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator->allocate, "allocate not set",
-    return RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator->deallocate, "deallocate not set",
-    return RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-
+  RCL_CHECK_ALLOCATOR_WITH_MSG(allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(client, RCL_RET_INVALID_ARGUMENT, *allocator);
   RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_INVALID_ARGUMENT, *allocator);
   if (!node->impl) {

--- a/rcl/src/rcl/client.c
+++ b/rcl/src/rcl/client.c
@@ -22,6 +22,7 @@ extern "C"
 #include <stdio.h>
 #include <string.h>
 
+#include "rcl/error_handling.h"
 #include "rcl/expand_topic_name.h"
 #include "rcutils/logging_macros.h"
 #include "rmw/error_handling.h"

--- a/rcl/src/rcl/common.c
+++ b/rcl/src/rcl/common.c
@@ -22,6 +22,7 @@ extern "C"
 #include <stdlib.h>
 
 #include "rcl/allocator.h"
+#include "rcl/error_handling.h"
 
 #if defined(_WIN32)
 # define WINDOWS_ENV_BUFFER_SIZE 2048

--- a/rcl/src/rcl/common.h
+++ b/rcl/src/rcl/common.h
@@ -23,16 +23,6 @@ extern "C"
 #include "rcl/error_handling.h"
 #include "rcl/types.h"
 
-#define RCL_CHECK_ARGUMENT_FOR_NULL(argument, error_return_type, allocator) \
-  RCL_CHECK_FOR_NULL_WITH_MSG(argument, #argument " argument is null", \
-    return error_return_type, allocator)
-
-#define RCL_CHECK_FOR_NULL_WITH_MSG(value, msg, error_statement, allocator) \
-  if (!(value)) { \
-    RCL_SET_ERROR_MSG(msg, allocator); \
-    error_statement; \
-  }
-
 /// Retrieve the value of the given environment variable if it exists, or "".
 /* The returned cstring is only valid until the next time this function is
  * called, because it is a direct pointer to the static storage.

--- a/rcl/src/rcl/common.h
+++ b/rcl/src/rcl/common.h
@@ -20,7 +20,6 @@ extern "C"
 {
 #endif
 
-#include "rcl/error_handling.h"
 #include "rcl/types.h"
 
 /// Retrieve the value of the given environment variable if it exists, or "".

--- a/rcl/src/rcl/graph.c
+++ b/rcl/src/rcl/graph.c
@@ -19,12 +19,13 @@ extern "C"
 
 #include "rcl/graph.h"
 
-#include <rcutils/allocator.h>
-#include <rcutils/types.h>
-#include <rmw/get_service_names_and_types.h>
-#include <rmw/get_topic_names_and_types.h>
-#include <rmw/names_and_types.h>
-#include <rmw/rmw.h>
+#include "rcl/error_handling.h"
+#include "rcutils/allocator.h"
+#include "rcutils/types.h"
+#include "rmw/get_service_names_and_types.h"
+#include "rmw/get_topic_names_and_types.h"
+#include "rmw/names_and_types.h"
+#include "rmw/rmw.h"
 
 #include "./common.h"
 

--- a/rcl/src/rcl/guard_condition.c
+++ b/rcl/src/rcl/guard_condition.c
@@ -19,7 +19,7 @@ extern "C"
 
 #include "rcl/guard_condition.h"
 
-#include "./common.h"
+#include "rcl/error_handling.h"
 #include "rcl/rcl.h"
 #include "rmw/error_handling.h"
 #include "rmw/rmw.h"

--- a/rcl/src/rcl/guard_condition.c
+++ b/rcl/src/rcl/guard_condition.c
@@ -48,12 +48,7 @@ __rcl_guard_condition_init_from_rmw_impl(
 
   // Perform argument validation.
   const rcl_allocator_t * allocator = &options.allocator;
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator->allocate, "allocate not set",
-    return RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator->deallocate, "deallocate not set",
-    return RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
+  RCL_CHECK_ALLOCATOR_WITH_MSG(allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(guard_condition, RCL_RET_INVALID_ARGUMENT, *allocator);
   // Ensure the guard_condition handle is zero initialized.
   if (guard_condition->impl) {

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -102,12 +102,7 @@ rcl_node_init(
   // Check options and allocator first, so allocator can be used for errors.
   RCL_CHECK_ARGUMENT_FOR_NULL(options, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   const rcl_allocator_t * allocator = &options->allocator;
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator->allocate, "allocate not set",
-    return RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator->deallocate, "deallocate not set",
-    return RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
+  RCL_CHECK_ALLOCATOR_WITH_MSG(allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
 
   RCL_CHECK_ARGUMENT_FOR_NULL(name, RCL_RET_INVALID_ARGUMENT, *allocator);
   RCL_CHECK_ARGUMENT_FOR_NULL(namespace_, RCL_RET_INVALID_ARGUMENT, *allocator);

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -24,6 +24,7 @@ extern "C"
 #include <stdlib.h>
 #include <string.h>
 
+#include "rcl/error_handling.h"
 #include "rcl/rcl.h"
 #include "rcutils/filesystem.h"
 #include "rcutils/get_env.h"

--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -23,6 +23,7 @@ extern "C"
 #include <string.h>
 
 #include "./common.h"
+#include "rcl/allocator.h"
 #include "rcl/expand_topic_name.h"
 #include "rcutils/logging_macros.h"
 #include "rmw/error_handling.h"
@@ -55,12 +56,7 @@ rcl_publisher_init(
   // Check options and allocator first, so allocator can be used with errors.
   RCL_CHECK_ARGUMENT_FOR_NULL(options, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   const rcl_allocator_t * allocator = &options->allocator;
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator->allocate, "allocate not set",
-    return RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator->deallocate, "deallocate not set",
-    return RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
+  RCL_CHECK_ALLOCATOR_WITH_MSG(allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
 
   RCL_CHECK_ARGUMENT_FOR_NULL(publisher, RCL_RET_INVALID_ARGUMENT, *allocator);
   if (publisher->impl) {

--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -22,8 +22,8 @@ extern "C"
 #include <stdio.h>
 #include <string.h>
 
-#include "./common.h"
 #include "rcl/allocator.h"
+#include "rcl/error_handling.h"
 #include "rcl/expand_topic_name.h"
 #include "rcutils/logging_macros.h"
 #include "rmw/error_handling.h"

--- a/rcl/src/rcl/rcl.c
+++ b/rcl/src/rcl/rcl.c
@@ -21,7 +21,6 @@ extern "C"
 
 #include <string.h>
 
-#include "./common.h"
 #include "./stdatomic_helper.h"
 #include "rcl/error_handling.h"
 #include "rmw/error_handling.h"

--- a/rcl/src/rcl/rcl.c
+++ b/rcl/src/rcl/rcl.c
@@ -59,14 +59,7 @@ rcl_init(int argc, char ** argv, rcl_allocator_t allocator)
   rcl_ret_t fail_ret = RCL_RET_ERROR;
 
   // Check allocator first, so it can be used in other errors.
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator.allocate,
-    "invalid allocator, allocate not set",
-    return RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator.deallocate,
-    "invalid allocator, deallocate not set",
-    return RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
+  RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
 
   if (argc > 0) {
     RCL_CHECK_ARGUMENT_FOR_NULL(argv, RCL_RET_INVALID_ARGUMENT, allocator);

--- a/rcl/src/rcl/rmw_implementation_identifier_check.c
+++ b/rcl/src/rcl/rmw_implementation_identifier_check.c
@@ -21,8 +21,9 @@ extern "C"
 #include <stdlib.h>
 #include <string.h>
 
-#include <rcutils/logging_macros.h>
-#include <rmw/rmw.h>
+#include "rcl/error_handling.h"
+#include "rcutils/logging_macros.h"
+#include "rmw/rmw.h"
 
 #include "rcl/types.h"
 #include "./common.h"

--- a/rcl/src/rcl/service.c
+++ b/rcl/src/rcl/service.c
@@ -22,7 +22,7 @@ extern "C"
 #include <stdio.h>
 #include <string.h>
 
-#include "./common.h"
+#include "rcl/error_handling.h"
 #include "rcl/expand_topic_name.h"
 #include "rcutils/logging_macros.h"
 #include "rmw/error_handling.h"

--- a/rcl/src/rcl/service.c
+++ b/rcl/src/rcl/service.c
@@ -55,12 +55,7 @@ rcl_service_init(
   // Check options and allocator first, so the allocator can be used in errors.
   RCL_CHECK_ARGUMENT_FOR_NULL(options, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   const rcl_allocator_t * allocator = &options->allocator;
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator->allocate, "allocate not set",
-    return RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator->deallocate, "deallocate not set",
-    return RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
+  RCL_CHECK_ALLOCATOR_WITH_MSG(allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
 
   RCL_CHECK_ARGUMENT_FOR_NULL(service, RCL_RET_INVALID_ARGUMENT, *allocator);
   RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_INVALID_ARGUMENT, *allocator);

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -21,7 +21,7 @@ extern "C"
 
 #include <stdio.h>
 
-#include "./common.h"
+#include "rcl/error_handling.h"
 #include "rcl/expand_topic_name.h"
 #include "rcutils/logging_macros.h"
 #include "rmw/error_handling.h"

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -54,12 +54,7 @@ rcl_subscription_init(
   // Check options and allocator first, so the allocator can be used in errors.
   RCL_CHECK_ARGUMENT_FOR_NULL(options, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
   const rcl_allocator_t * allocator = &options->allocator;
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator->allocate, "allocate not set",
-    return RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator->deallocate, "deallocate not set",
-    return RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
+  RCL_CHECK_ALLOCATOR_WITH_MSG(allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
 
   RCL_CHECK_ARGUMENT_FOR_NULL(subscription, RCL_RET_INVALID_ARGUMENT, *allocator);
   RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_INVALID_ARGUMENT, *allocator);

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -51,12 +51,7 @@ rcl_timer_init(
   const rcl_timer_callback_t callback,
   rcl_allocator_t allocator)
 {
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator.allocate, "allocate not set",
-    return RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator.deallocate, "deallocate not set",
-    return RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
+  RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(timer, RCL_RET_INVALID_ARGUMENT, allocator);
   if (timer->impl) {
     RCL_SET_ERROR_MSG("timer already initailized, or memory was uninitialized", allocator);

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -19,8 +19,8 @@ extern "C"
 
 #include "rcl/timer.h"
 
-#include "./common.h"
 #include "./stdatomic_helper.h"
+#include "rcl/error_handling.h"
 #include "rcutils/time.h"
 
 typedef struct rcl_timer_impl_t

--- a/rcl/src/rcl/validate_topic_name.c
+++ b/rcl/src/rcl/validate_topic_name.c
@@ -22,8 +22,8 @@ extern "C"
 #include <ctype.h>
 #include <string.h>
 
-#include "./common.h"
 #include "rcl/allocator.h"
+#include "rcl/error_handling.h"
 #include "rcutils/isalnum_no_locale.h"
 
 rcl_ret_t

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -23,7 +23,6 @@ extern "C"
 #include <stdbool.h>
 #include <string.h>
 
-#include "./common.h"
 #include "./stdatomic_helper.h"
 #include "rcl/error_handling.h"
 #include "rcl/time.h"

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -116,16 +116,7 @@ rcl_wait_set_init(
 {
   rcl_ret_t fail_ret = RCL_RET_ERROR;
 
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator.allocate, "allocate not set",
-    return RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator.deallocate, "deallocate not set",
-    return RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    allocator.reallocate, "reallocate not set",
-    return RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-
+  RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(wait_set, RCL_RET_INVALID_ARGUMENT, allocator);
   if (__wait_set_is_valid(wait_set)) {
     RCL_SET_ERROR_MSG("wait_set already initialized, or memory was uninitialized.", allocator);


### PR DESCRIPTION
 to check the required methods are set on the allocator

I found 2 instances of this already partially impelemented and was starting to write several more for the time PRs. 

Linux: [![Build Status](http://ci.ros2.org/job/ci_linux/3481/badge/icon)](http://ci.ros2.org/job/ci_linux/3481/)
Linux arm64: [![Build Status](http://ci.ros2.org/job/ci_linux-aarch64/718/badge/icon)](http://ci.ros2.org/job/ci_linux-aarch64/718/)
OSX: [![Build Status](http://ci.ros2.org/job/ci_osx/2808/badge/icon)](http://ci.ros2.org/job/ci_osx/2808/)
Windows: [![Build Status](http://ci.ros2.org/job/ci_windows/3526/badge/icon)](http://ci.ros2.org/job/ci_windows/3526/)