### PR TITLE
Remove error message when client take returns false

### DIFF
--- a/rcl/include/rcl/client.h
+++ b/rcl/include/rcl/client.h
@@ -275,6 +275,8 @@ rcl_send_request(const rcl_client_t * client, const void * ros_request, int64_t 
  * \return `RCL_RET_OK` if the response was taken successfully, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
  * \return `RCL_RET_CLIENT_INVALID` if the client is invalid, or
+ * \return `RCL_RET_CLIENT_TAKE_FAILED` if take failed but no error occurred
+ *         in the middleware, or
  * \return `RCL_RET_ERROR` if an unspecified error occurs.
  */
 RCL_PUBLIC

--- a/rcl/include/rcl/service.h
+++ b/rcl/include/rcl/service.h
@@ -234,6 +234,8 @@ rcl_service_get_default_options(void);
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
  * \return `RCL_RET_SERVICE_INVALID` if the service is invalid, or
  * \return `RCL_RET_BAD_ALLOC` if allocating memory failed, or
+ * \return `RCL_RET_SERVICE_TAKE_FAILED` if take failed but no error occurred
+ *         in the middleware, or
  * \return `RCL_RET_ERROR` if an unspecified error occurs.
  */
 RCL_PUBLIC

--- a/rcl/src/rcl/client.c
+++ b/rcl/src/rcl/client.c
@@ -276,7 +276,6 @@ rcl_take_response(
     return RCL_RET_ERROR;
   }
   if (!taken) {
-    RCL_SET_ERROR_MSG(rmw_get_error_string_safe(), client->impl->options.allocator);
     return RCL_RET_CLIENT_TAKE_FAILED;
   }
   return RCL_RET_OK;


### PR DESCRIPTION
Equivalent of https://github.com/ros2/rcl/pull/88 for clients, brought up in https://github.com/ros2/rclcpp/issues/397

Also documenting the return code, following doc of subscription's: https://github.com/ros2/rcl/blob/25589233152b331ae173c8827f8d3f303606bd95/rcl/include/rcl/subscription.h#L245

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3530)](http://ci.ros2.org/job/ci_linux/3530/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=746)](http://ci.ros2.org/job/ci_linux-aarch64/746/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2877)](http://ci.ros2.org/job/ci_osx/2877/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3616)](http://ci.ros2.org/job/ci_windows/3616/)