### PR TITLE
Deallocate ret_val to avoid memery leak

### DIFF
--- a/rcl_yaml_param_parser/src/parser.c
+++ b/rcl_yaml_param_parser/src/parser.c
@@ -964,6 +964,9 @@ static rcl_ret_t parse_value(
             allocator.zero_allocate(1U, sizeof(rcutils_string_array_t), allocator.state);
           if (NULL == param_value->string_array_value) {
             RCUTILS_SAFE_FWRITE_TO_STDERR("Error allocating mem");
+            if (NULL != ret_val) {
+              allocator.deallocate(ret_val, allocator.state);
+            }
             return RCL_RET_BAD_ALLOC;
           }
         } else {


### PR DESCRIPTION
In get_value() function ret_val is allocated from rcutils_strdup when type is DATA_TYPE_STRING,

Should be deallocate in switch val_type=DATA_TYPE_STRING case.

Signed-off-by: Chris Ye <chris.ye@intel.com>