### PR TITLE
Fix maybe-uninitialized warning

### DIFF
--- a/rcl_yaml_param_parser/src/parser.c
+++ b/rcl_yaml_param_parser/src/parser.c
@@ -1163,7 +1163,7 @@ static rcl_ret_t parse_events(
   bool is_key = true;
   bool is_seq = false;
   uint32_t line_num = 0;
-  data_types_t seq_data_type;
+  data_types_t seq_data_type = DATA_TYPE_UNKNOWN;
   uint32_t map_level = 1U;
   uint32_t map_depth = 0U;
   bool is_new_map = false;


### PR DESCRIPTION
This suppresses an occurrance of a `maybe-uninitialized` warning on gcc 4.x. I don't see a warning using gcc 5.4

It seems to be a false positive. Searching for false positive `maybe-uninitialized` gcc bugs returns [too many to reasonably search for a match](https://gcc.gnu.org/bugzilla/buglist.cgi?quicksearch=maybe-uninitialized). It's strange to me that the warning is not also present on lines 941, 921, 883, etc.

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=packaging_linux-aarch64&build=452)](https://ci.ros2.org/view/packaging/job/packaging_linux-aarch64/452/)

In progress while CI runs