### PR TITLE
Fix rosidl dependencies

### DIFF
--- a/rcl_lifecycle/CMakeLists.txt
+++ b/rcl_lifecycle/CMakeLists.txt
@@ -37,13 +37,14 @@ set_source_files_properties(
 
 ### C-Library depending only on RCL
 add_library(
-  rcl_lifecycle
+  ${PROJECT_NAME}
   ${rcl_lifecycle_sources})
 
 # specific order: dependents before dependencies
 ament_target_dependencies(rcl_lifecycle
   "rcl"
   "lifecycle_msgs"
+  "rosidl_generator_c"
   "rcutils"
 )
 

--- a/rcl_lifecycle/package.xml
+++ b/rcl_lifecycle/package.xml
@@ -13,11 +13,13 @@
   <build_depend>rcl</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>rmw_implementation</build_depend>
+  <build_depend>rosidl_generator_c</build_depend>
 
   <exec_depend>lifecycle_msgs</exec_depend>
   <exec_depend>rcl</exec_depend>
   <exec_depend>rcutils</exec_depend>
   <exec_depend>rmw_implementation</exec_depend>
+  <exec_depend>rosidl_generator_c</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rcl_lifecycle/package.xml
+++ b/rcl_lifecycle/package.xml
@@ -8,19 +8,16 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
-  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <build_depend>lifecycle_msgs</build_depend>
   <build_depend>rcl</build_depend>
   <build_depend>rcutils</build_depend>
   <build_depend>rmw_implementation</build_depend>
-  <build_depend>rosidl_default_generators</build_depend>
 
   <exec_depend>lifecycle_msgs</exec_depend>
   <exec_depend>rcl</exec_depend>
   <exec_depend>rcutils</exec_depend>
   <exec_depend>rmw_implementation</exec_depend>
-  <exec_depend>rosidl_default_runtime</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
This package does not generate any message so it doesnt need to depend on the generators, instead it should link against the libraries that provide the symbols it uses (in this case rosidl_generator_c)

Connects to ros2/demos#264