### PR TITLE
Skip parsing argv[0] for remap rules

### DIFF
--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -104,7 +104,8 @@ rcl_parse_arguments(
   }
 
   // Attempt to parse arguments as remap rules
-  for (int i = 0; i < argc; ++i) {
+  // Start at index 1 because argv[0] represents the program name
+  for (int i = 1; i < argc; ++i) {
     rcl_remap_t * rule = &(args_impl->remap_rules[args_impl->num_remap_rules]);
     *rule = rcl_remap_get_zero_initialized();
     if (RCL_RET_OK == _rcl_parse_remap_rule(argv[i], allocator, rule)) {


### PR DESCRIPTION
I turned on debug logging investigating https://github.com/ros2/rcl/pull/248 and was surprised that argv[0] was being parsed.

```
$ ros2 run demo_nodes_cpp talker
[WARN] [rcl]: arg 0 (/home/dhood/ros2_ws/install_isolated/demo_nodes_cpp/lib/demo_nodes_cpp/talker) error 'Expected lexeme type (19) not found, at /home/dhood/ros2_ws/src/ros2/rcl/rcl/src/rcl/lexer_lookahead.c:227'
[INFO] [talker]: Publishing: 'Hello World: 1'
```
(error message format using changes in https://github.com/ros2/rcl/pull/248)

Is it safe to assume that argv[0] is never going to have remapping arguments? (I am not 100% sure)
