### PR TITLE
cmake 3.10 compatibility: pass absolute path to file(GENERATE) function

### DIFF
--- a/rcl/test/cmake/rcl_add_custom_launch_test.cmake
+++ b/rcl/test/cmake/rcl_add_custom_launch_test.cmake
@@ -29,7 +29,7 @@ macro(rcl_add_custom_launch_test test_name executable1 executable2)
     @ONLY
   )
   file(GENERATE
-    OUTPUT "test/${test_name}${target_suffix}_$<CONFIG>.py"
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test/${test_name}${target_suffix}_$<CONFIG>.py"
     INPUT "${CMAKE_CURRENT_BINARY_DIR}/${test_name}${target_suffix}.py.configure"
   )
   ament_add_pytest_test(${test_name}${target_suffix} "${CMAKE_CURRENT_BINARY_DIR}/${test_name}${target_suffix}_$<CONFIG>.py" ${ARGN})

--- a/rcl/test/cmake/rcl_add_custom_launch_test.cmake
+++ b/rcl/test/cmake/rcl_add_custom_launch_test.cmake
@@ -32,6 +32,6 @@ macro(rcl_add_custom_launch_test test_name executable1 executable2)
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test/${test_name}${target_suffix}_$<CONFIG>.py"
     INPUT "${CMAKE_CURRENT_BINARY_DIR}/${test_name}${target_suffix}.py.configure"
   )
-  ament_add_pytest_test(${test_name}${target_suffix} "${CMAKE_CURRENT_BINARY_DIR}/${test_name}${target_suffix}_$<CONFIG>.py" ${ARGN})
+  ament_add_pytest_test(${test_name}${target_suffix} "${CMAKE_CURRENT_BINARY_DIR}/test/${test_name}${target_suffix}_$<CONFIG>.py" ${ARGN})
   set_tests_properties(${test_name}${target_suffix} PROPERTIES DEPENDS "${executable1}${target_suffix} ${executable2}${target_suffix}")
 endmacro()


### PR DESCRIPTION
This is needed to support cmake 3.10. We could define the policy based on the version of CMake but I preferred updating the codebase to have something compliant with all cmake versions without relying on undefined behavior.

More details at https://cmake.org/cmake/help/git-stage/policy/CMP0070.html

Example of CMake warning without this patch:
```
Policy CMP0070 is not set: Define file(GENERATE) behavior for relative
paths.  Run "cmake --help-policy CMP0070" for policy details.  Use the
cmake_policy command to set the policy and suppress this warning.

file(GENERATE) given relative OUTPUT path:

  test/test_services__rmw_connext_cpp_RelWithDebInfo.py

This is not defined behavior unless CMP0070 is set to NEW.  For
compatibility with older versions of CMake, the previous undefined behavior
will be used.
```