### PR TITLE
Reset RMWCount when DEALLOC rmw storage of wait set

### DIFF
--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -317,10 +317,10 @@ rcl_wait_set_get_allocator(const rcl_wait_set_t * wait_set, rcl_allocator_t * al
 
 #define SET_RESIZE_RMW_DEALLOC(RMWStorage) \
   /* Also deallocate the rmw storage. */ \
-  wait_set->impl->RMWCount = 0; \
   if (wait_set->impl->RMWStorage) { \
     allocator.deallocate((void *)wait_set->impl->RMWStorage, allocator.state); \
     wait_set->impl->RMWStorage = NULL; \
+    wait_set->impl->RMWCount = 0; \
   }
 
 #define SET_RESIZE_RMW_REALLOC(Type, RMWStorage, RMWCount) \

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -317,6 +317,7 @@ rcl_wait_set_get_allocator(const rcl_wait_set_t * wait_set, rcl_allocator_t * al
 
 #define SET_RESIZE_RMW_DEALLOC(RMWStorage) \
   /* Also deallocate the rmw storage. */ \
+  wait_set->impl->RMWCount = 0; \
   if (wait_set->impl->RMWStorage) { \
     allocator.deallocate((void *)wait_set->impl->RMWStorage, allocator.state); \
     wait_set->impl->RMWStorage = NULL; \


### PR DESCRIPTION
It is safe to reset RMWCount when free rmw storage of wait set

Signed-off-by: jwang <jing.j.wang@intel.com>