### PR TITLE
Revert "Reset RMWCount when DEALLOC rmw storage of wait set"

### DIFF
--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -320,7 +320,6 @@ rcl_wait_set_get_allocator(const rcl_wait_set_t * wait_set, rcl_allocator_t * al
   if (wait_set->impl->RMWStorage) { \
     allocator.deallocate((void *)wait_set->impl->RMWStorage, allocator.state); \
     wait_set->impl->RMWStorage = NULL; \
-    wait_set->impl->RMWCount = 0; \
   }
 
 #define SET_RESIZE_RMW_REALLOC(Type, RMWStorage, RMWCount) \


### PR DESCRIPTION
Reverts ros2/rcl#209

I believe this is a regression based on http://ci.ros2.org/job/ci_osx/3214/consoleFull. Since there was no CI (that I saw on the origin pr) I'll assume that's the case and revert until it can be tested separately.