### PR TITLE
[rcl_yaml_param_parser] fix export symbols

### DIFF
--- a/rcl_yaml_param_parser/CMakeLists.txt
+++ b/rcl_yaml_param_parser/CMakeLists.txt
@@ -28,6 +28,10 @@ add_library(
   ${rcl_yaml_parser_sources})
 ament_target_dependencies(${PROJECT_NAME} "yaml" "rcutils" "rcl")
 
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+target_compile_definitions(${PROJECT_NAME} PRIVATE "RCL_YAML_PARAM_PARSER_BUILDING_DLL")
+
 install(TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib

--- a/rcl_yaml_param_parser/CMakeLists.txt
+++ b/rcl_yaml_param_parser/CMakeLists.txt
@@ -42,10 +42,6 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  macro(rcutils_custom_add_gtest target)
-    ament_add_gtest(${target} ${ARGN})
-  endmacro()
-
   # Gtests
   ament_add_gtest(test_parse_yaml
     test/test_parse_yaml.cpp

--- a/rcl_yaml_param_parser/include/rcl_yaml_param_parser/parser.h
+++ b/rcl_yaml_param_parser/include/rcl_yaml_param_parser/parser.h
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 
 #include "rcl_yaml_param_parser/types.h"
+#include "rcl_yaml_param_parser/visibility_control.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -28,6 +29,7 @@ extern "C"
 /// \param[in] file_path is the path to the YAML file
 /// \param[out] params_st points to the populated paramter struct
 /// \return true on success and false on failure
+RCL_YAML_PARAM_PARSER_PUBLIC
 bool rcl_parse_yaml_file(
   const char * file_path,
   rcl_params_t * params_st);
@@ -35,12 +37,14 @@ bool rcl_parse_yaml_file(
 /// \brief Free param structure
 /// \param[in] params_st points to the populated paramter struct
 /// \param[in] allocator memeory allocator to be used
+RCL_YAML_PARAM_PARSER_PUBLIC
 void rcl_yaml_node_struct_fini(
   rcl_params_t * params_st,
   const rcutils_allocator_t allocator);
 
 /// \brief Print the parameter structure to stdout
 /// \param[in] params_st points to the populated paramter struct
+RCL_YAML_PARAM_PARSER_PUBLIC
 void rcl_yaml_node_struct_print(
   const rcl_params_t * const params_st);
 

--- a/rcl_yaml_param_parser/include/rcl_yaml_param_parser/visibility_control.h
+++ b/rcl_yaml_param_parser/include/rcl_yaml_param_parser/visibility_control.h
@@ -1,0 +1,58 @@
+// Copyright 2015 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCL_YAML_PARAM_PARSER__VISIBILITY_CONTROL_H_
+#define RCL_YAML_PARAM_PARSER__VISIBILITY_CONTROL_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define RCL_YAML_PARAM_PARSER_EXPORT __attribute__ ((dllexport))
+    #define RCL_YAML_PARAM_PARSER_IMPORT __attribute__ ((dllimport))
+  #else
+    #define RCL_YAML_PARAM_PARSER_EXPORT __declspec(dllexport)
+    #define RCL_YAML_PARAM_PARSER_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef RCL_YAML_PARAM_PARSER_BUILDING_DLL
+    #define RCL_YAML_PARAM_PARSER_PUBLIC RCL_YAML_PARAM_PARSER_EXPORT
+  #else
+    #define RCL_YAML_PARAM_PARSER_PUBLIC RCL_YAML_PARAM_PARSER_IMPORT
+  #endif
+  #define RCL_YAML_PARAM_PARSER_PUBLIC_TYPE RCL_YAML_PARAM_PARSER_PUBLIC
+  #define RCL_YAML_PARAM_PARSER_LOCAL
+#else
+  #define RCL_YAML_PARAM_PARSER_EXPORT __attribute__ ((visibility("default")))
+  #define RCL_YAML_PARAM_PARSER_IMPORT
+  #if __GNUC__ >= 4
+    #define RCL_YAML_PARAM_PARSER_PUBLIC __attribute__ ((visibility("default")))
+    #define RCL_YAML_PARAM_PARSER_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define RCL_YAML_PARAM_PARSER_PUBLIC
+    #define RCL_YAML_PARAM_PARSER_LOCAL
+  #endif
+  #define RCL_YAML_PARAM_PARSER_PUBLIC_TYPE
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RCL_YAML_PARAM_PARSER__VISIBILITY_CONTROL_H_


### PR DESCRIPTION
The first commit adds visibility macros to the public symbole of the library
The second commit remove the unused cmake macro as it was missed in the previous round of fixups