### PR TITLE
remove use of uninitialized CMake var

### DIFF
--- a/rcl_lifecycle/CMakeLists.txt
+++ b/rcl_lifecycle/CMakeLists.txt
@@ -70,7 +70,6 @@ if(BUILD_TESTING)
   if(TARGET test_default_state_machine)
     target_include_directories(test_default_state_machine PUBLIC
       ${rcl_INCLUDE_DIRS}
-      ${rcl_lifecycle_INCLUDE_DIRS}
     )
     target_link_libraries(test_default_state_machine ${PROJECT_NAME})
   endif()
@@ -80,7 +79,6 @@ if(BUILD_TESTING)
   if(TARGET test_multiple_instances)
     target_include_directories(test_multiple_instances PUBLIC
       ${rcl_INCLUDE_DIRS}
-      ${rcl_lifecycle_INCLUDE_DIRS}
     )
     target_link_libraries(test_multiple_instances ${PROJECT_NAME})
   endif()
@@ -90,7 +88,6 @@ if(BUILD_TESTING)
   if(TARGET test_transition_map)
     target_include_directories(test_transition_map PUBLIC
       ${rcl_INCLUDE_DIRS}
-      ${rcl_lifecycle_INCLUDE_DIRS}
     )
     target_link_libraries(test_transition_map ${PROJECT_NAME})
   endif()


### PR DESCRIPTION
When building with --warn-uninitialized the variable is being flagged so it can be safely removed.