### PR TITLE
Print warning if non-FQN namespace remapping passed

### DIFF
--- a/rcl/include/rcl/lexer.h
+++ b/rcl/include/rcl/lexer.h
@@ -30,7 +30,7 @@ extern "C"
 /// Type of lexeme found by lexical analysis.
 typedef enum rcl_lexeme_t
 {
-  /// Indicates no valid lexeme was found (end of input may not have been reached)
+  /// Indicates no valid lexeme was found (end of input not reached)
   RCL_LEXEME_NONE = 0,
   /// Indicates end of input has been reached
   RCL_LEXEME_EOF = 1,

--- a/rcl/include/rcl/lexer.h
+++ b/rcl/include/rcl/lexer.h
@@ -30,7 +30,7 @@ extern "C"
 /// Type of lexeme found by lexical analysis.
 typedef enum rcl_lexeme_t
 {
-  /// Indicates no valid lexeme was found
+  /// Indicates no valid lexeme was found (end of input may not have been reached)
   RCL_LEXEME_NONE = 0,
   /// Indicates end of input has been reached
   RCL_LEXEME_EOF = 1,

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -657,6 +657,10 @@ _rcl_parse_remap_namespace_replacement(
   }
   ret = _rcl_parse_remap_fully_qualified_namespace(lex_lookahead);
   if (RCL_RET_OK != ret) {
+    if (RCL_RET_INVALID_REMAP_RULE == ret) {
+      RCUTILS_LOG_WARN_NAMED(
+        ROS_PACKAGE_NAME, "Namespace not remapped to a fully qualified name (found: %s)", ns_start);
+    }
     return ret;
   }
 

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -110,7 +110,8 @@ rcl_parse_arguments(
     if (RCL_RET_OK == _rcl_parse_remap_rule(argv[i], allocator, rule)) {
       ++(args_impl->num_remap_rules);
     } else {
-      RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "arg %d error '%s'", i, rcl_get_error_string());
+      RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "arg %d (%s) error '%s'", i, argv[i],
+        rcl_get_error_string());
       rcl_reset_error();
       args_impl->unparsed_args[args_impl->num_unparsed_args] = i;
       ++(args_impl->num_unparsed_args);

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -658,9 +658,18 @@ _rcl_parse_remap_namespace_replacement(
   ret = _rcl_parse_remap_fully_qualified_namespace(lex_lookahead);
   if (RCL_RET_OK != ret) {
     if (RCL_RET_INVALID_REMAP_RULE == ret) {
+      // The name didn't start with a leading forward slash
       RCUTILS_LOG_WARN_NAMED(
         ROS_PACKAGE_NAME, "Namespace not remapped to a fully qualified name (found: %s)", ns_start);
     }
+    return ret;
+  }
+  // There should be nothing left
+  ret = rcl_lexer_lookahead2_expect(lex_lookahead, RCL_LEXEME_EOF, NULL, NULL);
+  if (RCL_RET_OK != ret) {
+    // The name must have started with a leading forward slash but had an otherwise invalid format
+    RCUTILS_LOG_WARN_NAMED(
+      ROS_PACKAGE_NAME, "Namespace not remapped to a fully qualified name (found: %s)", ns_start);
     return ret;
   }
 

--- a/rcl/src/rcl/lexer_lookahead.c
+++ b/rcl/src/rcl/lexer_lookahead.c
@@ -222,6 +222,11 @@ rcl_lexer_lookahead2_expect(
     return ret;
   }
   if (type != lexeme) {
+    if (RCL_LEXEME_NONE == lexeme || RCL_LEXEME_EOF == lexeme) {
+      RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
+        buffer->impl->allocator, "Expected lexeme type (%d) not found", type);
+      return RCL_RET_WRONG_LEXEME;
+    }
     RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
       buffer->impl->allocator, "Expected lexeme type %d, got %d at index %lu", type, lexeme,
       buffer->impl->text_idx);

--- a/rcl/src/rcl/lexer_lookahead.c
+++ b/rcl/src/rcl/lexer_lookahead.c
@@ -223,7 +223,8 @@ rcl_lexer_lookahead2_expect(
   }
   if (type != lexeme) {
     RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
-      buffer->impl->allocator, "Expected %d got %d at %lu", type, lexeme, buffer->impl->text_idx);
+      buffer->impl->allocator, "Expected lexeme type %d, got %d at index %lu", type, lexeme,
+      buffer->impl->text_idx);
     return RCL_RET_WRONG_LEXEME;
   }
   return rcl_lexer_lookahead2_accept(buffer, lexeme_text, lexeme_text_length);

--- a/rcl/src/rcl/lexer_lookahead.c
+++ b/rcl/src/rcl/lexer_lookahead.c
@@ -224,7 +224,8 @@ rcl_lexer_lookahead2_expect(
   if (type != lexeme) {
     if (RCL_LEXEME_NONE == lexeme || RCL_LEXEME_EOF == lexeme) {
       RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
-        buffer->impl->allocator, "Expected lexeme type (%d) not found", type);
+        buffer->impl->allocator, "Expected lexeme type (%d) not found, search ended at index %lu",
+        type, buffer->impl->text_idx);
       return RCL_RET_WRONG_LEXEME;
     }
     RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(


### PR DESCRIPTION
I haven't used command-line remapping much, and the first thing I tried was `__ns:=asdf` which didn't do anything. I have understood from the design doc that that's the expected behaviour (it has to be FQN), but since that wasn't the case in ROS1, I was confused for a while.

This adds a warning message in that case (and a couple of debugging improvements I found useful along the way).

Now you get:

```
dhood@osrf-esteve:~/ros2_ws [ros2_ws]$ ros2 run demo_nodes_cpp talker __ns:=asdf
[WARN] [rcl]: Namespace not remapped to a fully qualified name (found: asdf)
[INFO] [talker]: Publishing: 'Hello World: 1'
^Csignal_handler(2)
dhood@osrf-esteve:~/ros2_ws [ros2_ws]$ ros2 run demo_nodes_cpp talker __ns:=123
[WARN] [rcl]: Namespace not remapped to a fully qualified name (found: 123)
^Csignal_handler(2)
dhood@osrf-esteve:~/ros2_ws [ros2_ws]$ ros2 run demo_nodes_cpp talker __ns:=/123
[WARN] [rcl]: Namespace not remapped to a fully qualified name (found: /123)
[INFO] [talker]: Publishing: 'Hello World: 1'
^Csignal_handler(2)
```

(the latter case requires [this change](https://github.com/ros2/rcl/commit/d838bd14cab98f1a838ff4aa9b5a5147522cad71))

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4517)](http://ci.ros2.org/job/ci_linux/4517/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1436)](http://ci.ros2.org/job/ci_linux-aarch64/1436/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3706)](http://ci.ros2.org/job/ci_osx/3706/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4594)](http://ci.ros2.org/job/ci_windows/4594/)