### PR TITLE
Fix small leak of ns_with_separators in rcl_create_node_logger_name

### DIFF
--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -93,10 +93,7 @@ const char * rcl_create_node_logger_name(
   // Join the namespace and node name to create the logger name.
   char * node_logger_name = rcutils_format_string(
     *allocator, "%s%s%s", ns_with_separators, RCUTILS_LOGGING_SEPARATOR_STRING, node_name);
-  if (NULL == node_logger_name) {
-    allocator->deallocate((char *)ns_with_separators, allocator->state);
-    return NULL;
-  }
+  allocator->deallocate((char *)ns_with_separators, allocator->state);
   return node_logger_name;
 }
 


### PR DESCRIPTION
`ns_with_separators` is allocated by `rcutils_repl_str`, but it only gets deallocated if `rcutils_format_string` fails. This PR makes sure it is always deallocated.

CI
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4017)](http://ci.ros2.org/job/ci_linux/4017/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1112)](http://ci.ros2.org/job/ci_linux-aarch64/1112/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3344)](http://ci.ros2.org/job/ci_osx/3344/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4108)](http://ci.ros2.org/job/ci_windows/4108/)