### PR TITLE
Remove the slash behind SET_CLEAR MACRO

### DIFF
--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -276,7 +276,7 @@ rcl_wait_set_get_allocator(const rcl_wait_set_t * wait_set, rcl_allocator_t * al
     (void *)wait_set->Type ## s, \
     0, \
     sizeof(rcl_ ## Type ## _t *) * wait_set->size_of_ ## Type ## s); \
-  wait_set->impl->Type ## _index = 0; \
+  wait_set->impl->Type ## _index = 0;
 
 #define SET_CLEAR_RMW(Type, RMWStorage, RMWCount) \
   /* Also clear the rmw storage. */ \


### PR DESCRIPTION
In some case, extra slash may casue choas. Fix it anyway

Signed-off-by: jwang <jing.j.wang@intel.com>