### PR TITLE
allocate twice the space for each condition

### DIFF
--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -144,8 +144,8 @@ rcl_wait_set_init(
   wait_set->impl->rmw_services.service_count = 0;
 
   wait_set->impl->rmw_waitset = rmw_create_waitset(
-    2 * number_of_subscriptions + number_of_guard_conditions + number_of_clients +
-    number_of_services);
+    2 * (number_of_subscriptions + number_of_guard_conditions + number_of_clients +
+    number_of_services));
   if (!wait_set->impl->rmw_waitset) {
     goto fail;
   }


### PR DESCRIPTION
Not sure why we allocate `2 * number_of_subscriptions`. It has been introduced in https://github.com/ros2/rcl/pull/7/files but I didnt see a justification for it.

Looking at the implementations of `rmw_create_waitset`
[Fast-RTPS](https://github.com/ros2/rmw_fastrtps/blob/8118e1cad741192c0b2df2f91940fdae30037325/rmw_fastrtps_cpp/src/rmw_waitset.cpp#L28): the parameter `max_conditions` is not used
[Connext](https://github.com/ros2/rmw_connext/blob/9e8479039a3941df8c3c746c1a9e7fa91109abb3/rmw_connext_shared_cpp/src/waitset.cpp#L63-L71) (static and dynamic) and [OpenSplice](https://github.com/ros2/rmw_opensplice/blob/d66acbbd0aee5aba9a3cbd54fcdaee6454dcd3f2/rmw_opensplice_cpp/src/rmw_waitset.cpp#L76-L84): My guess is that it is done to allocate space for both `active_conditions` and `attached_conditions`. In that case we would need to pass `2 * (sum of all conditions)` rather than just `2 * number_of_subscriptions`

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3602)](http://ci.ros2.org/job/ci_linux/3602/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=792)](http://ci.ros2.org/job/ci_linux-aarch64/792/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=2939)](http://ci.ros2.org/job/ci_osx/2939/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3691)](http://ci.ros2.org/job/ci_windows/3691/)
