### PR TITLE
Waitset member allocation use rmw types

### DIFF
--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -305,7 +305,7 @@ rcl_wait_set_get_allocator(const rcl_wait_set_t * wait_set, rcl_allocator_t * al
   } else { \
     wait_set->Type ## s = (const rcl_ ## Type ## _t * *)allocator.reallocate( \
       (void *)wait_set->Type ## s, sizeof(rcl_ ## Type ## _t *) * size, allocator.state); \
-    memset(wait_set->Type ## s, 0, sizeof(rcl_ ## Type ## _t *) * size); \
+    memset((void *)wait_set->Type ## s, 0, sizeof(rcl_ ## Type ## _t *) * size); \
     RCL_CHECK_FOR_NULL_WITH_MSG( \
       wait_set->Type ## s, "allocating memory failed", \
       return RCL_RET_BAD_ALLOC, wait_set->impl->allocator); \

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -305,10 +305,10 @@ rcl_wait_set_get_allocator(const rcl_wait_set_t * wait_set, rcl_allocator_t * al
   } else { \
     wait_set->Type ## s = (const rcl_ ## Type ## _t * *)allocator.reallocate( \
       (void *)wait_set->Type ## s, sizeof(rcl_ ## Type ## _t *) * size, allocator.state); \
-    memset((void *)wait_set->Type ## s, 0, sizeof(rcl_ ## Type ## _t *) * size); \
     RCL_CHECK_FOR_NULL_WITH_MSG( \
       wait_set->Type ## s, "allocating memory failed", \
       return RCL_RET_BAD_ALLOC, wait_set->impl->allocator); \
+    memset((void *)wait_set->Type ## s, 0, sizeof(rcl_ ## Type ## _t *) * size); \
     wait_set->size_of_ ## Type ## s = size; \
     ExtraRealloc \
   } \
@@ -325,14 +325,14 @@ rcl_wait_set_get_allocator(const rcl_wait_set_t * wait_set, rcl_allocator_t * al
   /* Also resize the rmw storage. */ \
   wait_set->impl->RMWCount = 0; \
   wait_set->impl->RMWStorage = (void **)allocator.reallocate( \
-    wait_set->impl->RMWStorage, sizeof(rmw_ ## Type ## _t *) * size, allocator.state); \
+    wait_set->impl->RMWStorage, sizeof(void *) * size, allocator.state); \
   if (!wait_set->impl->RMWStorage) { \
     allocator.deallocate((void *)wait_set->Type ## s, allocator.state); \
     wait_set->size_of_ ## Type ## s = 0; \
     RCL_SET_ERROR_MSG("allocating memory failed", wait_set->impl->allocator); \
     return RCL_RET_BAD_ALLOC; \
   } \
-  memset(wait_set->impl->RMWStorage, 0, sizeof(rmw_ ## Type ## _t *) * size);
+  memset(wait_set->impl->RMWStorage, 0, sizeof(void *) * size);
 
 /* Implementation-specific notes:
  *

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -324,7 +324,7 @@ rcl_wait_set_get_allocator(const rcl_wait_set_t * wait_set, rcl_allocator_t * al
   /* Also resize the rmw storage. */ \
   wait_set->impl->RMWCount = 0; \
   wait_set->impl->RMWStorage = (void **)allocator.reallocate( \
-    wait_set->impl->RMWStorage, sizeof(rcl_ ## Type ## _t *) * size, allocator.state); \
+    wait_set->impl->RMWStorage, sizeof(rmw_ ## Type ## _t *) * size, allocator.state); \
   if (!wait_set->impl->RMWStorage) { \
     allocator.deallocate((void *)wait_set->Type ## s, allocator.state); \
     wait_set->size_of_ ## Type ## s = 0; \

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -305,6 +305,7 @@ rcl_wait_set_get_allocator(const rcl_wait_set_t * wait_set, rcl_allocator_t * al
   } else { \
     wait_set->Type ## s = (const rcl_ ## Type ## _t * *)allocator.reallocate( \
       (void *)wait_set->Type ## s, sizeof(rcl_ ## Type ## _t *) * size, allocator.state); \
+    memset(wait_set->Type ## s, 0, sizeof(rcl_ ## Type ## _t *) * size); \
     RCL_CHECK_FOR_NULL_WITH_MSG( \
       wait_set->Type ## s, "allocating memory failed", \
       return RCL_RET_BAD_ALLOC, wait_set->impl->allocator); \
@@ -330,7 +331,8 @@ rcl_wait_set_get_allocator(const rcl_wait_set_t * wait_set, rcl_allocator_t * al
     wait_set->size_of_ ## Type ## s = 0; \
     RCL_SET_ERROR_MSG("allocating memory failed", wait_set->impl->allocator); \
     return RCL_RET_BAD_ALLOC; \
-  }
+  } \
+  memset(wait_set->impl->RMWStorage, 0, sizeof(rmw_ ## Type ## _t *) * size);
 
 /* Implementation-specific notes:
  *

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -283,7 +283,7 @@ rcl_wait_set_get_allocator(const rcl_wait_set_t * wait_set, rcl_allocator_t * al
   memset( \
     wait_set->impl->RMWStorage, \
     0, \
-    sizeof(rmw_ ## Type ## _t *) * wait_set->impl->RMWCount); \
+    sizeof(void *) * wait_set->impl->RMWCount); \
   wait_set->impl->RMWCount = 0;
 
 #define SET_RESIZE(Type, ExtraDealloc, ExtraRealloc) \


### PR DESCRIPTION
Saw this when reviewing changes from https://github.com/ros2/rcl/pull/54/files#diff-8fda46206fc38bfdbcac0e5213bffddaR304.

The first commit uses the size of the rmw type to allocate memory (that if the type of the stored structure)
The second commit zero initializes allocated memory in the SET_RESIZE macros

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3591)](http://ci.ros2.org/job/ci_linux/3591/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=784)](http://ci.ros2.org/job/ci_linux-aarch64/784/) (unrelated)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2931)](http://ci.ros2.org/job/ci_osx/2931/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3682)](http://ci.ros2.org/job/ci_windows/3682/) (fixed in dfda56b694815c94fcfa5e541dda6d659f5229e9)
