### PR TITLE
initialize memory before sending a message

### DIFF
--- a/rcl/test/rcl/client_fixture.cpp
+++ b/rcl/test/rcl/client_fixture.cpp
@@ -158,6 +158,7 @@ int main(int argc, char ** argv)
 
     // Initialize a request.
     test_msgs__srv__Primitives_Request client_request;
+    // TODO zero initialization necessary until https://github.com/ros2/ros2/issues/397 is implemented
     memset(&client_request, 0, sizeof(test_msgs__srv__Primitives_Request));
     test_msgs__srv__Primitives_Request__init(&client_request);
     client_request.uint8_value = 1;
@@ -179,6 +180,7 @@ int main(int argc, char ** argv)
 
     // Initialize the response owned by the client and take the response.
     test_msgs__srv__Primitives_Response client_response;
+    // TODO zero initialization necessary until https://github.com/ros2/ros2/issues/397 is implemented
     memset(&client_response, 0, sizeof(test_msgs__srv__Primitives_Response));
     test_msgs__srv__Primitives_Response__init(&client_response);
 

--- a/rcl/test/rcl/client_fixture.cpp
+++ b/rcl/test/rcl/client_fixture.cpp
@@ -158,7 +158,8 @@ int main(int argc, char ** argv)
 
     // Initialize a request.
     test_msgs__srv__Primitives_Request client_request;
-    // TODO zero initialization necessary until https://github.com/ros2/ros2/issues/397 is implemented
+    // TODO(dirk-thomas) zero initialization necessary until
+    // https://github.com/ros2/ros2/issues/397 is implemented
     memset(&client_request, 0, sizeof(test_msgs__srv__Primitives_Request));
     test_msgs__srv__Primitives_Request__init(&client_request);
     client_request.uint8_value = 1;
@@ -180,7 +181,8 @@ int main(int argc, char ** argv)
 
     // Initialize the response owned by the client and take the response.
     test_msgs__srv__Primitives_Response client_response;
-    // TODO zero initialization necessary until https://github.com/ros2/ros2/issues/397 is implemented
+    // TODO(dirk-thomas) zero initialization necessary until
+    // https://github.com/ros2/ros2/issues/397 is implemented
     memset(&client_response, 0, sizeof(test_msgs__srv__Primitives_Response));
     test_msgs__srv__Primitives_Response__init(&client_response);
 

--- a/rcl/test/rcl/client_fixture.cpp
+++ b/rcl/test/rcl/client_fixture.cpp
@@ -158,6 +158,7 @@ int main(int argc, char ** argv)
 
     // Initialize a request.
     test_msgs__srv__Primitives_Request client_request;
+    memset(&client_request, 0, sizeof(test_msgs__srv__Primitives_Request));
     test_msgs__srv__Primitives_Request__init(&client_request);
     client_request.uint8_value = 1;
     client_request.uint32_value = 2;
@@ -178,6 +179,7 @@ int main(int argc, char ** argv)
 
     // Initialize the response owned by the client and take the response.
     test_msgs__srv__Primitives_Response client_response;
+    memset(&client_response, 0, sizeof(test_msgs__srv__Primitives_Response));
     test_msgs__srv__Primitives_Response__init(&client_response);
 
     if (!wait_for_client_to_be_ready(&client, 1000, 100)) {

--- a/rcl/test/rcl/service_fixture.cpp
+++ b/rcl/test/rcl/service_fixture.cpp
@@ -125,6 +125,7 @@ int main(int argc, char ** argv)
 
     // Initialize a response.
     test_msgs__srv__Primitives_Response service_response;
+    // TODO zero initialization necessary until https://github.com/ros2/ros2/issues/397 is implemented
     memset(&service_response, 0, sizeof(test_msgs__srv__Primitives_Response));
     test_msgs__srv__Primitives_Response__init(&service_response);
     OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
@@ -140,6 +141,7 @@ int main(int argc, char ** argv)
 
     // Take the pending request.
     test_msgs__srv__Primitives_Request service_request;
+    // TODO zero initialization necessary until https://github.com/ros2/ros2/issues/397 is implemented
     memset(&service_request, 0, sizeof(test_msgs__srv__Primitives_Request));
     test_msgs__srv__Primitives_Request__init(&service_request);
     OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({

--- a/rcl/test/rcl/service_fixture.cpp
+++ b/rcl/test/rcl/service_fixture.cpp
@@ -125,6 +125,7 @@ int main(int argc, char ** argv)
 
     // Initialize a response.
     test_msgs__srv__Primitives_Response service_response;
+    memset(&service_response, 0, sizeof(test_msgs__srv__Primitives_Response));
     test_msgs__srv__Primitives_Response__init(&service_response);
     OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
       test_msgs__srv__Primitives_Response__fini(&service_response);
@@ -139,6 +140,7 @@ int main(int argc, char ** argv)
 
     // Take the pending request.
     test_msgs__srv__Primitives_Request service_request;
+    memset(&service_request, 0, sizeof(test_msgs__srv__Primitives_Request));
     test_msgs__srv__Primitives_Request__init(&service_request);
     OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
       test_msgs__srv__Primitives_Request__fini(&service_request);

--- a/rcl/test/rcl/service_fixture.cpp
+++ b/rcl/test/rcl/service_fixture.cpp
@@ -125,7 +125,8 @@ int main(int argc, char ** argv)
 
     // Initialize a response.
     test_msgs__srv__Primitives_Response service_response;
-    // TODO zero initialization necessary until https://github.com/ros2/ros2/issues/397 is implemented
+    // TODO(dirk-thomas) zero initialization necessary until
+    // https://github.com/ros2/ros2/issues/397 is implemented
     memset(&service_response, 0, sizeof(test_msgs__srv__Primitives_Response));
     test_msgs__srv__Primitives_Response__init(&service_response);
     OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
@@ -141,7 +142,8 @@ int main(int argc, char ** argv)
 
     // Take the pending request.
     test_msgs__srv__Primitives_Request service_request;
-    // TODO zero initialization necessary until https://github.com/ros2/ros2/issues/397 is implemented
+    // TODO(dirk-thomas) zero initialization necessary until
+    // https://github.com/ros2/ros2/issues/397 is implemented
     memset(&service_request, 0, sizeof(test_msgs__srv__Primitives_Request));
     test_msgs__srv__Primitives_Request__init(&service_request);
     OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({


### PR DESCRIPTION
The memory of a C message must be initialized to avoid undefined behavior.

Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5041)](https://ci.ros2.org/job/ci_linux/5041/)
After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5043)](https://ci.ros2.org/job/ci_linux/5043/)