### PR TITLE
optimize to avoid uninitialized scalar variable

### DIFF
--- a/rcl_lifecycle/src/com_interface.c
+++ b/rcl_lifecycle/src/com_interface.c
@@ -67,6 +67,7 @@ rcl_lifecycle_com_interface_t
 rcl_lifecycle_get_zero_initialized_com_interface()
 {
   rcl_lifecycle_com_interface_t com_interface;
+  com_interface.node_handle = NULL;
   com_interface.pub_transition_event = rcl_get_zero_initialized_publisher();
   com_interface.srv_change_state = rcl_get_zero_initialized_service();
   com_interface.srv_get_state = rcl_get_zero_initialized_service();

--- a/rcl_lifecycle/src/rcl_lifecycle.c
+++ b/rcl_lifecycle/src/rcl_lifecycle.c
@@ -38,6 +38,7 @@ rcl_lifecycle_state_machine_t
 rcl_lifecycle_get_zero_initialized_state_machine()
 {
   rcl_lifecycle_state_machine_t state_machine;
+  state_machine.current_state = NULL;
   state_machine.transition_map = rcl_lifecycle_get_zero_initialized_transition_map();
   state_machine.com_interface = rcl_lifecycle_get_zero_initialized_com_interface();
   return state_machine;


### PR DESCRIPTION
They contains an arbitrary value left from earlier computations,
and the security checking complains it
Signed-off-by: Ethan Gao <ethan.gao@linux.intel.com>