### PR TITLE
Clarify that rcl_take_response() populates request_header

### DIFF
--- a/rcl/include/rcl/client.h
+++ b/rcl/include/rcl/client.h
@@ -256,8 +256,9 @@ rcl_send_request(const rcl_client_t * client, const void * ros_request, int64_t 
  * cannot be checked by this function and therefore no deliberate error will
  * occur.
  * The request_header is an rmw struct for meta-information about the request
- * sent (e.g. the sequence number). The caller must provide a pointer to an
- * allocated struct. This function will populate the struct's fields.
+ * sent (e.g. the sequence number).
+ * The caller must provide a pointer to an allocated struct.
+ * This function will populate the struct's fields.
  * `ros_response` should point to an already allocated ROS response message
  * struct of the correct type, into which the response from the service will be
  * copied.

--- a/rcl/include/rcl/client.h
+++ b/rcl/include/rcl/client.h
@@ -256,7 +256,8 @@ rcl_send_request(const rcl_client_t * client, const void * ros_request, int64_t 
  * cannot be checked by this function and therefore no deliberate error will
  * occur.
  * The request_header is an rmw struct for meta-information about the request
- * sent (e.g. the sequence number).
+ * sent (e.g. the sequence number). The caller must provide a pointer to an
+ * allocated struct. This function will populate the struct's fields.
  * `ros_response` should point to an already allocated ROS response message
  * struct of the correct type, into which the response from the service will be
  * copied.


### PR DESCRIPTION
This pull request adds to the documentation on `rcl_take_response` to make it clear the parameter `request_header` is populated by this function.

For context rclpy has a bug where it populates the sequence number it hopes to take and passes that in  while ignoring the actual sequence number returned. ros2/rclpy#170 has a fix. 

CI linux only since this is just a documentation change

 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=3842)](http://ci.ros2.org/job/ci_linux/3842/)