### PR TITLE
Support passing yaml parameter files via commandline 

### DIFF
--- a/rcl/include/rcl/arguments.h
+++ b/rcl/include/rcl/arguments.h
@@ -20,8 +20,6 @@
 #include "rcl/types.h"
 #include "rcl/visibility_control.h"
 
-#include "rcutils/types.h"
-
 #ifdef __cplusplus
 extern "C"
 {

--- a/rcl/include/rcl/arguments.h
+++ b/rcl/include/rcl/arguments.h
@@ -137,7 +137,20 @@ rcl_arguments_get_unparsed(
   rcl_allocator_t allocator,
   int ** output_unparsed_indices);
 
-
+/// Return the number of parameter yaml files given in the arguments.
+/**
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] args An arguments structure that has been parsed.
+ * \return number of yaml files, or
+ * \return -1 if args is `NULL` or zero initialized.
+ */
 RCL_PUBLIC
 RCL_WARN_UNUSED
 int

--- a/rcl/include/rcl/arguments.h
+++ b/rcl/include/rcl/arguments.h
@@ -147,14 +147,33 @@ rcl_arguments_get_param_files_count(
   const rcl_arguments_t * args);
 
 
+/// Return a list of yaml parameter file paths specified on the command line.
+/**
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] arguments An arguments structure that has been parsed.
+ * \param[in] allocator A valid allocator.
+ * \param[out] parameter_files An allocated array of paramter file names.
+ *   This array must be deallocated by the caller using the given allocator.
+ *   The output is NULL if there were no paramter files.
+ * \return `RCL_RET_OK` if everything goes correctly, or
+ * \return `RCL_RET_INVALID_ARGUMENT` if any function arguments are invalid, or
+ * \return `RCL_RET_BAD_ALLOC` if allocating memory failed, or
+ * \return `RCL_RET_ERROR` if an unspecified error occurs.
+ */
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
 rcl_arguments_get_param_files(
   const rcl_arguments_t * arguments,
   rcl_allocator_t allocator,
-  char ** parameter_files);
-  // rcutils_string_array_t * parameter_files);
+  char *** parameter_files);
 
 /// Return a list of arguments with ROS-specific arguments removed.
 /**

--- a/rcl/include/rcl/arguments.h
+++ b/rcl/include/rcl/arguments.h
@@ -20,6 +20,8 @@
 #include "rcl/types.h"
 #include "rcl/visibility_control.h"
 
+#include "rcutils/types.h"
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -136,6 +138,23 @@ rcl_arguments_get_unparsed(
   const rcl_arguments_t * args,
   rcl_allocator_t allocator,
   int ** output_unparsed_indices);
+
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+int
+rcl_arguments_get_param_files_count(
+  const rcl_arguments_t * args);
+
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_arguments_get_param_files(
+  const rcl_arguments_t * arguments,
+  rcl_allocator_t allocator,
+  char ** parameter_files);
+  // rcutils_string_array_t * parameter_files);
 
 /// Return a list of arguments with ROS-specific arguments removed.
 /**

--- a/rcl/include/rcl/types.h
+++ b/rcl/include/rcl/types.h
@@ -92,7 +92,7 @@ typedef rmw_ret_t rcl_ret_t;
 #define RCL_RET_INVALID_REMAP_RULE 1001
 /// Expected one type of lexeme but got another
 #define RCL_RET_WRONG_LEXEME 1002
-/// Argument is not a valid remap rule
+/// Argument is not a valid parameter rule
 #define RCL_RET_INVALID_PARAM_RULE 1010
 
 #endif  // RCL__TYPES_H_

--- a/rcl/include/rcl/types.h
+++ b/rcl/include/rcl/types.h
@@ -92,5 +92,7 @@ typedef rmw_ret_t rcl_ret_t;
 #define RCL_RET_INVALID_REMAP_RULE 1001
 /// Expected one type of lexeme but got another
 #define RCL_RET_WRONG_LEXEME 1002
+/// Argument is not a valid remap rule
+#define RCL_RET_INVALID_PARAM_RULE 1010
 
 #endif  // RCL__TYPES_H_

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -942,7 +942,7 @@ _rcl_parse_param_rule(
   RCL_CHECK_ARGUMENT_FOR_NULL(arg, RCL_RET_INVALID_ARGUMENT, allocator);
 
   const char * param_prefix = "__params:=";
-  size_t param_prefix_len = strlen(param_prefix);
+  const size_t param_prefix_len = strlen(param_prefix);
   if (strncmp(param_prefix, arg, param_prefix_len) == 0) {
     size_t outlen = strlen(arg) - param_prefix_len;
     *output_rule = allocator.allocate(sizeof(char) * (outlen + 1), allocator.state);

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -162,13 +162,13 @@ rcl_parse_arguments(
       RCL_RET_OK == _rcl_parse_param_rule(
         argv[i], allocator, &(args_impl->parameter_files[args_impl->num_param_files_args]))
     ) {
-      ++(args_impl->num_param_files_args);
       RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME,
         "params rule : %s\n total num param rules %d",
         args_impl->parameter_files[args_impl->num_param_files_args],
         // args_impl->parameter_files[args_impl->num_param_files_args],
         // foobar,
         args_impl->num_param_files_args)
+      ++(args_impl->num_param_files_args);
     } else if (RCL_RET_OK == _rcl_parse_remap_rule(argv[i], allocator, rule)) {
       RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME, "remap rule")
       ++(args_impl->num_remap_rules);

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -168,13 +168,11 @@ rcl_parse_arguments(
       RCL_RET_OK == _rcl_parse_param_rule(
         argv[i], allocator, &(args_impl->parameter_files[args_impl->num_param_files_args]))
     ) {
+      ++(args_impl->num_param_files_args);
       RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME,
         "params rule : %s\n total num param rules %d",
-        args_impl->parameter_files[args_impl->num_param_files_args],
-        // args_impl->parameter_files[args_impl->num_param_files_args],
-        // foobar,
+        args_impl->parameter_files[args_impl->num_param_files_args - 1],
         args_impl->num_param_files_args)
-      ++(args_impl->num_param_files_args);
     } else if (RCL_RET_OK == _rcl_parse_remap_rule(argv[i], allocator, rule)) {
       RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME, "remap rule")
       ++(args_impl->num_remap_rules);

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -164,8 +164,8 @@ rcl_parse_arguments(
     args_impl->parameter_files[args_impl->num_param_files_args] = NULL;
     if (
       RCL_RET_OK == _rcl_parse_param_rule(
-        argv[i], allocator, &(args_impl->parameter_files[args_impl->num_param_files_args]))
-    ) {
+        argv[i], allocator, &(args_impl->parameter_files[args_impl->num_param_files_args])))
+    {
       ++(args_impl->num_param_files_args);
       RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
         "params rule : %s\n total num param rules %d",

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -438,6 +438,16 @@ rcl_arguments_fini(
     args->impl->num_unparsed_args = 0;
     args->impl->unparsed_args = NULL;
 
+    if (args->impl->parameter_files) {
+      for (int p = 0; p < args->impl->num_param_files_args; ++p) {
+        args->impl->allocator.deallocate(
+          args->impl->parameter_files[p], args->impl->allocator.state);
+      }
+      args->impl->allocator.deallocate(args->impl->parameter_files, args->impl->allocator.state);
+      args->impl->num_param_files_args = 0;
+      args->impl->parameter_files = NULL;
+    }
+
     args->impl->allocator.deallocate(args->impl, args->impl->allocator.state);
     args->impl = NULL;
     return ret;

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -62,21 +62,20 @@ rcl_ret_t
 rcl_arguments_get_param_files(
   const rcl_arguments_t * arguments,
   rcl_allocator_t allocator,
-  // char ** parameter_files)
-  rcutils_string_array_t * parameter_files)
+  char *** parameter_files)
 {
   RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(arguments, RCL_RET_INVALID_ARGUMENT, allocator);
   RCL_CHECK_ARGUMENT_FOR_NULL(arguments->impl, RCL_RET_INVALID_ARGUMENT, allocator);
   RCL_CHECK_ARGUMENT_FOR_NULL(parameter_files, RCL_RET_INVALID_ARGUMENT, allocator);
-  rcutils_ret_t ret = rcutils_string_array_init(
-    parameter_files, arguments->impl->num_param_files_args, &allocator);
-  if (ret != RCUTILS_RET_OK) {
+  *(parameter_files) = allocator.allocate(
+    sizeof(char *) * arguments->impl->num_param_files_args, allocator.state);
+  if (NULL == *parameter_files) {
     return RCL_RET_BAD_ALLOC;
   }
   for (int i = 0; i < arguments->impl->num_param_files_args; ++i) {
     snprintf(
-      parameter_files->data[i],
+      (*parameter_files)[i],
       strlen(arguments->impl->parameter_files[i]),
       "%s", arguments->impl->parameter_files[i]);
   }

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -195,6 +195,18 @@ rcl_parse_arguments(
     allocator.deallocate(args_impl->remap_rules, allocator.state);
     args_impl->remap_rules = NULL;
   }
+  // Shrink Parameter files
+  if (0 == args_impl->num_param_files_args) {
+    allocator.deallocate(args_impl->parameter_files, allocator.state);
+    args_impl->parameter_files = NULL;
+  } else if (args_impl->num_param_files_args < argc) {
+    args_impl->parameter_files = rcutils_reallocf(
+      args_impl->parameter_files, sizeof(char *) * args_impl->num_param_files_args, &allocator);
+    if (NULL == args_impl->parameter_files) {
+      ret = RCL_RET_BAD_ALLOC;
+      goto fail;
+    }
+  }
   // Shrink unparsed_args
   if (0 == args_impl->num_unparsed_args) {
     // No unparsed args

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -74,10 +74,16 @@ rcl_arguments_get_param_files(
     return RCL_RET_BAD_ALLOC;
   }
   for (int i = 0; i < arguments->impl->num_param_files_args; ++i) {
-    snprintf(
-      (*parameter_files)[i],
-      strlen(arguments->impl->parameter_files[i]),
-      "%s", arguments->impl->parameter_files[i]);
+    (*parameter_files)[i] = rcutils_strdup(arguments->impl->parameter_files[i], allocator);
+    if (NULL == *parameter_files) {
+      // deallocate allocated memory
+      for (int r = i; r >= 0; --r) {
+        allocator.deallocate((*parameter_files[i]), allocator.state);
+      }
+      allocator.deallocate((*parameter_files), allocator.state);
+      (*parameter_files) = NULL;
+      return RCL_RET_BAD_ALLOC;
+    }
   }
   return RCL_RET_OK;
 }

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -157,10 +157,8 @@ rcl_parse_arguments(
     goto fail;
   }
 
-  RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME, "coucou1");
   // Attempt to parse arguments as remap rules
   for (int i = 0; i < argc; ++i) {
-    RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME, "coucou2 : %d", i);
     rcl_remap_t * rule = &(args_impl->remap_rules[args_impl->num_remap_rules]);
     *rule = rcl_remap_get_zero_initialized();
     args_impl->parameter_files[args_impl->num_param_files_args] = NULL;
@@ -169,12 +167,11 @@ rcl_parse_arguments(
         argv[i], allocator, &(args_impl->parameter_files[args_impl->num_param_files_args]))
     ) {
       ++(args_impl->num_param_files_args);
-      RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME,
+      RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
         "params rule : %s\n total num param rules %d",
         args_impl->parameter_files[args_impl->num_param_files_args - 1],
         args_impl->num_param_files_args)
     } else if (RCL_RET_OK == _rcl_parse_remap_rule(argv[i], allocator, rule)) {
-      RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME, "remap rule")
       ++(args_impl->num_remap_rules);
     } else {
       RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "arg %d (%s) error '%s'", i, argv[i],
@@ -184,7 +181,6 @@ rcl_parse_arguments(
       ++(args_impl->num_unparsed_args);
     }
   }
-  RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME, "coucou3");
 
   // Shrink remap_rules array to match number of successfully parsed rules
   if (args_impl->num_remap_rules > 0) {

--- a/rcl/src/rcl/arguments_impl.h
+++ b/rcl/src/rcl/arguments_impl.h
@@ -31,6 +31,12 @@ typedef struct rcl_arguments_impl_t
   /// Length of unparsed_args.
   int num_unparsed_args;
 
+  // TODO(mikaelarguedas) consider storing CLI parameter rules here
+  /// Array of yaml parameter file paths
+  char ** parameter_files;
+  /// Length of parameter_files.
+  int num_param_files_args;
+
   /// Array of rules for name remapping.
   rcl_remap_t * remap_rules;
   /// Length of remap_rules.

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -100,6 +100,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), check_valid_vs_inval
   EXPECT_TRUE(is_valid_arg("rostopic://rostopic:=rosservice"));
   EXPECT_TRUE(is_valid_arg("rostopic:///rosservice:=rostopic"));
   EXPECT_TRUE(is_valid_arg("rostopic:///foo/bar:=baz"));
+  EXPECT_TRUE(is_valid_arg("__params:=node_name"));
 
   EXPECT_FALSE(is_valid_arg(":="));
   EXPECT_FALSE(is_valid_arg("foo:="));
@@ -117,6 +118,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), check_valid_vs_inval
   EXPECT_FALSE(is_valid_arg("foo:=/b}ar"));
   EXPECT_FALSE(is_valid_arg("rostopic://:=rosservice"));
   EXPECT_FALSE(is_valid_arg("rostopic::=rosservice"));
+  EXPECT_FALSE(is_valid_arg("__param:=node_name"));
 }
 
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_no_args) {

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -315,6 +315,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_
 
   int parameter_filecount = rcl_arguments_get_param_files_count(&parsed_args);
   EXPECT_EQ(0, parameter_filecount);
+  EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
 }
 
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_single) {
@@ -336,6 +337,12 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_
   ret = rcl_arguments_get_param_files(&parsed_args, alloc, &parameter_files);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
   EXPECT_STREQ("parameter_filepath", parameter_files[0]);
+
+  for (int i = 0; i < parameter_filecount; ++i) {
+    alloc.deallocate(parameter_files[i], alloc.state);
+  }
+  alloc.deallocate(parameter_files, alloc.state);
+  EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
 }
 
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_multiple) {
@@ -359,4 +366,9 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
   EXPECT_STREQ("parameter_filepath1", parameter_files[0]);
   EXPECT_STREQ("parameter_filepath2", parameter_files[1]);
+  for (int i = 0; i < parameter_filecount; ++i) {
+    alloc.deallocate(parameter_files[i], alloc.state);
+  }
+  alloc.deallocate(parameter_files, alloc.state);
+  EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
 }

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -318,7 +318,9 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_
 }
 
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_single) {
-  const char * argv[] = {"process_name", "__ns:=/namespace", "random:=arg", "__params:=parameter_filepath"};
+  const char * argv[] = {
+    "process_name", "__ns:=/namespace", "random:=arg", "__params:=parameter_filepath"
+  };
   int argc = sizeof(argv) / sizeof(const char *);
   rcl_ret_t ret;
 
@@ -339,7 +341,8 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_multiple) {
   const char * argv[] = {
     "process_name", "__params:=parameter_filepath1", "__ns:=/namespace",
-    "random:=arg", "__params:=parameter_filepath2"};
+    "random:=arg", "__params:=parameter_filepath2"
+  };
   int argc = sizeof(argv) / sizeof(const char *);
   rcl_ret_t ret;
 


### PR DESCRIPTION
Utilities to pass yaml parameter files via commandline using the `__params:=<YAML_FILE_PATH>`
Provides functions to retrieve them to be able to call `rcl_parse_yaml_file` on them

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4530)](http://ci.ros2.org/job/ci_linux/4530/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1448)](http://ci.ros2.org/job/ci_linux-aarch64/1448/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3721)](http://ci.ros2.org/job/ci_osx/3721/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4607)](http://ci.ros2.org/job/ci_windows/4607/)

This should enable https://github.com/ros2/rclcpp/pull/488