### PR TITLE
segmentation fault for NULL dereference

### DIFF
--- a/rcl/src/rcl/service.c
+++ b/rcl/src/rcl/service.c
@@ -248,7 +248,7 @@ rcl_take_request(
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Service server taking service request")
   const rcl_service_options_t * options = rcl_service_get_options(service);
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    options, "Failed to get service option", return RCL_RET_ERROR, rcl_get_default_allocator());
+    options, "Failed to get service options", return RCL_RET_ERROR, rcl_get_default_allocator());
   RCL_CHECK_ARGUMENT_FOR_NULL(request_header, RCL_RET_INVALID_ARGUMENT, options->allocator);
   RCL_CHECK_ARGUMENT_FOR_NULL(ros_request, RCL_RET_INVALID_ARGUMENT, options->allocator);
 
@@ -276,7 +276,7 @@ rcl_send_response(
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Sending service response")
   const rcl_service_options_t * options = rcl_service_get_options(service);
   RCL_CHECK_FOR_NULL_WITH_MSG(
-    options, "Failed to get service option", return RCL_RET_ERROR, rcl_get_default_allocator());
+    options, "Failed to get service options", return RCL_RET_ERROR, rcl_get_default_allocator());
   RCL_CHECK_ARGUMENT_FOR_NULL(request_header, RCL_RET_INVALID_ARGUMENT, options->allocator);
   RCL_CHECK_ARGUMENT_FOR_NULL(ros_response, RCL_RET_INVALID_ARGUMENT, options->allocator);
 

--- a/rcl/src/rcl/service.c
+++ b/rcl/src/rcl/service.c
@@ -247,6 +247,8 @@ rcl_take_request(
 {
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Service server taking service request")
   const rcl_service_options_t * options = rcl_service_get_options(service);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    options, "Failed to get service option", return RCL_RET_ERROR, rcl_get_default_allocator());
   RCL_CHECK_ARGUMENT_FOR_NULL(request_header, RCL_RET_INVALID_ARGUMENT, options->allocator);
   RCL_CHECK_ARGUMENT_FOR_NULL(ros_request, RCL_RET_INVALID_ARGUMENT, options->allocator);
 
@@ -273,6 +275,8 @@ rcl_send_response(
 {
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Sending service response")
   const rcl_service_options_t * options = rcl_service_get_options(service);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    options, "Failed to get service option", return RCL_RET_ERROR, rcl_get_default_allocator());
   RCL_CHECK_ARGUMENT_FOR_NULL(request_header, RCL_RET_INVALID_ARGUMENT, options->allocator);
   RCL_CHECK_ARGUMENT_FOR_NULL(ros_response, RCL_RET_INVALID_ARGUMENT, options->allocator);
 

--- a/rcl_lifecycle/src/rcl_lifecycle.c
+++ b/rcl_lifecycle/src/rcl_lifecycle.c
@@ -285,15 +285,22 @@ rcl_lifecycle_is_valid_transition(
   const rcl_lifecycle_state_t * current_state = rcl_lifecycle_get_state(
     &state_machine->transition_map, current_id);
 
+  if (NULL == current_state) {
+    RCL_SET_ERROR_MSG("rcl_lifecycle_get_state returns NULL", rcl_get_default_allocator());
+    return NULL;
+  }
+
   for (unsigned int i = 0; i < current_state->valid_transition_size; ++i) {
     if (current_state->valid_transition_keys[i] == key) {
       return &current_state->valid_transitions[i];
     }
   }
+
   RCUTILS_LOG_WARN_NAMED(
     ROS_PACKAGE_NAME,
     "No callback transition matching %d found for current state %s",
     key, state_machine->current_state->label)
+
   return NULL;
 }
 
@@ -318,6 +325,7 @@ rcl_lifecycle_trigger_transition(
   if (!transition->goal) {
     RCUTILS_LOG_ERROR_NAMED(
       ROS_PACKAGE_NAME, "No valid goal is set")
+    return RCL_RET_ERROR;
   }
   state_machine->current_state = transition->goal;
   if (publish_notification) {

--- a/rcl_lifecycle/src/rcl_lifecycle.c
+++ b/rcl_lifecycle/src/rcl_lifecycle.c
@@ -285,10 +285,8 @@ rcl_lifecycle_is_valid_transition(
   const rcl_lifecycle_state_t * current_state = rcl_lifecycle_get_state(
     &state_machine->transition_map, current_id);
 
-  if (NULL == current_state) {
-    RCL_SET_ERROR_MSG("rcl_lifecycle_get_state returns NULL", rcl_get_default_allocator());
-    return NULL;
-  }
+  RCL_CHECK_FOR_NULL_WITH_MSG(current_state,
+    "rcl_lifecycle_get_state returns NULL", return NULL, rcl_get_default_allocator());
 
   for (unsigned int i = 0; i < current_state->valid_transition_size; ++i) {
     if (current_state->valid_transition_keys[i] == key) {


### PR DESCRIPTION
`rcl_lifecycle_get_state` may return NULL

`transition->goal` is checked for NULL but no return
while it's true and this may result the follow-up
NULL dereference

Signed-off-by: Ethan Gao <ethan.gao@linux.intel.com>