### PR TITLE
Store logger name associated with node

### DIFF
--- a/rcl/include/rcl/node.h
+++ b/rcl/include/rcl/node.h
@@ -452,6 +452,33 @@ RCL_WARN_UNUSED
 const struct rcl_guard_condition_t *
 rcl_node_get_graph_guard_condition(const rcl_node_t * node);
 
+/// Return the logger name of the node.
+/**
+ * This function returns the node's internal logger name string.
+ * This function can fail, and therefore return `NULL`, if:
+ *   - node is `NULL`
+ *   - node has not been initialized (the implementation is invalid)
+ *
+ * The returned string is only valid as long as the given rcl_node_t is valid.
+ * The value of the string may change if the value in the rcl_node_t changes,
+ * and therefore copying the string is recommended if this is a concern.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] node pointer to the node
+ * \return logger_name string if successful, otherwise `NULL`
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+const char *
+rcl_node_get_logger_name(const rcl_node_t * node);
+
 #if __cplusplus
 }
 #endif

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -492,6 +492,15 @@ rcl_node_get_graph_guard_condition(const rcl_node_t * node)
   return node->impl->graph_guard_condition;
 }
 
+const char *
+rcl_node_get_logger_name(const rcl_node_t * node)
+{
+  if (!rcl_node_is_valid(node, NULL)) {
+    return NULL;
+  }
+  return node->impl->logger_name;
+}
+
 #if __cplusplus
 }
 #endif

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -78,7 +78,9 @@ const char * rcl_create_node_logger_name(
     }
   }
   // convert slashes to dot separators
-  const char * node_logger_name = rcutils_repl_str(node_name_with_ns, "/", ".", allocator);
+  const char * node_logger_name = rcutils_repl_str(
+    node_name_with_ns, "/", ".",
+    (rcl_allocator_t *)allocator);  // TODO(dhood): remove need for casting away const
   if (NULL == node_logger_name) {
     allocator->deallocate((char *)node_name_with_ns, allocator->state);
     return NULL;

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -85,7 +85,7 @@ const char * rcl_create_node_logger_name(
   const char * ns_with_separators = rcutils_repl_str(
     node_namespace + 1,  // Ignore the leading forward slash.
     "/", RCUTILS_LOGGING_SEPARATOR_STRING,
-    (rcl_allocator_t *)allocator);  // TODO(dhood): remove need for casting away const
+    allocator);
   if (NULL == ns_with_separators) {
     return NULL;
   }

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -59,6 +59,16 @@ typedef struct rcl_node_impl_t
 } rcl_node_impl_t;
 
 
+/// Return the logger name associated with a node given the validated node name and namespace.
+/**
+ * E.g. for a node named "c" in namespace "/a/b", the logger name will be
+ * "a.b.c", assuming logger name separator of ".".
+ *
+ * \param[in] node_name validated node name (a single token)
+ * \param[in] node_namespace validated, absolute namespace (starting with "/")
+ * \param[in] allocator the allocator to use for allocation
+ * \returns duplicated string or null if there is an error
+ */
 const char * rcl_create_node_logger_name(
   const char * node_name,
   const char * node_namespace,

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -84,7 +84,7 @@ const char * rcl_create_node_logger_name(
   // i.e. it will start with a forward slash, which we want to ignore.
   const char * ns_with_separators = rcutils_repl_str(
     node_namespace + 1,  // Ignore the leading forward slash.
-    "/", ".",
+    "/", RCUTILS_LOGGING_SEPARATOR_STRING,
     (rcl_allocator_t *)allocator);  // TODO(dhood): remove need for casting away const
   if (NULL == ns_with_separators) {
     return NULL;
@@ -92,7 +92,7 @@ const char * rcl_create_node_logger_name(
 
   // Join the namespace and node name to create the logger name.
   char * node_logger_name = rcutils_format_string(
-    *allocator, "%s.%s", ns_with_separators, node_name);
+    *allocator, "%s%s%s", ns_with_separators, RCUTILS_LOGGING_SEPARATOR_STRING, node_name);
   if (NULL == node_logger_name) {
     allocator->deallocate((char *)ns_with_separators, allocator->state);
     return NULL;

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -613,7 +613,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_logger_name
     EXPECT_EQ(RCL_RET_OK, ret);
   }
 
-  // Node namespace that is an empty string, which is also valid.
+  // Node namespace that is an empty string.
   {
     rcl_node_t node = rcl_get_zero_initialized_node();
     ret = rcl_node_init(&node, name, "", &default_options);
@@ -627,7 +627,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_logger_name
     EXPECT_EQ(RCL_RET_OK, ret);
   }
 
-  // Node namespace that is just a forward slash, which is valid.
+  // Node namespace that is just a forward slash.
   {
     rcl_node_t node = rcl_get_zero_initialized_node();
     ret = rcl_node_init(&node, name, "/", &default_options);

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -178,6 +178,30 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   if (actual_node_namespace) {
     EXPECT_EQ(std::string(namespace_), std::string(actual_node_namespace));
   }
+  // Test rcl_node_get_logger_name().
+  const char * actual_node_logger_name;
+  actual_node_logger_name = rcl_node_get_logger_name(nullptr);
+  EXPECT_EQ(nullptr, actual_node_logger_name);
+  rcl_reset_error();
+  actual_node_logger_name = rcl_node_get_logger_name(&zero_node);
+  EXPECT_EQ(nullptr, actual_node_logger_name);
+  rcl_reset_error();
+  actual_node_logger_name = rcl_node_get_logger_name(&invalid_node);
+  EXPECT_EQ(nullptr, actual_node_logger_name);
+  rcl_reset_error();
+  start_memory_checking();
+  assert_no_malloc_begin();
+  assert_no_realloc_begin();
+  assert_no_free_begin();
+  actual_node_logger_name = rcl_node_get_logger_name(&node);
+  assert_no_malloc_end();
+  assert_no_realloc_end();
+  assert_no_free_end();
+  stop_memory_checking();
+  EXPECT_TRUE(actual_node_logger_name ? true : false);
+  if (actual_node_logger_name) {
+    EXPECT_EQ("ns." + std::string(name), std::string(actual_node_logger_name));
+  }
   // Test rcl_node_get_options().
   const rcl_node_options_t * actual_options;
   actual_options = rcl_node_get_options(nullptr);


### PR DESCRIPTION
This PR adds the logic to convert `/my_ns/my_node_name` into logger name `my_ns.my_node_name` and stores it on the node.

Still in progress because I'm sorting out some issues with const-ness of allocators.

The purpose is to prevent client libraries from reimplementing the logic of what logger name is associated with a node: they should get it from rcl.

This also will let rcl use the node's logger name in its log calls if we want that, but I haven't included that in this PR. It might be appropriate to store the logger name on the node imp at the rmw layer if we want to use the logger there as well.