### PR TITLE
Add rcl_validate_topic_name_with_size()

### DIFF
--- a/rcl/include/rcl/validate_topic_name.h
+++ b/rcl/include/rcl/validate_topic_name.h
@@ -94,6 +94,22 @@ rcl_validate_topic_name(
   int * validation_result,
   size_t * invalid_index);
 
+/// Validate a given topic name.
+/**
+ * This is an overload with an extra parameter for the length of topic_name.
+ * \param[in] topic_name_length The number of characters in topic_name.
+ *
+ * \sa rcl_validate_topic_name(const char *, int *, size_t *)
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_validate_topic_name_with_size(
+  const char * topic_name,
+  size_t topic_name_length,
+  int * validation_result,
+  size_t * invalid_index);
+
 /// Return a validation result description, or NULL if unknown or RCL_TOPIC_NAME_VALID.
 RCL_PUBLIC
 RCL_WARN_UNUSED

--- a/rcl/src/rcl/validate_topic_name.c
+++ b/rcl/src/rcl/validate_topic_name.c
@@ -34,9 +34,21 @@ rcl_validate_topic_name(
 {
   rcl_allocator_t allocator = rcutils_get_default_allocator();
   RCL_CHECK_ARGUMENT_FOR_NULL(topic_name, RCL_RET_INVALID_ARGUMENT, allocator)
+  return rcl_validate_topic_name_with_size(
+    topic_name, strlen(topic_name), validation_result, invalid_index);
+}
+
+rcl_ret_t
+rcl_validate_topic_name_with_size(
+  const char * topic_name,
+  size_t topic_name_length,
+  int * validation_result,
+  size_t * invalid_index)
+{
+  rcl_allocator_t allocator = rcutils_get_default_allocator();
+  RCL_CHECK_ARGUMENT_FOR_NULL(topic_name, RCL_RET_INVALID_ARGUMENT, allocator)
   RCL_CHECK_ARGUMENT_FOR_NULL(validation_result, RCL_RET_INVALID_ARGUMENT, allocator)
 
-  size_t topic_name_length = strlen(topic_name);
   if (topic_name_length == 0) {
     *validation_result = RCL_TOPIC_NAME_INVALID_IS_EMPTY_STRING;
     if (invalid_index) {


### PR DESCRIPTION
This splits `rcl_validate_topic_name` to add a new method that accepts a string length. It helps ros2/rcl#217 avoid a copy.

CI
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4073)](http://ci.ros2.org/job/ci_linux/4073/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1176)](http://ci.ros2.org/job/ci_linux-aarch64/1176/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3379)](http://ci.ros2.org/job/ci_osx/3379/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4144)](http://ci.ros2.org/job/ci_windows/4144/)