### PR TITLE
adapt to NULL removal from rmw result validation string

### DIFF
--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -166,9 +166,7 @@ rcl_node_init(
   }
   if (validation_result != RMW_NAMESPACE_VALID) {
     const char * msg = rmw_namespace_validation_result_string(validation_result);
-    char fixed_msg[256];
-    rcutils_snprintf(fixed_msg, sizeof(fixed_msg), "%s, result '%d'", msg, validation_result);
-    RCL_SET_ERROR_MSG(fixed_msg, *allocator);
+    RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(*allocator, "%s, result '%d'", msg, validation_result);
 
     if (should_free_local_namespace_) {
       allocator->deallocate((char *)local_namespace_, allocator->state);

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -167,9 +167,7 @@ rcl_node_init(
   if (validation_result != RMW_NAMESPACE_VALID) {
     const char * msg = rmw_namespace_validation_result_string(validation_result);
     char fixed_msg[256];
-    rcutils_snprintf(
-      fixed_msg, sizeof(fixed_msg),
-      "%s: '%d'", msg, validation_result);
+    rcutils_snprintf(fixed_msg, sizeof(fixed_msg), "%s, result '%d'", msg, validation_result);
     RCL_SET_ERROR_MSG(fixed_msg, *allocator);
 
     if (should_free_local_namespace_) {

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -27,6 +27,7 @@ extern "C"
 #include "rcl/error_handling.h"
 #include "rcl/rcl.h"
 #include "rcutils/filesystem.h"
+#include "rcutils/format_string.h"
 #include "rcutils/get_env.h"
 #include "rcutils/logging_macros.h"
 #include "rcutils/macros.h"
@@ -166,7 +167,7 @@ rcl_node_init(
   }
   if (validation_result != RMW_NAMESPACE_VALID) {
     const char * msg = rmw_namespace_validation_result_string(validation_result);
-    RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(*allocator, "%s, result '%d'", msg, validation_result);
+    RCL_SET_ERROR_MSG_WITH_FORMAT_STRING((*allocator), "%s, result: %d", msg, validation_result);
 
     if (should_free_local_namespace_) {
       allocator->deallocate((char *)local_namespace_, allocator->state);

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -128,9 +128,6 @@ rcl_node_init(
   }
   if (validation_result != RMW_NODE_NAME_VALID) {
     const char * msg = rmw_node_name_validation_result_string(validation_result);
-    if (!msg) {
-      msg = "unknown validation_result, this should not happen";
-    }
     RCL_SET_ERROR_MSG(msg, *allocator);
     return RCL_RET_NODE_INVALID_NAME;
   }
@@ -169,15 +166,11 @@ rcl_node_init(
   }
   if (validation_result != RMW_NAMESPACE_VALID) {
     const char * msg = rmw_namespace_validation_result_string(validation_result);
-    if (!msg) {
-      char fixed_msg[256];
-      rcutils_snprintf(
-        fixed_msg, sizeof(fixed_msg),
-        "unknown validation_result '%d', this should not happen", validation_result);
-      RCL_SET_ERROR_MSG(fixed_msg, *allocator);
-    } else {
-      RCL_SET_ERROR_MSG(msg, *allocator);
-    }
+    char fixed_msg[256];
+    rcutils_snprintf(
+      fixed_msg, sizeof(fixed_msg),
+      "%s: '%d'", msg, validation_result);
+    RCL_SET_ERROR_MSG(fixed_msg, *allocator);
 
     if (should_free_local_namespace_) {
       allocator->deallocate((char *)local_namespace_, allocator->state);

--- a/rcl/src/rcl/validate_topic_name.c
+++ b/rcl/src/rcl/validate_topic_name.c
@@ -193,6 +193,8 @@ const char *
 rcl_topic_name_validation_result_string(int validation_result)
 {
   switch (validation_result) {
+    case RCL_TOPIC_NAME_VALID:
+      return NULL;
     case RCL_TOPIC_NAME_INVALID_IS_EMPTY_STRING:
       return "topic name must not be empty string";
     case RCL_TOPIC_NAME_INVALID_ENDS_WITH_FORWARD_SLASH:
@@ -213,7 +215,7 @@ rcl_topic_name_validation_result_string(int validation_result)
     case RCL_TOPIC_NAME_INVALID_SUBSTITUTION_STARTS_WITH_NUMBER:
       return "substitution name must not start with a number";
     default:
-      return NULL;
+      return "undefined topic name type";
   }
 }
 

--- a/rcl/src/rcl/validate_topic_name.c
+++ b/rcl/src/rcl/validate_topic_name.c
@@ -215,7 +215,7 @@ rcl_topic_name_validation_result_string(int validation_result)
     case RCL_TOPIC_NAME_INVALID_SUBSTITUTION_STARTS_WITH_NUMBER:
       return "substitution name must not start with a number";
     default:
-      return "undefined topic name type";
+      return "unknown result code for rcl topic name validation";
   }
 }
 

--- a/rcl/test/rcl/test_validate_topic_name.cpp
+++ b/rcl/test/rcl/test_validate_topic_name.cpp
@@ -28,10 +28,10 @@ TEST(test_validate_topic_name, normal) {
   // passing without invalid_index
   {
     int validation_result;
-    ret = rcl_validate_topic_name("topic", &validation_result, NULL);
+    ret = rcl_validate_topic_name("topic", &validation_result, nullptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
     EXPECT_EQ(RCL_TOPIC_NAME_VALID, validation_result);
-    EXPECT_EQ(NULL, rcl_topic_name_validation_result_string(validation_result));
+    EXPECT_EQ(nullptr, rcl_topic_name_validation_result_string(validation_result));
   }
 
   // passing with invalid_index
@@ -42,7 +42,7 @@ TEST(test_validate_topic_name, normal) {
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
     EXPECT_EQ(RCL_TOPIC_NAME_VALID, validation_result);
     EXPECT_EQ(42u, invalid_index);  // ensure invalid_index is not assigned on success
-    EXPECT_EQ(NULL, rcl_topic_name_validation_result_string(validation_result));
+    EXPECT_EQ(nullptr, rcl_topic_name_validation_result_string(validation_result));
   }
 
   // failing with invalid_index
@@ -63,14 +63,14 @@ TEST(test_validate_topic_name, invalid_arguments) {
   // pass null for topic string
   {
     int validation_result;
-    ret = rcl_validate_topic_name(NULL, &validation_result, NULL);
+    ret = rcl_validate_topic_name(nullptr, &validation_result, nullptr);
     EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
     rcl_reset_error();
   }
 
   // pass null for validation_result
   {
-    ret = rcl_validate_topic_name("topic", NULL, NULL);
+    ret = rcl_validate_topic_name("topic", nullptr, nullptr);
     EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
     rcl_reset_error();
   }


### PR DESCRIPTION
align to the update of APIs `rmw_*_validation_result_string()`
Signed-off-by: Ethan Gao <ethan.gao@linux.intel.com>

Connects to ros2/rmw#130