### PR TITLE
Set default logger level from command line

### DIFF
--- a/rcl/Doxyfile
+++ b/rcl/Doxyfile
@@ -19,6 +19,10 @@ EXPAND_ONLY_PREDEF     = YES
 PREDEFINED             += RCL_PUBLIC=
 PREDEFINED             += RCL_WARN_UNUSED=
 
+# Uncomment to generate internal documentation.
+ENABLED_SECTIONS       = INTERNAL
+INPUT                  += ./src/rcl/arguments.c
+
 # Tag files that do not exist will produce a warning and cross-project linking will not work.
 TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
 # Consider changing "latest" to the version you want to reference (e.g. beta1 or 1.0.0)

--- a/rcl/include/rcl/arguments.h
+++ b/rcl/include/rcl/arguments.h
@@ -34,7 +34,8 @@ typedef struct rcl_arguments_t
   struct rcl_arguments_impl_t * impl;
 } rcl_arguments_t;
 
-static const char LOG_LEVEL_ARG_RULE[] = "__log:=";
+#define RCL_LOG_LEVEL_ARG_RULE "__log:="
+#define RCL_PARAM_FILE_ARG_RULE "__params:="
 
 /// Return a rcl_node_t struct with members initialized to `NULL`.
 RCL_PUBLIC

--- a/rcl/include/rcl/arguments.h
+++ b/rcl/include/rcl/arguments.h
@@ -56,7 +56,7 @@ rcl_get_zero_initialized_arguments(void);
  * If given arguments `{"__ns:=/foo", "__ns:=/bar"}` then the namespace used by nodes in this
  * process will be `/foo` and not `/bar`.
  *
- * The default log level will be parsed as `__log:=level`, where `level` is a name representing
+ * The default log level will be parsed as `__log_level:=level`, where `level` is a name representing
  * one of the log levels in the `RCUTILS_LOG_SEVERITY` enum, e.g. `info`, `debug`, `warn`, not case
  * sensitive.
  *

--- a/rcl/include/rcl/arguments.h
+++ b/rcl/include/rcl/arguments.h
@@ -56,9 +56,10 @@ rcl_get_zero_initialized_arguments(void);
  * If given arguments `{"__ns:=/foo", "__ns:=/bar"}` then the namespace used by nodes in this
  * process will be `/foo` and not `/bar`.
  *
- * The default log level will be parsed as `__log_level:=level`, where `level` is a name representing
- * one of the log levels in the `RCUTILS_LOG_SEVERITY` enum, e.g. `info`, `debug`, `warn`, not case
- * sensitive.
+ * The default log level will be parsed as `__log_level:=level`, where `level` is a name
+ * representing one of the log levels in the `RCUTILS_LOG_SEVERITY` enum, e.g. `info`, `debug`,
+ * `warn`, not case sensitive.
+ * If multiple of these rules are found, the last one parsed will be used.
  *
  * \sa rcl_remap_topic_name()
  * \sa rcl_remap_service_name()

--- a/rcl/include/rcl/arguments.h
+++ b/rcl/include/rcl/arguments.h
@@ -34,6 +34,8 @@ typedef struct rcl_arguments_t
   struct rcl_arguments_impl_t * impl;
 } rcl_arguments_t;
 
+static const char LOG_LEVEL_ARG_RULE[] = "__log:=";
+
 /// Return a rcl_node_t struct with members initialized to `NULL`.
 RCL_PUBLIC
 RCL_WARN_UNUSED
@@ -52,6 +54,11 @@ rcl_get_zero_initialized_arguments(void);
  * Successfully parsed remap rules are stored in the order they were given in `argv`.
  * If given arguments `{"__ns:=/foo", "__ns:=/bar"}` then the namespace used by nodes in this
  * process will be `/foo` and not `/bar`.
+ *
+ * The default log level will be parsed as `__log:=level`, where `level` is a name representing
+ * one of the log levels in the `RCUTILS_LOG_SEVERITY` enum, e.g. `info`, `debug`, `warn`, not case
+ * sensitive.
+ *
  * \sa rcl_remap_topic_name()
  * \sa rcl_remap_service_name()
  * \sa rcl_remap_node_name()

--- a/rcl/include/rcl/arguments.h
+++ b/rcl/include/rcl/arguments.h
@@ -34,7 +34,7 @@ typedef struct rcl_arguments_t
   struct rcl_arguments_impl_t * impl;
 } rcl_arguments_t;
 
-#define RCL_LOG_LEVEL_ARG_RULE "__log:="
+#define RCL_LOG_LEVEL_ARG_RULE "__log_level:="
 #define RCL_PARAM_FILE_ARG_RULE "__params:="
 
 /// Return a rcl_node_t struct with members initialized to `NULL`.

--- a/rcl/include/rcl/types.h
+++ b/rcl/include/rcl/types.h
@@ -94,5 +94,7 @@ typedef rmw_ret_t rcl_ret_t;
 #define RCL_RET_WRONG_LEXEME 1002
 /// Argument is not a valid parameter rule
 #define RCL_RET_INVALID_PARAM_RULE 1010
+/// Argument is not a valid log level rule
+#define RCL_RET_INVALID_LOG_LEVEL_RULE 1020
 
 #endif  // RCL__TYPES_H_

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/// \cond INTERNAL  // Internal Doxygen documentation
+
 #include "rcl/arguments.h"
 
 #include <string.h>
@@ -46,7 +48,6 @@ static rcl_arguments_t __rcl_global_arguments;
  * \return RCL_RET_INVALID_REMAP_RULE if the argument is not a valid rule, or
  * \return RCL_RET_BAD_ALLOC if an allocation failed, or
  * \return RLC_RET_ERROR if an unspecified error occurred.
- * \internal
  */
 RCL_LOCAL
 rcl_ret_t
@@ -65,7 +66,6 @@ _rcl_parse_remap_rule(
  * \return RCL_RET_INVALID_PARAM_RULE if the argument is not a valid rule, or
  * \return RCL_RET_BAD_ALLOC if an allocation failed, or
  * \return RLC_RET_ERROR if an unspecified error occurred.
- * \internal
  */
 RCL_LOCAL
 rcl_ret_t
@@ -123,7 +123,6 @@ rcl_arguments_get_param_files_count(
  * \return RCL_RET_INVALID_LOG_LEVEL_RULE if the argument is not a valid rule, or
  * \return RCL_RET_BAD_ALLOC if an allocation failed, or
  * \return RLC_RET_ERROR if an unspecified error occurred.
- * \internal
  */
 RCL_LOCAL
 rcl_ret_t
@@ -523,7 +522,6 @@ rcl_get_global_arguments()
 /// Parses a fully qualified namespace for a namespace replacement rule (ex: `/foo/bar`)
 /**
  * \sa _rcl_parse_remap_begin_remap_rule()
- * \internal
  */
 RCL_LOCAL
 rcl_ret_t
@@ -557,7 +555,6 @@ _rcl_parse_remap_fully_qualified_namespace(
 /// Parse either a token or a backreference (ex: `bar`, or `\7`).
 /**
  * \sa _rcl_parse_remap_begin_remap_rule()
- * \internal
  */
 RCL_LOCAL
 rcl_ret_t
@@ -592,7 +589,6 @@ _rcl_parse_remap_replacement_token(
 /// Parse the replacement side of a name remapping rule (ex: `bar/\1/foo`).
 /**
  * \sa _rcl_parse_remap_begin_remap_rule()
- * \internal
  */
 RCL_LOCAL
 rcl_ret_t
@@ -660,7 +656,6 @@ _rcl_parse_remap_replacement_name(
 /// Parse either a token or a wildcard (ex: `foobar`, or `*`, or `**`).
 /**
  * \sa _rcl_parse_remap_begin_remap_rule()
- * \internal
  */
 RCL_LOCAL
 rcl_ret_t
@@ -695,7 +690,6 @@ _rcl_parse_remap_match_token(
 /// Parse the match side of a name remapping rule (ex: `rostopic://foo`)
 /**
  * \sa _rcl_parse_remap_begin_remap_rule()
- * \internal
  */
 RCL_LOCAL
 rcl_ret_t
@@ -780,7 +774,6 @@ _rcl_parse_remap_match_name(
 /// Parse a name remapping rule (ex: `rostopic:///foo:=bar`).
 /**
  * \sa _rcl_parse_remap_begin_remap_rule()
- * \internal
  */
 RCL_LOCAL
 rcl_ret_t
@@ -811,7 +804,6 @@ _rcl_parse_remap_name_remap(
 /// Parse a namespace replacement rule (ex: `__ns:=/new/ns`).
 /**
  * \sa _rcl_parse_remap_begin_remap_rule()
- * \internal
  */
 RCL_LOCAL
 rcl_ret_t
@@ -870,7 +862,6 @@ _rcl_parse_remap_namespace_replacement(
 /// Parse a nodename replacement rule (ex: `__node:=new_name`).
 /**
  * \sa _rcl_parse_remap_begin_remap_rule()
- * \internal
  */
 RCL_LOCAL
 rcl_ret_t
@@ -914,7 +905,6 @@ _rcl_parse_remap_nodename_replacement(
 /// Parse a nodename prefix including trailing colon (ex: `node_name:`).
 /**
  * \sa _rcl_parse_remap_begin_remap_rule()
- * \internal
  */
 RCL_LOCAL
 rcl_ret_t
@@ -954,7 +944,6 @@ _rcl_parse_remap_nodename_prefix(
  * \return RCL_RET_INVALID_REMAP_RULE if the argument is not a valid rule, or
  * \return RCL_RET_BAD_ALLOC if an allocation failed, or
  * \return RLC_RET_ERROR if an unspecified error occurred.
- * \internal
  */
 RCL_LOCAL
 rcl_ret_t
@@ -1093,3 +1082,5 @@ _rcl_parse_param_file_rule(
 #ifdef __cplusplus
 }
 #endif
+
+/// \endcond  // Internal Doxygen documentation

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -146,6 +146,7 @@ rcl_parse_arguments(
   rcl_arguments_impl_t * args_impl = args_output->impl;
   args_impl->num_remap_rules = 0;
   args_impl->remap_rules = NULL;
+  args_impl->log_level = -1;
   args_impl->unparsed_args = NULL;
   args_impl->num_unparsed_args = 0;
   args_impl->parameter_files = NULL;
@@ -195,8 +196,7 @@ rcl_parse_arguments(
     } else {
       // Attempt to parse argument as log level configuration
       if (RCL_RET_OK == _rcl_parse_log_level(argv[i], allocator, &log_level)) {
-        // Set the log level immediately so it can take effect for the rest of the argument parsing.
-        rcutils_logging_set_default_logger_level(log_level);
+        args_impl->log_level = log_level;
       } else {
         RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "arg %d (%s) error '%s'", i, argv[i],
           rcl_get_error_string());

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -38,8 +38,8 @@ static rcl_arguments_t __rcl_global_arguments;
 /// Parse an argument that may or may not be a remap rule.
 /// \param[in] arg the argument to parse
 /// \param[in] allocator an allocator to use
-/// \param[in,out] output_rule input a zero intialized rule, output a fully initialized one
-/// \return RCL_RET_OK if a valid rule was parsed, or
+/// \param[in,out] log_level parsed log level represented by RCUTILS_LOG_SEVERITY enum
+/// \return RCL_RET_OK if a valid log level was parsed, or
 /// \return RCL_RET_INVALID_REMAP_RULE if the argument is not a valid rule, or
 /// \return RCL_RET_BAD_ALLOC if an allocation failed, or
 /// \return RLC_RET_ERROR if an unspecified error occurred.
@@ -980,7 +980,7 @@ _rcl_parse_log_level(
   } else if (strcmp("__log:=UNSET", severity_string) == 0) {
     severity = RCUTILS_LOG_SEVERITY_UNSET;
   } else {
-    return RCL_RET_ERROR;
+    return RCL_INVALID_REMAP_RULE;
   }
   *log_level = severity;
   return RCL_RET_OK;

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -52,12 +52,22 @@ _rcl_parse_remap_rule(
   rcl_allocator_t allocator,
   rcl_remap_t * output_rule);
 
+/// Parse an argument that may or may not be a parameter file rule.
+/// The syntax of the file name is not validated.
+/// \param[in] arg the argument to parse
+/// \param[in] allocator an allocator to use
+/// \param[in,out] param_file string that could be a parameter file name
+/// \return RCL_RET_OK if the rule was parsed correctly, or
+/// \return RCL_RET_INVALID_PARAM_RULE if the argument is not a valid rule, or
+/// \return RCL_RET_BAD_ALLOC if an allocation failed, or
+/// \return RLC_RET_ERROR if an unspecified error occurred.
+/// \internal
 RCL_LOCAL
 rcl_ret_t
-_rcl_parse_param_rule(
+_rcl_parse_param_file_rule(
   const char * arg,
   rcl_allocator_t allocator,
-  char ** output_rule);
+  char ** param_file);
 
 rcl_ret_t
 rcl_arguments_get_param_files(
@@ -179,7 +189,7 @@ rcl_parse_arguments(
     // Attempt to parse argument as parameter file rule
     args_impl->parameter_files[args_impl->num_param_files_args] = NULL;
     if (
-      RCL_RET_OK == _rcl_parse_param_rule(
+      RCL_RET_OK == _rcl_parse_param_file_rule(
         argv[i], allocator, &(args_impl->parameter_files[args_impl->num_param_files_args])))
     {
       ++(args_impl->num_param_files_args);
@@ -1031,22 +1041,22 @@ _rcl_parse_remap_rule(
 }
 
 rcl_ret_t
-_rcl_parse_param_rule(
+_rcl_parse_param_file_rule(
   const char * arg,
   rcl_allocator_t allocator,
-  char ** output_rule)
+  char ** param_file)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(arg, RCL_RET_INVALID_ARGUMENT, allocator);
 
   const size_t param_prefix_len = strlen(RCL_PARAM_FILE_ARG_RULE);
   if (strncmp(RCL_PARAM_FILE_ARG_RULE, arg, param_prefix_len) == 0) {
     size_t outlen = strlen(arg) - param_prefix_len;
-    *output_rule = allocator.allocate(sizeof(char) * (outlen + 1), allocator.state);
-    if (NULL == output_rule) {
+    *param_file = allocator.allocate(sizeof(char) * (outlen + 1), allocator.state);
+    if (NULL == param_file) {
       RCL_SET_ERROR_MSG("Failed to allocate memory for parameters file path", allocator)
       return RCL_RET_BAD_ALLOC;
     }
-    snprintf(*output_rule, outlen + 1, "%s", arg + param_prefix_len);
+    snprintf(*param_file, outlen + 1, "%s", arg + param_prefix_len);
     return RCL_RET_OK;
   }
   RCL_SET_ERROR_MSG("Argument does not start with '" RCL_PARAM_FILE_ARG_RULE "'", allocator);

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -22,6 +22,7 @@
 #include "rcl/lexer_lookahead.h"
 #include "rcl/validate_topic_name.h"
 #include "rcutils/allocator.h"
+#include "rcutils/error_handling.h"
 #include "rcutils/logging.h"
 #include "rcutils/logging_macros.h"
 #include "rcutils/strdup.h"
@@ -1053,7 +1054,7 @@ _rcl_parse_param_file_rule(
     size_t outlen = strlen(arg) - param_prefix_len;
     *param_file = allocator.allocate(sizeof(char) * (outlen + 1), allocator.state);
     if (NULL == param_file) {
-      RCL_SET_ERROR_MSG("Failed to allocate memory for parameters file path", allocator)
+      RCUTILS_SAFE_FWRITE_TO_STDERR("Failed to allocate memory for parameters file path\n");
       return RCL_RET_BAD_ALLOC;
     }
     snprintf(*param_file, outlen + 1, "%s", arg + param_prefix_len);

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -39,8 +39,8 @@ static rcl_arguments_t __rcl_global_arguments;
 /// Parse an argument that may or may not be a remap rule.
 /// \param[in] arg the argument to parse
 /// \param[in] allocator an allocator to use
-/// \param[in,out] log_level parsed log level represented by RCUTILS_LOG_SEVERITY enum
-/// \return RCL_RET_OK if a valid log level was parsed, or
+/// \param[in,out] output_rule input a zero intialized rule, output a fully initialized one
+/// \return RCL_RET_OK if a valid rule was parsed, or
 /// \return RCL_RET_INVALID_REMAP_RULE if the argument is not a valid rule, or
 /// \return RCL_RET_BAD_ALLOC if an allocation failed, or
 /// \return RLC_RET_ERROR if an unspecified error occurred.
@@ -109,10 +109,10 @@ rcl_arguments_get_param_files_count(
   return args->impl->num_param_files_args;
 }
 
-/// Parse an argument that may or may not be a remap rule.
+/// Parse an argument that may or may not be a log level rule.
 /// \param[in] arg the argument to parse
 /// \param[in] allocator an allocator to use
-/// \param[in,out] log_level parsed log level represented by RCUTILS_LOG_SEVERITY enum
+/// \param[in,out] log_level parsed log level represented by `RCUTILS_LOG_SEVERITY` enum
 /// \return RCL_RET_OK if a valid log level was parsed, or
 /// \return RCL_RET_INVALID_LOG_LEVEL_RULE if the argument is not a valid rule, or
 /// \return RCL_RET_BAD_ALLOC if an allocation failed, or

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -38,14 +38,16 @@ extern "C"
 static rcl_arguments_t __rcl_global_arguments;
 
 /// Parse an argument that may or may not be a remap rule.
-/// \param[in] arg the argument to parse
-/// \param[in] allocator an allocator to use
-/// \param[in,out] output_rule input a zero intialized rule, output a fully initialized one
-/// \return RCL_RET_OK if a valid rule was parsed, or
-/// \return RCL_RET_INVALID_REMAP_RULE if the argument is not a valid rule, or
-/// \return RCL_RET_BAD_ALLOC if an allocation failed, or
-/// \return RLC_RET_ERROR if an unspecified error occurred.
-/// \internal
+/**
+ * \param[in] arg the argument to parse
+ * \param[in] allocator an allocator to use
+ * \param[in,out] output_rule input a zero intialized rule, output a fully initialized one
+ * \return RCL_RET_OK if a valid rule was parsed, or
+ * \return RCL_RET_INVALID_REMAP_RULE if the argument is not a valid rule, or
+ * \return RCL_RET_BAD_ALLOC if an allocation failed, or
+ * \return RLC_RET_ERROR if an unspecified error occurred.
+ * \internal
+ */
 RCL_LOCAL
 rcl_ret_t
 _rcl_parse_remap_rule(
@@ -54,15 +56,17 @@ _rcl_parse_remap_rule(
   rcl_remap_t * output_rule);
 
 /// Parse an argument that may or may not be a parameter file rule.
-/// The syntax of the file name is not validated.
-/// \param[in] arg the argument to parse
-/// \param[in] allocator an allocator to use
-/// \param[in,out] param_file string that could be a parameter file name
-/// \return RCL_RET_OK if the rule was parsed correctly, or
-/// \return RCL_RET_INVALID_PARAM_RULE if the argument is not a valid rule, or
-/// \return RCL_RET_BAD_ALLOC if an allocation failed, or
-/// \return RLC_RET_ERROR if an unspecified error occurred.
-/// \internal
+/**
+ * The syntax of the file name is not validated.
+ * \param[in] arg the argument to parse
+ * \param[in] allocator an allocator to use
+ * \param[in,out] param_file string that could be a parameter file name
+ * \return RCL_RET_OK if the rule was parsed correctly, or
+ * \return RCL_RET_INVALID_PARAM_RULE if the argument is not a valid rule, or
+ * \return RCL_RET_BAD_ALLOC if an allocation failed, or
+ * \return RLC_RET_ERROR if an unspecified error occurred.
+ * \internal
+ */
 RCL_LOCAL
 rcl_ret_t
 _rcl_parse_param_file_rule(
@@ -111,14 +115,16 @@ rcl_arguments_get_param_files_count(
 }
 
 /// Parse an argument that may or may not be a log level rule.
-/// \param[in] arg the argument to parse
-/// \param[in] allocator an allocator to use
-/// \param[in,out] log_level parsed log level represented by `RCUTILS_LOG_SEVERITY` enum
-/// \return RCL_RET_OK if a valid log level was parsed, or
-/// \return RCL_RET_INVALID_LOG_LEVEL_RULE if the argument is not a valid rule, or
-/// \return RCL_RET_BAD_ALLOC if an allocation failed, or
-/// \return RLC_RET_ERROR if an unspecified error occurred.
-/// \internal
+/**
+ * \param[in] arg the argument to parse
+ * \param[in] allocator an allocator to use
+ * \param[in,out] log_level parsed log level represented by `RCUTILS_LOG_SEVERITY` enum
+ * \return RCL_RET_OK if a valid log level was parsed, or
+ * \return RCL_RET_INVALID_LOG_LEVEL_RULE if the argument is not a valid rule, or
+ * \return RCL_RET_BAD_ALLOC if an allocation failed, or
+ * \return RLC_RET_ERROR if an unspecified error occurred.
+ * \internal
+ */
 RCL_LOCAL
 rcl_ret_t
 _rcl_parse_log_level_rule(
@@ -515,8 +521,10 @@ rcl_get_global_arguments()
 }
 
 /// Parses a fully qualified namespace for a namespace replacement rule (ex: `/foo/bar`)
-/// \sa _rcl_parse_remap_begin_remap_rule()
-/// \internal
+/**
+ * \sa _rcl_parse_remap_begin_remap_rule()
+ * \internal
+ */
 RCL_LOCAL
 rcl_ret_t
 _rcl_parse_remap_fully_qualified_namespace(
@@ -547,8 +555,10 @@ _rcl_parse_remap_fully_qualified_namespace(
 }
 
 /// Parse either a token or a backreference (ex: `bar`, or `\7`).
-/// \sa _rcl_parse_remap_begin_remap_rule()
-/// \internal
+/**
+ * \sa _rcl_parse_remap_begin_remap_rule()
+ * \internal
+ */
 RCL_LOCAL
 rcl_ret_t
 _rcl_parse_remap_replacement_token(
@@ -580,8 +590,10 @@ _rcl_parse_remap_replacement_token(
 }
 
 /// Parse the replacement side of a name remapping rule (ex: `bar/\1/foo`).
-/// \sa _rcl_parse_remap_begin_remap_rule()
-/// \internal
+/**
+ * \sa _rcl_parse_remap_begin_remap_rule()
+ * \internal
+ */
 RCL_LOCAL
 rcl_ret_t
 _rcl_parse_remap_replacement_name(
@@ -646,8 +658,10 @@ _rcl_parse_remap_replacement_name(
 }
 
 /// Parse either a token or a wildcard (ex: `foobar`, or `*`, or `**`).
-/// \sa _rcl_parse_remap_begin_remap_rule()
-/// \internal
+/**
+ * \sa _rcl_parse_remap_begin_remap_rule()
+ * \internal
+ */
 RCL_LOCAL
 rcl_ret_t
 _rcl_parse_remap_match_token(
@@ -679,8 +693,10 @@ _rcl_parse_remap_match_token(
 }
 
 /// Parse the match side of a name remapping rule (ex: `rostopic://foo`)
-/// \sa _rcl_parse_remap_begin_remap_rule()
-/// \internal
+/**
+ * \sa _rcl_parse_remap_begin_remap_rule()
+ * \internal
+ */
 RCL_LOCAL
 rcl_ret_t
 _rcl_parse_remap_match_name(
@@ -762,8 +778,10 @@ _rcl_parse_remap_match_name(
 }
 
 /// Parse a name remapping rule (ex: `rostopic:///foo:=bar`).
-/// \sa _rcl_parse_remap_begin_remap_rule()
-/// \internal
+/**
+ * \sa _rcl_parse_remap_begin_remap_rule()
+ * \internal
+ */
 RCL_LOCAL
 rcl_ret_t
 _rcl_parse_remap_name_remap(
@@ -791,8 +809,10 @@ _rcl_parse_remap_name_remap(
 }
 
 /// Parse a namespace replacement rule (ex: `__ns:=/new/ns`).
-/// \sa _rcl_parse_remap_begin_remap_rule()
-/// \internal
+/**
+ * \sa _rcl_parse_remap_begin_remap_rule()
+ * \internal
+ */
 RCL_LOCAL
 rcl_ret_t
 _rcl_parse_remap_namespace_replacement(
@@ -848,8 +868,10 @@ _rcl_parse_remap_namespace_replacement(
 }
 
 /// Parse a nodename replacement rule (ex: `__node:=new_name`).
-/// \sa _rcl_parse_remap_begin_remap_rule()
-/// \internal
+/**
+ * \sa _rcl_parse_remap_begin_remap_rule()
+ * \internal
+ */
 RCL_LOCAL
 rcl_ret_t
 _rcl_parse_remap_nodename_replacement(
@@ -890,8 +912,10 @@ _rcl_parse_remap_nodename_replacement(
 }
 
 /// Parse a nodename prefix including trailing colon (ex: `node_name:`).
-/// \sa _rcl_parse_remap_begin_remap_rule()
-/// \internal
+/**
+ * \sa _rcl_parse_remap_begin_remap_rule()
+ * \internal
+ */
 RCL_LOCAL
 rcl_ret_t
 _rcl_parse_remap_nodename_prefix(
@@ -923,13 +947,15 @@ _rcl_parse_remap_nodename_prefix(
 }
 
 /// Start recursive descent parsing of a remap rule.
-/// \param[in] lex_lookahead a lookahead(2) buffer for the parser to use.
-/// \param[in,out] rule input a zero intialized rule, output a fully initialized one.
-/// \return RCL_RET_OK if a valid rule was parsed, or
-/// \return RCL_RET_INVALID_REMAP_RULE if the argument is not a valid rule, or
-/// \return RCL_RET_BAD_ALLOC if an allocation failed, or
-/// \return RLC_RET_ERROR if an unspecified error occurred.
-/// \internal
+/**
+ * \param[in] lex_lookahead a lookahead(2) buffer for the parser to use.
+ * \param[in,out] rule input a zero intialized rule, output a fully initialized one.
+ * \return RCL_RET_OK if a valid rule was parsed, or
+ * \return RCL_RET_INVALID_REMAP_RULE if the argument is not a valid rule, or
+ * \return RCL_RET_BAD_ALLOC if an allocation failed, or
+ * \return RLC_RET_ERROR if an unspecified error occurred.
+ * \internal
+ */
 RCL_LOCAL
 rcl_ret_t
 _rcl_parse_remap_begin_remap_rule(

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -960,24 +960,22 @@ _rcl_parse_remap_begin_remap_rule(
 
 rcl_ret_t
 _rcl_parse_log_level(
-  const char * arg,
+  const char * severity_string,
   rcl_allocator_t allocator,
   int * log_level)
 {
-  RCL_CHECK_ARGUMENT_FOR_NULL(arg, RCL_RET_INVALID_ARGUMENT, allocator);
+  RCL_CHECK_ARGUMENT_FOR_NULL(severity_string, RCL_RET_INVALID_ARGUMENT, allocator);
   RCL_CHECK_ARGUMENT_FOR_NULL(log_level, RCL_RET_INVALID_ARGUMENT, allocator);
 
-  static const char LOG_ARG_RULE[] = "__log:=";
-  const char * severity_string = arg;
-  if (strncmp(LOG_ARG_RULE, severity_string, strlen(LOG_ARG_RULE)) != 0) {
-    return RCL_RET_INVALID_REMAP_RULE;
+  if (strncmp(LOG_LEVEL_ARG_RULE, severity_string, strlen(LOG_LEVEL_ARG_RULE)) != 0) {
+    return RCL_RET_INVALID_LOG_LEVEL_RULE;
   }
   rcutils_ret_t ret = rcutils_logging_severity_level_from_string(
-    severity_string + strlen(LOG_ARG_RULE), allocator, log_level);
+    severity_string + strlen(LOG_LEVEL_ARG_RULE), allocator, log_level);
   if (RCUTILS_RET_OK == ret) {
     return RCL_RET_OK;
   }
-  return RCL_RET_INVALID_REMAP_RULE;
+  return RCL_RET_INVALID_LOG_LEVEL_RULE;
 }
 
 

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -102,15 +102,15 @@ rcl_arguments_get_param_files_count(
 /// Parse an argument that may or may not be a remap rule.
 /// \param[in] arg the argument to parse
 /// \param[in] allocator an allocator to use
-/// \param[in,out] output_rule input a zero intialized rule, output a fully initialized one
-/// \return RCL_RET_OK if a valid rule was parsed, or
-/// \return RCL_RET_INVALID_REMAP_RULE if the argument is not a valid rule, or
+/// \param[in,out] log_level parsed log level represented by RCUTILS_LOG_SEVERITY enum
+/// \return RCL_RET_OK if a valid log level was parsed, or
+/// \return RCL_RET_INVALID_LOG_LEVEL_RULE if the argument is not a valid rule, or
 /// \return RCL_RET_BAD_ALLOC if an allocation failed, or
 /// \return RLC_RET_ERROR if an unspecified error occurred.
 /// \internal
 RCL_LOCAL
 rcl_ret_t
-_rcl_parse_log_level(
+_rcl_parse_log_level_rule(
   const char * arg,
   rcl_allocator_t allocator,
   int * log_level);
@@ -195,7 +195,7 @@ rcl_parse_arguments(
       ++(args_impl->num_remap_rules);
     } else {
       // Attempt to parse argument as log level configuration
-      if (RCL_RET_OK == _rcl_parse_log_level(argv[i], allocator, &log_level)) {
+      if (RCL_RET_OK == _rcl_parse_log_level_rule(argv[i], allocator, &log_level)) {
         args_impl->log_level = log_level;
       } else {
         RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "arg %d (%s) error '%s'", i, argv[i],
@@ -959,7 +959,7 @@ _rcl_parse_remap_begin_remap_rule(
 }
 
 rcl_ret_t
-_rcl_parse_log_level(
+_rcl_parse_log_level_rule(
   const char * severity_string,
   rcl_allocator_t allocator,
   int * log_level)

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -960,18 +960,18 @@ _rcl_parse_remap_begin_remap_rule(
 
 rcl_ret_t
 _rcl_parse_log_level_rule(
-  const char * severity_string,
+  const char * arg,
   rcl_allocator_t allocator,
   int * log_level)
 {
-  RCL_CHECK_ARGUMENT_FOR_NULL(severity_string, RCL_RET_INVALID_ARGUMENT, allocator);
+  RCL_CHECK_ARGUMENT_FOR_NULL(arg, RCL_RET_INVALID_ARGUMENT, allocator);
   RCL_CHECK_ARGUMENT_FOR_NULL(log_level, RCL_RET_INVALID_ARGUMENT, allocator);
 
-  if (strncmp(LOG_LEVEL_ARG_RULE, severity_string, strlen(LOG_LEVEL_ARG_RULE)) != 0) {
+  if (strncmp(LOG_LEVEL_ARG_RULE, arg, strlen(LOG_LEVEL_ARG_RULE)) != 0) {
     return RCL_RET_INVALID_LOG_LEVEL_RULE;
   }
   rcutils_ret_t ret = rcutils_logging_severity_level_from_string(
-    severity_string + strlen(LOG_LEVEL_ARG_RULE), allocator, log_level);
+    arg + strlen(LOG_LEVEL_ARG_RULE), allocator, log_level);
   if (RCUTILS_RET_OK == ret) {
     return RCL_RET_OK;
   }

--- a/rcl/src/rcl/arguments_impl.h
+++ b/rcl/src/rcl/arguments_impl.h
@@ -42,6 +42,9 @@ typedef struct rcl_arguments_impl_t
   /// Length of remap_rules.
   int num_remap_rules;
 
+  /// Default log level (represented by `RCUTILS_LOG_SEVERITY` enum or -1 if not specified.
+  int log_level;
+
   /// Allocator used to allocate objects in this struct
   rcl_allocator_t allocator;
 } rcl_arguments_impl_t;

--- a/rcl/src/rcl/arguments_impl.h
+++ b/rcl/src/rcl/arguments_impl.h
@@ -42,7 +42,7 @@ typedef struct rcl_arguments_impl_t
   /// Length of remap_rules.
   int num_remap_rules;
 
-  /// Default log level (represented by `RCUTILS_LOG_SEVERITY` enum or -1 if not specified.
+  /// Default log level (represented by `RCUTILS_LOG_SEVERITY` enum) or -1 if not specified.
   int log_level;
 
   /// Allocator used to allocate objects in this struct

--- a/rcl/src/rcl/rcl.c
+++ b/rcl/src/rcl/rcl.c
@@ -117,6 +117,12 @@ rcl_init(int argc, char const * const * argv, rcl_allocator_t allocator)
     RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME, "Failed to parse global arguments");
     goto fail;
   }
+
+  // Update the default log level if specified in arguments.
+  if (global_args->impl->log_level >= 0) {
+    rcutils_logging_set_default_logger_level(global_args->impl->log_level);
+  }
+
   rcl_atomic_store(&__rcl_instance_id, ++__rcl_next_unique_id);
   if (rcl_atomic_load_uint64_t(&__rcl_instance_id) == 0) {
     // Roll over occurred.

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -100,7 +100,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), check_valid_vs_inval
   EXPECT_TRUE(is_valid_arg("rostopic://rostopic:=rosservice"));
   EXPECT_TRUE(is_valid_arg("rostopic:///rosservice:=rostopic"));
   EXPECT_TRUE(is_valid_arg("rostopic:///foo/bar:=baz"));
-  EXPECT_TRUE(is_valid_arg("__params:=node_name"));
+  EXPECT_TRUE(is_valid_arg("__params:=file_name.yaml"));
 
   EXPECT_FALSE(is_valid_arg(":="));
   EXPECT_FALSE(is_valid_arg("foo:="));
@@ -118,7 +118,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), check_valid_vs_inval
   EXPECT_FALSE(is_valid_arg("foo:=/b}ar"));
   EXPECT_FALSE(is_valid_arg("rostopic://:=rosservice"));
   EXPECT_FALSE(is_valid_arg("rostopic::=rosservice"));
-  EXPECT_FALSE(is_valid_arg("__param:=node_name"));
+  EXPECT_FALSE(is_valid_arg("__param:=file_name.yaml"));
 
   // Setting logger level
   EXPECT_TRUE(is_valid_arg("__log:=UNSET"));

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -127,8 +127,9 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), check_valid_vs_inval
   EXPECT_TRUE(is_valid_arg("__log:=WARN"));
   EXPECT_TRUE(is_valid_arg("__log:=ERROR"));
   EXPECT_TRUE(is_valid_arg("__log:=FATAL"));
+  EXPECT_TRUE(is_valid_arg("__log:=debug"));
+  EXPECT_TRUE(is_valid_arg("__log:=Info"));
 
-  EXPECT_FALSE(is_valid_arg("__log:=Debug"));
   EXPECT_FALSE(is_valid_arg("__log:="));
   EXPECT_FALSE(is_valid_arg("__log:=foo"));
 }

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -121,17 +121,19 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), check_valid_vs_inval
   EXPECT_FALSE(is_valid_arg("__param:=file_name.yaml"));
 
   // Setting logger level
-  EXPECT_TRUE(is_valid_arg("__log:=UNSET"));
-  EXPECT_TRUE(is_valid_arg("__log:=DEBUG"));
-  EXPECT_TRUE(is_valid_arg("__log:=INFO"));
-  EXPECT_TRUE(is_valid_arg("__log:=WARN"));
-  EXPECT_TRUE(is_valid_arg("__log:=ERROR"));
-  EXPECT_TRUE(is_valid_arg("__log:=FATAL"));
-  EXPECT_TRUE(is_valid_arg("__log:=debug"));
-  EXPECT_TRUE(is_valid_arg("__log:=Info"));
+  EXPECT_TRUE(is_valid_arg("__log_level:=UNSET"));
+  EXPECT_TRUE(is_valid_arg("__log_level:=DEBUG"));
+  EXPECT_TRUE(is_valid_arg("__log_level:=INFO"));
+  EXPECT_TRUE(is_valid_arg("__log_level:=WARN"));
+  EXPECT_TRUE(is_valid_arg("__log_level:=ERROR"));
+  EXPECT_TRUE(is_valid_arg("__log_level:=FATAL"));
+  EXPECT_TRUE(is_valid_arg("__log_level:=debug"));
+  EXPECT_TRUE(is_valid_arg("__log_level:=Info"));
 
-  EXPECT_FALSE(is_valid_arg("__log:="));
   EXPECT_FALSE(is_valid_arg("__log:=foo"));
+  EXPECT_FALSE(is_valid_arg("__loglevel:=foo"));
+  EXPECT_FALSE(is_valid_arg("__log_level:="));
+  EXPECT_FALSE(is_valid_arg("__log_level:=foo"));
 }
 
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_no_args) {

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -119,6 +119,18 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), check_valid_vs_inval
   EXPECT_FALSE(is_valid_arg("rostopic://:=rosservice"));
   EXPECT_FALSE(is_valid_arg("rostopic::=rosservice"));
   EXPECT_FALSE(is_valid_arg("__param:=node_name"));
+
+  // Setting logger level
+  EXPECT_TRUE(is_valid_arg("__log:=UNSET"));
+  EXPECT_TRUE(is_valid_arg("__log:=DEBUG"));
+  EXPECT_TRUE(is_valid_arg("__log:=INFO"));
+  EXPECT_TRUE(is_valid_arg("__log:=WARN"));
+  EXPECT_TRUE(is_valid_arg("__log:=ERROR"));
+  EXPECT_TRUE(is_valid_arg("__log:=FATAL"));
+
+  EXPECT_FALSE(is_valid_arg("__log:=Debug"));
+  EXPECT_FALSE(is_valid_arg("__log:="));
+  EXPECT_FALSE(is_valid_arg("__log:=foo"));
 }
 
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_no_args) {


### PR DESCRIPTION
connects to ros2/ros2#498
requires ros2/rcutils#107

This lets you set the level of the _default_ logger (the unnamed/root logger). Loggers (e.g. rcl, or a user's node) by default don't have a given threshold level, they inherit it from the root logger, which has a level of info by default. Setting the root logger's level to debug will set all _unset_ loggers to debug. However, any loggers that have had their level _explicitly_ set to a different severity, will not be affected by this argument.

Usage (case insensitive level string)
```
$ ros2 run demo_nodes_cpp listener __log_level:=debug
[DEBUG] [rcl]: Initializing node 'listener' in namespace ''
[DEBUG] [rcl]: Using domain ID of '70'
[DEBUG] [rcl]: Using security: false
[DEBUG] [rcl]: Node initialized
[DEBUG] [rcl]: Initializing publisher for topic name 'parameter_events'
[DEBUG] [rcl]: Expanded topic name '/parameter_events'
[DEBUG] [rcl]: Publisher initialized
[DEBUG] [rcl]: Initializing subscription for topic name '/clock'
[DEBUG] [rcl]: Expanded topic name '/clock'
[DEBUG] [rcl]: Subscription initialized
[DEBUG] [rcl]: Initializing client for service name 'listener/get_parameters'
[DEBUG] [rcl]: Expanded service name '/listener/get_parameters'
[DEBUG] [rmw_fastrtps_cpp]: ************ Client Details *********
[DEBUG] [rmw_fastrtps_cpp]: Sub Topic get_parametersReply
[DEBUG] [rmw_fastrtps_cpp]: Sub Partition rr/listener
[DEBUG] [rmw_fastrtps_cpp]: Pub Topic get_parametersRequest
[DEBUG] [rmw_fastrtps_cpp]: Pub Partition rq/listener
[DEBUG] [rmw_fastrtps_cpp]: ***********
[DEBUG] [rcl]: Client initialized
...
[DEBUG] [rcl]: Waiting without timeout
[DEBUG] [rcl]: Timeout calculated based on next scheduled timer: false
^Csignal_handler(2)
[DEBUG] [rcl]: Guard condition in wait set is ready
[DEBUG] [rcl]: Finalizing subscription
[DEBUG] [rcl]: Subscription finalized
[DEBUG] [rcl]: Finalizing subscription
...
[DEBUG] [rcl]: Finalizing node
[DEBUG] [rcl]: Node finalized
```

Out of scope: log level of specific loggers (e.g. a specific node's).

The log level is applied after all argument parsing is done. I considered applying it immediately (useful if debugging argument parsing) but it would perhaps be an unexpected side effect of a function that just claims to parse arguments, so it's done in `rcl_init`, after all argument passing.

I started this before https://github.com/ros2/rcl/pull/253 was merged. After rebasing I added some changes to that work (parameter files) for consistency with the changes related to log level.