### PR TITLE
Switch rcl_lifecyle to ament_cmake_ros

### DIFF
--- a/rcl_lifecycle/CMakeLists.txt
+++ b/rcl_lifecycle/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rcl_lifecycle)
 
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 
 find_package(lifecycle_msgs REQUIRED)
 find_package(rcl REQUIRED)
@@ -38,7 +38,6 @@ set_source_files_properties(
 ### C-Library depending only on RCL
 add_library(
   rcl_lifecycle
-  SHARED
   ${rcl_lifecycle_sources})
 
 ament_target_dependencies(rcl_lifecycle

--- a/rcl_lifecycle/package.xml
+++ b/rcl_lifecycle/package.xml
@@ -7,7 +7,7 @@
   <maintainer email="karsten@osrfoundation.org">Karsten Knese</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <build_depend>lifecycle_msgs</build_depend>


### PR DESCRIPTION
connects to ros2/ros2#306
parallel of https://github.com/ros2/rcl/pull/93

I am interested in this to get access to `ROS_PACKAGE_NAME` for logging (see https://github.com/ros2/ament_cmake_ros/pull/2#issuecomment-345107445)

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3571)](http://ci.ros2.org/job/ci_linux/3571/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=768)](http://ci.ros2.org/job/ci_linux-aarch64/768/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2911)](http://ci.ros2.org/job/ci_osx/2911/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3664)](http://ci.ros2.org/job/ci_windows/3664/)