### PR TITLE
Explain error getting RMW impl id was because not installed

### DIFF
--- a/rcl/src/rcl/rmw_implementation_identifier_check.c
+++ b/rcl/src/rcl/rmw_implementation_identifier_check.c
@@ -128,7 +128,7 @@ INITIALIZER(initialize) {
     if (!actual_rmw_impl_id) {
       RCUTILS_LOG_ERROR_NAMED(
         ROS_PACKAGE_NAME,
-        "Error getting RMW implementation identifier/RMW implementation not installed "
+        "Error getting RMW implementation identifier / RMW implementation not installed "
         "(expected identifier of '%s'), exiting with %d.",
         expected_rmw_impl,
         RCL_RET_ERROR

--- a/rcl/src/rcl/rmw_implementation_identifier_check.c
+++ b/rcl/src/rcl/rmw_implementation_identifier_check.c
@@ -63,7 +63,7 @@ INITIALIZER(initialize) {
   if (ret != RCL_RET_OK) {
     RCUTILS_LOG_ERROR_NAMED(
       ROS_PACKAGE_NAME,
-      "Error getting environement variable 'RMW_IMPLEMENTATION': %s",
+      "Error getting environment variable 'RMW_IMPLEMENTATION': %s",
       rcl_get_error_string_safe()
     )
     exit(ret);
@@ -83,7 +83,7 @@ INITIALIZER(initialize) {
   if (ret != RCL_RET_OK) {
     RCUTILS_LOG_ERROR_NAMED(
       ROS_PACKAGE_NAME,
-      "Error getting environement variable 'RCL_ASSERT_RMW_ID_MATCHES': %s",
+      "Error getting environment variable 'RCL_ASSERT_RMW_ID_MATCHES': %s",
       rcl_get_error_string_safe()
     )
     exit(ret);
@@ -128,7 +128,10 @@ INITIALIZER(initialize) {
     if (!actual_rmw_impl_id) {
       RCUTILS_LOG_ERROR_NAMED(
         ROS_PACKAGE_NAME,
-        "Error getting RMW implementation identifier."
+        "Error getting RMW implementation identifier/RMW implementation not installed "
+        "(expected identifier of '%s'), exiting with %d.",
+        expected_rmw_impl,
+        RCL_RET_ERROR
       )
       exit(RCL_RET_ERROR);
     }


### PR DESCRIPTION
[this is just changing the error message, not the functionality]

In the case of having one rmw impl installed, poco is not used, and `rmw_fastrtps_cpp` will be retrieved even if users specify `RMW_IMPLEMENTATION=garbage`. Then we say they don't match.

When multiple rmw impls are installed, poco is used, and nothing is retrieved for `rmw_get_implementation_identifier()` if users specify `RMW_IMPLEMENTATION=garbage`.

The current state since https://github.com/ros2/rcl/pull/198 with multiple rmw implementations installed:
```
$ RMW_IMPLEMENTATION=garbage ./build_isolated/rcl/test/test_rcl__rmw_fastrtps_cpp
[ERROR] [rcl]: Error getting RMW implementation identifier.
```
(it's not clear that the reason for the error was that the rmw implementation is not available)

With this proposal:
```
$ RMW_IMPLEMENTATION=garbage ./build_isolated/rcl/test/test_rcl__rmw_fastrtps_cpp
[ERROR] [rcl]: Error getting RMW implementation identifier/RMW implementation not installed (expected identifier of 'garbage'), exiting with 1.
```