### PR TITLE
Add regression test for node:__ns remapping

### DIFF
--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -244,7 +244,7 @@ rcl_node_init(
   }
   char * remapped_namespace = NULL;
   ret = rcl_remap_node_namespace(
-    &(node->impl->options.arguments), global_args, local_namespace_,
+    &(node->impl->options.arguments), global_args, name,
     *allocator, &remapped_namespace);
   if (RCL_RET_OK != ret) {
     goto fail;

--- a/rcl/test/rcl/test_remap_integration.cpp
+++ b/rcl/test/rcl/test_remap_integration.cpp
@@ -302,4 +302,5 @@ TEST_F(CLASSNAME(TestRemapIntegrationFixture, RMW_IMPLEMENTATION), remap_using_n
   {  // Node namespace gets remapped
     EXPECT_STREQ("/new_ns", rcl_node_get_namespace(&node));
   }
+  EXPECT_EQ(RCL_RET_OK, rcl_node_fini(&node));
 }

--- a/rcl/test/rcl/test_remap_integration.cpp
+++ b/rcl/test/rcl/test_remap_integration.cpp
@@ -288,3 +288,18 @@ TEST_F(CLASSNAME(TestRemapIntegrationFixture, RMW_IMPLEMENTATION), remap_relativ
 
   EXPECT_EQ(RCL_RET_OK, rcl_node_fini(&node));
 }
+
+TEST_F(CLASSNAME(TestRemapIntegrationFixture, RMW_IMPLEMENTATION), remap_using_node_rules) {
+  int argc;
+  char ** argv;
+  SCOPE_GLOBAL_ARGS(
+    argc, argv, "process_name", "original_name:__ns:=/new_ns");
+
+  rcl_node_t node = rcl_get_zero_initialized_node();
+  rcl_node_options_t default_options = rcl_node_get_default_options();
+  ASSERT_EQ(RCL_RET_OK, rcl_node_init(&node, "original_name", "", &default_options));
+
+  {  // Node namespace gets remapped
+    EXPECT_STREQ("/new_ns", rcl_node_get_namespace(&node));
+  }
+}


### PR DESCRIPTION
Regression test for https://github.com/ros2/rcl/issues/262 to check it's not just my machine

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4745)](http://ci.ros2.org/job/ci_linux/4745/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1613)](http://ci.ros2.org/job/ci_linux-aarch64/1613/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=3933)](http://ci.ros2.org/job/ci_osx/3933/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=4805)](http://ci.ros2.org/job/ci_windows/4805/)