### PR TITLE
Fail if RMW_IMPLEMENTATION is set but doesn't match

### DIFF
--- a/rcl/src/rcl/rmw_implementation_identifier_check.c
+++ b/rcl/src/rcl/rmw_implementation_identifier_check.c
@@ -97,7 +97,7 @@ INITIALIZER(initialize) {
     }
   }
 
-  // If both environment variables are set, and they do not match, print a warning and exit.
+  // If both environment variables are set, and they do not match, print an error and exit.
   if (expected_rmw_impl && asserted_rmw_impl && strcmp(expected_rmw_impl, asserted_rmw_impl) != 0) {
     RCUTILS_LOG_ERROR_NAMED(
       ROS_PACKAGE_NAME,
@@ -122,7 +122,7 @@ INITIALIZER(initialize) {
     }
   }
 
-  // If either environment variable is set, and it does not match, print a warning and exit.
+  // If either environment variable is set, and it does not match, print an error and exit.
   if (expected_rmw_impl) {
     const char * actual_rmw_impl_id = rmw_get_implementation_identifier();
     if (!actual_rmw_impl_id) {

--- a/rcl/src/rcl/rmw_implementation_identifier_check.c
+++ b/rcl/src/rcl/rmw_implementation_identifier_check.c
@@ -115,6 +115,8 @@ INITIALIZER(initialize) {
     // No need for asserted_rmw_impl anymore, free the memory.
     allocator.deallocate((char *)asserted_rmw_impl, allocator.state);
   } else {
+    // One or none are set.
+    // If asserted_rmw_impl has contents, move it over to expected_rmw_impl.
     if (asserted_rmw_impl) {
       expected_rmw_impl = asserted_rmw_impl;
     }

--- a/rcl/src/rcl/rmw_implementation_identifier_check.c
+++ b/rcl/src/rcl/rmw_implementation_identifier_check.c
@@ -24,6 +24,7 @@ extern "C"
 #include "rcl/allocator.h"
 #include "rcl/error_handling.h"
 #include "rcutils/logging_macros.h"
+#include "rcutils/strdup.h"
 #include "rmw/rmw.h"
 
 #include "rcl/types.h"
@@ -69,13 +70,11 @@ INITIALIZER(initialize) {
   }
   if (strlen(expected_rmw_impl_env) > 0) {
     // Copy the environment variable so it doesn't get over-written by the next getenv call.
-    expected_rmw_impl = (char *)allocator.allocate(
-      strlen(expected_rmw_impl_env) + 1, allocator.state);
+    expected_rmw_impl = rcutils_strdup(expected_rmw_impl_env, allocator);
     if (!expected_rmw_impl) {
       RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME, "allocation failed")
       exit(RCL_RET_BAD_ALLOC);
     }
-    memcpy(expected_rmw_impl, expected_rmw_impl_env, strlen(expected_rmw_impl_env) + 1);
   }
 
   char * asserted_rmw_impl = NULL;
@@ -91,13 +90,11 @@ INITIALIZER(initialize) {
   }
   if (strlen(asserted_rmw_impl_env) > 0) {
     // Copy the environment variable so it doesn't get over-written by the next getenv call.
-    asserted_rmw_impl = (char *)allocator.allocate(
-      strlen(asserted_rmw_impl_env) + 1, allocator.state);
+    asserted_rmw_impl = rcutils_strdup(asserted_rmw_impl_env, allocator);
     if (!asserted_rmw_impl) {
       RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME, "allocation failed")
       exit(RCL_RET_BAD_ALLOC);
     }
-    memcpy(asserted_rmw_impl, asserted_rmw_impl_env, strlen(asserted_rmw_impl_env) + 1);
   }
 
   // If both environment variables are set, and they do not match, print a warning and exit.

--- a/rcl/src/rcl/rmw_implementation_identifier_check.c
+++ b/rcl/src/rcl/rmw_implementation_identifier_check.c
@@ -122,12 +122,20 @@ INITIALIZER(initialize) {
 
   // If either environment variable is set, and it does not match, print a warning and exit.
   if (expected_rmw_impl) {
-    if(strcmp(rmw_get_implementation_identifier(), expected_rmw_impl) != 0) {
+    const char * actual_rmw_impl_id = rmw_get_implementation_identifier();
+    if (!actual_rmw_impl_id) {
+      RCUTILS_LOG_ERROR_NAMED(
+        ROS_PACKAGE_NAME,
+        "Error getting RMW implementation identifier."
+      )
+      exit(RCL_RET_ERROR);
+    }
+    if (strcmp(actual_rmw_impl_id, expected_rmw_impl) != 0) {
       RCUTILS_LOG_ERROR_NAMED(
         ROS_PACKAGE_NAME,
         "Expected RMW implementation identifier of '%s' but instead found '%s', exiting with %d.",
         expected_rmw_impl,
-        rmw_get_implementation_identifier(),
+        actual_rmw_impl_id,
         RCL_RET_MISMATCHED_RMW_ID
       )
       exit(RCL_RET_MISMATCHED_RMW_ID);

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -177,10 +177,6 @@ function(test_target_function)
     TIMEOUT 15
   )
 
-  # Test for environment variables that check matching rmw id
-  add_executable(test_rmw_impl_id_check_exe  # build simple executable for testing.
-    rcl/test_rmw_impl_id_check_exe.cpp)
-  target_link_libraries(test_rmw_impl_id_check_exe ${PROJECT_NAME})
   set(TEST_RMW_IMPL_ID_CHECK_EXECUTABLE_NAME "$<TARGET_FILE:test_rmw_impl_id_check_exe>")
   configure_file(
     rcl/test_rmw_impl_id_check.py.in
@@ -214,6 +210,11 @@ macro(connext_workaround target)
     set_target_properties(${target} PROPERTIES LINK_FLAGS "${_link_flags}")
   endif()
 endmacro()
+
+# Build simple executable for using in the test_rmw_impl_id_check
+add_executable(test_rmw_impl_id_check_exe
+  rcl/test_rmw_impl_id_check_exe.cpp)
+target_link_libraries(test_rmw_impl_id_check_exe ${PROJECT_NAME})
 
 call_for_each_rmw_implementation(test_target)
 

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -176,6 +176,29 @@ function(test_target_function)
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     TIMEOUT 15
   )
+
+  add_executable(test_rmw_impl_id_check_exe  # build simple executable for testing.
+    rcl/test_rmw_impl_id_check_exe.cpp)
+  target_link_libraries(test_rmw_impl_id_check_exe ${PROJECT_NAME})
+  set(TEST_RMW_IMPL_ID_CHECK_EXECUTABLE_NAME "$<TARGET_FILE:test_rmw_impl_id_check_exe>")
+  configure_file(
+    rcl/test_rmw_impl_id_check.py.in
+    ${CMAKE_CURRENT_BINARY_DIR}/test_rmw_impl_id_check${target_suffix}.py.configure
+    @ONLY
+  )
+  file(GENERATE
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/test/test_rmw_impl_id_check${target_suffix}_$<CONFIG>.py"
+    INPUT "${CMAKE_CURRENT_BINARY_DIR}/test_rmw_impl_id_check${target_suffix}.py.configure"
+  )
+  ament_add_pytest_test(
+    test_rmw_impl_id_check${target_suffix}
+    "${CMAKE_CURRENT_BINARY_DIR}/test/test_rmw_impl_id_check${target_suffix}_$<CONFIG>.py"
+  )
+  set_tests_properties(
+    test_rmw_impl_id_check${target_suffix}
+    PROPERTIES DEPENDS test_rmw_impl_id_check_exe
+  )
+
 endfunction()
 
 macro(connext_workaround target)

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -177,6 +177,7 @@ function(test_target_function)
     TIMEOUT 15
   )
 
+  # Test for environment variables that check matching rmw id
   add_executable(test_rmw_impl_id_check_exe  # build simple executable for testing.
     rcl/test_rmw_impl_id_check_exe.cpp)
   target_link_libraries(test_rmw_impl_id_check_exe ${PROJECT_NAME})

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -177,6 +177,12 @@ function(test_target_function)
     TIMEOUT 15
   )
 
+  set(SKIP_TEST "")
+  if(WIN32)
+    # TODO(dhood): launch does not set the return code correctly for these tests on Windows.
+    # See https://github.com/ros2/launch/issues/66
+    set(SKIP_TEST "SKIP_TEST")
+  endif()
   set(TEST_RMW_IMPL_ID_CHECK_EXECUTABLE_NAME "$<TARGET_FILE:test_rmw_impl_id_check_exe>")
   configure_file(
     rcl/test_rmw_impl_id_check.py.in
@@ -191,6 +197,7 @@ function(test_target_function)
     test_rmw_impl_id_check${target_suffix}
     "${CMAKE_CURRENT_BINARY_DIR}/test/test_rmw_impl_id_check${target_suffix}_$<CONFIG>.py"
     APPEND_LIBRARY_DIRS "${extra_lib_dirs}"
+    ${SKIP_TEST}
   )
   if(TEST test_rmw_impl_id_check${target_suffix})
     set_tests_properties(

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -190,6 +190,7 @@ function(test_target_function)
   ament_add_pytest_test(
     test_rmw_impl_id_check${target_suffix}
     "${CMAKE_CURRENT_BINARY_DIR}/test/test_rmw_impl_id_check${target_suffix}_$<CONFIG>.py"
+    APPEND_LIBRARY_DIRS "${extra_lib_dirs}"
   )
   if(TEST test_rmw_impl_id_check${target_suffix})
     set_tests_properties(

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -195,10 +195,12 @@ function(test_target_function)
     test_rmw_impl_id_check${target_suffix}
     "${CMAKE_CURRENT_BINARY_DIR}/test/test_rmw_impl_id_check${target_suffix}_$<CONFIG>.py"
   )
-  set_tests_properties(
-    test_rmw_impl_id_check${target_suffix}
-    PROPERTIES DEPENDS test_rmw_impl_id_check_exe
-  )
+  if(TEST test_rmw_impl_id_check${target_suffix})
+    set_tests_properties(
+      test_rmw_impl_id_check${target_suffix}
+      PROPERTIES DEPENDS test_rmw_impl_id_check_exe
+    )
+  endif()
 
 endfunction()
 

--- a/rcl/test/rcl/test_rmw_impl_id_check.py.in
+++ b/rcl/test/rcl/test_rmw_impl_id_check.py.in
@@ -6,7 +6,9 @@ from launch import LaunchDescriptor
 from launch.launcher import DefaultLauncher
 
 
-def launch_test(rmw_implementation_env=None, rcl_assert_rmw_id_matches_env=None, expect_failure=False):
+def launch_test(
+    rmw_implementation_env=None, rcl_assert_rmw_id_matches_env=None, expect_failure=False
+):
     ld = LaunchDescriptor()
 
     env = dict(os.environ)

--- a/rcl/test/rcl/test_rmw_impl_id_check.py.in
+++ b/rcl/test/rcl/test_rmw_impl_id_check.py.in
@@ -40,16 +40,14 @@ def test_rmw_implementation_env():
 
 
 def test_rcl_assert_rmw_id_matches_env():
-    launch_test(rcl_assert_rmw_id_matches_env='@rmw_implementation@', expect_failure=False)
+    # Note(dhood): we don't test _only_ setting RCL_ASSERT_RMW_ID_MATCHES because if support for
+    # multiple RMW implementations is available then RMW_IMPLEMENTATION must be used in order to
+    # get non-default RMW implementation(s).
     launch_test(rcl_assert_rmw_id_matches_env='', expect_failure=False)
     launch_test(rcl_assert_rmw_id_matches_env='garbage', expect_failure=True)
 
 
 def test_both():
-    # Note(dhood): we don't test only setting rcl_assert_rmw_id_matches_env because if support for
-    # multiple RMW implementations is available it has different behavior for the default and
-    # non-default RMW implementation(s).
-
     launch_test(
         rmw_implementation_env='@rmw_implementation@',
         rcl_assert_rmw_id_matches_env='@rmw_implementation@',

--- a/rcl/test/rcl/test_rmw_impl_id_check.py.in
+++ b/rcl/test/rcl/test_rmw_impl_id_check.py.in
@@ -1,0 +1,76 @@
+# generated from rcl/test/test_rmw_impl_id_check.py.in
+
+import os
+
+from launch import LaunchDescriptor
+from launch.launcher import DefaultLauncher
+
+
+def launch_test(rmw_implementation_env=None, rcl_assert_rmw_id_matches_env=None, expect_failure=False):
+    ld = LaunchDescriptor()
+
+    env = dict(os.environ)
+    if rmw_implementation_env is not None:
+      env['RMW_IMPLEMENTATION'] = rmw_implementation_env
+    if rcl_assert_rmw_id_matches_env is not None:
+      env['RCL_ASSERT_RMW_ID_MATCHES'] = rcl_assert_rmw_id_matches_env
+
+    ld.add_process(
+        cmd=['@TEST_RMW_IMPL_ID_CHECK_EXECUTABLE_NAME@'],
+        name='@TEST_RMW_IMPL_ID_CHECK_EXECUTABLE_NAME@',
+        env=env,
+    )
+
+    launcher = DefaultLauncher()
+    launcher.add_launch_descriptor(ld)
+    rc = launcher.launch()
+
+    if expect_failure:
+      assert rc != 0, 'The executable did not fail as expected.'
+    else:
+      assert rc == 0, "The executable failed with exit code '" + str(rc) + "'. "
+
+
+def test_rmw_implementation_env():
+    launch_test(rmw_implementation_env='@rmw_implementation@', expect_failure=False)
+    launch_test(rmw_implementation_env='', expect_failure=False)
+    launch_test(rmw_implementation_env='garbage', expect_failure=True)
+
+
+def test_rcl_assert_rmw_id_matches_env():
+    launch_test(rcl_assert_rmw_id_matches_env='@rmw_implementation@', expect_failure=False)
+    launch_test(rcl_assert_rmw_id_matches_env='', expect_failure=False)
+    launch_test(rcl_assert_rmw_id_matches_env='garbage', expect_failure=True)
+
+
+def test_both():
+    launch_test(
+        rmw_implementation_env='@rmw_implementation@',
+        rcl_assert_rmw_id_matches_env='@rmw_implementation@',
+        expect_failure=False)
+    launch_test(
+        rmw_implementation_env='',
+        rcl_assert_rmw_id_matches_env='@rmw_implementation@',
+        expect_failure=False)
+    launch_test(
+        rmw_implementation_env='',
+        rcl_assert_rmw_id_matches_env='',
+        expect_failure=False)
+    launch_test(
+        rmw_implementation_env='@rmw_implementation@',
+        rcl_assert_rmw_id_matches_env='garbage',
+        expect_failure=True)
+    launch_test(
+        rmw_implementation_env='garbage',
+        rcl_assert_rmw_id_matches_env='@rmw_implementation@',
+        expect_failure=True)
+    launch_test(
+        rmw_implementation_env='garbage',
+        rcl_assert_rmw_id_matches_env='garbage',
+        expect_failure=True)
+
+
+if __name__ == '__main__':
+    test_rmw_impl_env()
+    test_rcl_assert_rmw_id_matches_env()
+    test_both()

--- a/rcl/test/rcl/test_rmw_impl_id_check.py.in
+++ b/rcl/test/rcl/test_rmw_impl_id_check.py.in
@@ -46,12 +46,12 @@ def test_rcl_assert_rmw_id_matches_env():
 
 
 def test_both():
+    # Note(dhood): we don't test only setting rcl_assert_rmw_id_matches_env because if support for
+    # multiple RMW implementations is available it has different behavior for the default and
+    # non-default RMW implementation(s).
+
     launch_test(
         rmw_implementation_env='@rmw_implementation@',
-        rcl_assert_rmw_id_matches_env='@rmw_implementation@',
-        expect_failure=False)
-    launch_test(
-        rmw_implementation_env='',
         rcl_assert_rmw_id_matches_env='@rmw_implementation@',
         expect_failure=False)
     launch_test(

--- a/rcl/test/rcl/test_rmw_impl_id_check_exe.cpp
+++ b/rcl/test/rcl/test_rmw_impl_id_check_exe.cpp
@@ -1,4 +1,4 @@
-// Copyright 2016 Open Source Robotics Foundation, Inc.
+// Copyright 2017 Open Source Robotics Foundation, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rcl/test/rcl/test_rmw_impl_id_check_exe.cpp
+++ b/rcl/test/rcl/test_rmw_impl_id_check_exe.cpp
@@ -1,0 +1,20 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rcl/rcl.h"
+
+int main(int, char **)
+{
+  rcl_init(0, nullptr, rcl_get_default_allocator());
+}

--- a/rcl/test/rcl/test_rmw_impl_id_check_exe.cpp
+++ b/rcl/test/rcl/test_rmw_impl_id_check_exe.cpp
@@ -16,5 +16,9 @@
 
 int main(int, char **)
 {
-  rcl_init(0, nullptr, rcl_get_default_allocator());
+  rcl_ret_t ret = rcl_init(0, nullptr, rcl_get_default_allocator());
+  if (ret != RCL_RET_OK) {
+    return ret;
+  }
+  return 0;
 }


### PR DESCRIPTION
Currently, `RMW_IMPLEMENTATION` can be used to swap rmw implementations, but users with only one rmw implementation can set that environment variable and it will not have any effect. There is no warning in that case.

We have the `RCL_ASSERT_RMW_ID_MATCHES` environment variable that can be used to be sure that we are using the rmw impl that we expect. This was added before rmw implementations could be changed at runtime, and must be specified in addition to `RMW_IMPLEMENTATION` if using the non-default rmw implementation.

This adds a check so that processes will fail if `RCL_ASSERT_RMW_ID_MATCHES` doesn't match (existing behaviour) **and/or `RMW_IMPLEMENTATION` doesn't match**. If both env vars are specified differently it also fails.

On @wjwwood's suggestion the new check was _added_ instead of replacing `RCL_ASSERT_RMW_ID_MATCHES` so that we can check the behaviours independently.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3747)](http://ci.ros2.org/job/ci_linux/3747/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=895)](http://ci.ros2.org/job/ci_linux-aarch64/895/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3087)](http://ci.ros2.org/job/ci_osx/3087/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=3841)](http://ci.ros2.org/job/ci_windows/3841/)

I'm adding some tests but am not sure that they'll be done by freeze.