### PR TITLE
Add failing test quoted number in string array

### DIFF
--- a/rcl_yaml_param_parser/test/string_array_with_quoted_number.yaml
+++ b/rcl_yaml_param_parser/test/string_array_with_quoted_number.yaml
@@ -1,0 +1,4 @@
+initial_params_node:
+    ros__parameters:
+        sa1: ["Four", "score"]
+        sa2: ["and", "7"]

--- a/rcl_yaml_param_parser/test/test_parse_yaml.cpp
+++ b/rcl_yaml_param_parser/test/test_parse_yaml.cpp
@@ -41,6 +41,24 @@ TEST(test_file_parser, correct_syntax) {
   free(path);
 }
 
+TEST(test_file_parser, string_array_with_quoted_number) {
+  rcutils_reset_error();
+  EXPECT_TRUE(rcutils_get_cwd(cur_dir, 1024));
+  char * test_path = rcutils_join_path(cur_dir, "test");
+  char * path = rcutils_join_path(test_path, "string_array_with_quoted_number.yaml");
+  fprintf(stderr, "cur_path: %s\n", path);
+  EXPECT_TRUE(rcutils_exists(path));
+  rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
+  ASSERT_TRUE(params_hdl);
+  bool res = rcl_parse_yaml_file(path, params_hdl);
+  fprintf(stderr, "%s\n", rcutils_get_error_string_safe());
+  ASSERT_TRUE(res);
+  rcl_yaml_node_struct_print(params_hdl);
+  rcl_yaml_node_struct_fini(params_hdl);
+  free(test_path);
+  free(path);
+}
+
 TEST(test_file_parser, multi_ns_correct_syntax) {
   rcutils_reset_error();
   EXPECT_TRUE(rcutils_get_cwd(cur_dir, 1024));


### PR DESCRIPTION
This adds a failing test and isn't intended to be merged.

Is there is another way to specify string array values in yaml? If a string array contains a quoted number then the parser complains about a type change.


```
1: [ RUN      ] test_file_parser.string_array_with_quoted_number
1: cur_path: /workspace/ros2-dev0/src/ros2/rcl/rcl_yaml_param_parser/test/string_array_with_quoted_number.yaml
1: Sequence should be of same type. Value type 'integer' do not belong at line_num 4, at /workspace/ros2-dev0/src/ros2/rcl/
rcl_yaml_param_parser/src/parser.c:914
1: /workspace/ros2-dev0/src/ros2/rcl/rcl_yaml_param_parser/test/test_parse_yaml.cpp:55: Failure
1: Value of: res
1:   Actual: false
1: Expected: true
```