### PR TITLE
changes to support memory audit

### DIFF
--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -117,7 +117,7 @@ const char * rcl_get_secure_root(const char * node_name, const rcl_allocator_t *
   }
   char * node_secure_root = rcutils_join_path(ros_secure_root_env, node_name, *allocator);
   if (!rcutils_is_directory(node_secure_root)) {
-    free(node_secure_root);
+    allocator->deallocate(node_secure_root, allocator->state);
     return NULL;
   }
   return node_secure_root;

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -99,7 +99,7 @@ const char * rcl_create_node_logger_name(
   return node_logger_name;
 }
 
-const char * rcl_get_secure_root(const char * node_name)
+const char * rcl_get_secure_root(const char * node_name, const rcl_allocator_t * allocator)
 {
   const char * ros_secure_root_env = NULL;
   if (NULL == node_name) {
@@ -115,7 +115,7 @@ const char * rcl_get_secure_root(const char * node_name)
   if (!ros_secure_root_size) {
     return NULL;  // environment variable was empty
   }
-  char * node_secure_root = rcutils_join_path(ros_secure_root_env, node_name);
+  char * node_secure_root = rcutils_join_path(ros_secure_root_env, node_name, *allocator);
   if (!rcutils_is_directory(node_secure_root)) {
     free(node_secure_root);
     return NULL;
@@ -315,7 +315,7 @@ rcl_node_init(
     node_security_options.enforce_security = RMW_SECURITY_ENFORCEMENT_PERMISSIVE;
   } else {  // if use_security
     // File discovery magic here
-    const char * node_secure_root = rcl_get_secure_root(name);
+    const char * node_secure_root = rcl_get_secure_root(name, allocator);
     if (node_secure_root) {
       node_security_options.security_root_path = node_secure_root;
     } else {

--- a/rcl/test/rcl/test_rcl.cpp
+++ b/rcl/test/rcl/test_rcl.cpp
@@ -88,10 +88,7 @@ struct FakeTestArgv
 
   rcutils_allocator_t allocator;
   int argc;
-  std::string foo;
-  std::string bar;
   char ** argv;
-  rcutils_allocator_t allocator = rcutils_get_default_allocator();
 
 private:
   FakeTestArgv(const FakeTestArgv &) = delete;

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -193,14 +193,14 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), default_clock_instanciation) {
   EXPECT_EQ(retval, RCL_RET_OK) << rcl_get_error_string_safe();
   ASSERT_TRUE(rcl_clock_valid(&ros_clock));
 
-  rcl_clock_t * steady_clock =
-    reinterpret_cast<rcl_clock_t *>(calloc(1, sizeof(rcl_clock_t)));
+  rcl_clock_t * steady_clock = reinterpret_cast<rcl_clock_t *>(
+    allocator.zero_allocate(1, sizeof(rcl_clock_t), allocator.state));
   retval = rcl_steady_clock_init(steady_clock, &allocator);
   EXPECT_EQ(retval, RCL_RET_OK) << rcl_get_error_string_safe();
   ASSERT_TRUE(rcl_clock_valid(steady_clock));
 
-  rcl_clock_t * system_clock =
-    reinterpret_cast<rcl_clock_t *>(calloc(1, sizeof(rcl_clock_t)));
+  rcl_clock_t * system_clock = reinterpret_cast<rcl_clock_t *>(
+    allocator.zero_allocate(1, sizeof(rcl_clock_t), allocator.state));
   retval = rcl_system_clock_init(system_clock, &allocator);
   EXPECT_EQ(retval, RCL_RET_OK) << rcl_get_error_string_safe();
   ASSERT_TRUE(rcl_clock_valid(system_clock));

--- a/rcl_yaml_param_parser/test/test_parse_yaml.cpp
+++ b/rcl_yaml_param_parser/test/test_parse_yaml.cpp
@@ -17,6 +17,7 @@
 
 #include "rcl_yaml_param_parser/parser.h"
 
+#include "rcutils/allocator.h"
 #include "rcutils/error_handling.h"
 #include "rcutils/filesystem.h"
 
@@ -26,8 +27,9 @@ rcutils_allocator_t allocator = rcutils_get_default_allocator();
 TEST(test_file_parser, correct_syntax) {
   rcutils_reset_error();
   EXPECT_TRUE(rcutils_get_cwd(cur_dir, 1024));
-  char * test_path = rcutils_join_path(cur_dir, "test");
-  char * path = rcutils_join_path(test_path, "correct_config.yaml");
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  char * test_path = rcutils_join_path(cur_dir, "test", allocator);
+  char * path = rcutils_join_path(test_path, "correct_config.yaml", allocator);
   fprintf(stderr, "cur_path: %s\n", path);
   EXPECT_TRUE(rcutils_exists(path));
   rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
@@ -37,15 +39,16 @@ TEST(test_file_parser, correct_syntax) {
   EXPECT_TRUE(res);
   rcl_yaml_node_struct_print(params_hdl);
   rcl_yaml_node_struct_fini(params_hdl);
-  free(test_path);
-  free(path);
+  allocator.deallocate(test_path, allocator.state);
+  allocator.deallocate(path, allocator.state);
 }
 
 TEST(test_file_parser, multi_ns_correct_syntax) {
   rcutils_reset_error();
   EXPECT_TRUE(rcutils_get_cwd(cur_dir, 1024));
-  char * test_path = rcutils_join_path(cur_dir, "test");
-  char * path = rcutils_join_path(test_path, "multi_ns_correct.yaml");
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  char * test_path = rcutils_join_path(cur_dir, "test", allocator);
+  char * path = rcutils_join_path(test_path, "multi_ns_correct.yaml", allocator);
   fprintf(stderr, "cur_path: %s\n", path);
   EXPECT_TRUE(rcutils_exists(path));
   rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
@@ -55,15 +58,16 @@ TEST(test_file_parser, multi_ns_correct_syntax) {
   EXPECT_TRUE(res);
   rcl_yaml_node_struct_print(params_hdl);
   rcl_yaml_node_struct_fini(params_hdl);
-  free(test_path);
-  free(path);
+  allocator.deallocate(test_path, allocator.state);
+  allocator.deallocate(path, allocator.state);
 }
 
 TEST(test_file_parser, seq_map1) {
   rcutils_reset_error();
   EXPECT_TRUE(rcutils_get_cwd(cur_dir, 1024));
-  char * test_path = rcutils_join_path(cur_dir, "test");
-  char * path = rcutils_join_path(test_path, "seq_map1.yaml");
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  char * test_path = rcutils_join_path(cur_dir, "test", allocator);
+  char * path = rcutils_join_path(test_path, "seq_map1.yaml", allocator);
   fprintf(stderr, "cur_path: %s\n", path);
   EXPECT_TRUE(rcutils_exists(path));
   rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
@@ -71,15 +75,16 @@ TEST(test_file_parser, seq_map1) {
   bool res = rcl_parse_yaml_file(path, params_hdl);
   fprintf(stderr, "%s\n", rcutils_get_error_string_safe());
   EXPECT_FALSE(res);
-  free(test_path);
-  free(path);
+  allocator.deallocate(test_path, allocator.state);
+  allocator.deallocate(path, allocator.state);
 }
 
 TEST(test_file_parser, seq_map2) {
   rcutils_reset_error();
   EXPECT_TRUE(rcutils_get_cwd(cur_dir, 1024));
-  char * test_path = rcutils_join_path(cur_dir, "test");
-  char * path = rcutils_join_path(test_path, "seq_map2.yaml");
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  char * test_path = rcutils_join_path(cur_dir, "test", allocator);
+  char * path = rcutils_join_path(test_path, "seq_map2.yaml", allocator);
   fprintf(stderr, "cur_path: %s\n", path);
   EXPECT_TRUE(rcutils_exists(path));
   rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
@@ -87,15 +92,16 @@ TEST(test_file_parser, seq_map2) {
   bool res = rcl_parse_yaml_file(path, params_hdl);
   fprintf(stderr, "%s\n", rcutils_get_error_string_safe());
   EXPECT_FALSE(res);
-  free(test_path);
-  free(path);
+  allocator.deallocate(test_path, allocator.state);
+  allocator.deallocate(path, allocator.state);
 }
 
 TEST(test_file_parser, params_with_no_node) {
   rcutils_reset_error();
   EXPECT_TRUE(rcutils_get_cwd(cur_dir, 1024));
-  char * test_path = rcutils_join_path(cur_dir, "test");
-  char * path = rcutils_join_path(test_path, "params_with_no_node.yaml");
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  char * test_path = rcutils_join_path(cur_dir, "test", allocator);
+  char * path = rcutils_join_path(test_path, "params_with_no_node.yaml", allocator);
   fprintf(stderr, "cur_path: %s\n", path);
   EXPECT_TRUE(rcutils_exists(path));
   rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
@@ -103,15 +109,16 @@ TEST(test_file_parser, params_with_no_node) {
   bool res = rcl_parse_yaml_file(path, params_hdl);
   fprintf(stderr, "%s\n", rcutils_get_error_string_safe());
   EXPECT_FALSE(res);
-  free(test_path);
-  free(path);
+  allocator.deallocate(test_path, allocator.state);
+  allocator.deallocate(path, allocator.state);
 }
 
 TEST(test_file_parser, no_alias_support) {
   rcutils_reset_error();
   EXPECT_TRUE(rcutils_get_cwd(cur_dir, 1024));
-  char * test_path = rcutils_join_path(cur_dir, "test");
-  char * path = rcutils_join_path(test_path, "no_alias_support.yaml");
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  char * test_path = rcutils_join_path(cur_dir, "test", allocator);
+  char * path = rcutils_join_path(test_path, "no_alias_support.yaml", allocator);
   fprintf(stderr, "cur_path: %s\n", path);
   EXPECT_TRUE(rcutils_exists(path));
   rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
@@ -119,15 +126,16 @@ TEST(test_file_parser, no_alias_support) {
   bool res = rcl_parse_yaml_file(path, params_hdl);
   fprintf(stderr, "%s\n", rcutils_get_error_string_safe());
   EXPECT_FALSE(res);
-  free(test_path);
-  free(path);
+  allocator.deallocate(test_path, allocator.state);
+  allocator.deallocate(path, allocator.state);
 }
 
 TEST(test_file_parser, max_string_sz) {
   rcutils_reset_error();
   EXPECT_TRUE(rcutils_get_cwd(cur_dir, 1024));
-  char * test_path = rcutils_join_path(cur_dir, "test");
-  char * path = rcutils_join_path(test_path, "max_string_sz.yaml");
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  char * test_path = rcutils_join_path(cur_dir, "test", allocator);
+  char * path = rcutils_join_path(test_path, "max_string_sz.yaml", allocator);
   fprintf(stderr, "cur_path: %s\n", path);
   EXPECT_TRUE(rcutils_exists(path));
   rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
@@ -135,15 +143,16 @@ TEST(test_file_parser, max_string_sz) {
   bool res = rcl_parse_yaml_file(path, params_hdl);
   fprintf(stderr, "%s\n", rcutils_get_error_string_safe());
   EXPECT_FALSE(res);
-  free(test_path);
-  free(path);
+  allocator.deallocate(test_path, allocator.state);
+  allocator.deallocate(path, allocator.state);
 }
 
 TEST(test_file_parser, no_value1) {
   rcutils_reset_error();
   EXPECT_TRUE(rcutils_get_cwd(cur_dir, 1024));
-  char * test_path = rcutils_join_path(cur_dir, "test");
-  char * path = rcutils_join_path(test_path, "no_value1.yaml");
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  char * test_path = rcutils_join_path(cur_dir, "test", allocator);
+  char * path = rcutils_join_path(test_path, "no_value1.yaml", allocator);
   fprintf(stderr, "cur_path: %s\n", path);
   EXPECT_TRUE(rcutils_exists(path));
   rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
@@ -151,15 +160,16 @@ TEST(test_file_parser, no_value1) {
   bool res = rcl_parse_yaml_file(path, params_hdl);
   fprintf(stderr, "%s\n", rcutils_get_error_string_safe());
   EXPECT_FALSE(res);
-  free(test_path);
-  free(path);
+  allocator.deallocate(test_path, allocator.state);
+  allocator.deallocate(path, allocator.state);
 }
 
 TEST(test_file_parser, indented_ns) {
   rcutils_reset_error();
   EXPECT_TRUE(rcutils_get_cwd(cur_dir, 1024));
-  char * test_path = rcutils_join_path(cur_dir, "test");
-  char * path = rcutils_join_path(test_path, "indented_name_space.yaml");
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  char * test_path = rcutils_join_path(cur_dir, "test", allocator);
+  char * path = rcutils_join_path(test_path, "indented_name_space.yaml", allocator);
   fprintf(stderr, "cur_path: %s\n", path);
   EXPECT_TRUE(rcutils_exists(path));
   rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
@@ -167,8 +177,8 @@ TEST(test_file_parser, indented_ns) {
   bool res = rcl_parse_yaml_file(path, params_hdl);
   fprintf(stderr, "%s\n", rcutils_get_error_string_safe());
   EXPECT_FALSE(res);
-  free(test_path);
-  free(path);
+  allocator.deallocate(test_path, allocator.state);
+  allocator.deallocate(path, allocator.state);
 }
 
 int32_t main(int32_t argc, char ** argv)


### PR DESCRIPTION
This pull request makes sure that we're using `rcutils_allocator_t`, or the alias `rcl_allocator_t`, everywhere and not using `malloc`, `realloc`, `calloc`, or `free` anywhere at all.

Connects to ros2/rcutils#102