### PR TITLE
Do not check environment variables on UWP

### DIFF
--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -39,7 +39,6 @@ set(${PROJECT_NAME}_sources
   src/rcl/publisher.c
   src/rcl/rcl.c
   src/rcl/remap.c
-  src/rcl/rmw_implementation_identifier_check.c
   src/rcl/service.c
   src/rcl/subscription.c
   src/rcl/time.c
@@ -47,6 +46,10 @@ set(${PROJECT_NAME}_sources
   src/rcl/validate_topic_name.c
   src/rcl/wait.c
 )
+
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "WindowsStore")
+  list(APPEND ${PROJECT_NAME}_source src/rcl/rmw_implementation_identifier_check.c)
+endif()
 
 add_library(${PROJECT_NAME} ${${PROJECT_NAME}_sources})
 # specific order: dependents before dependencies


### PR DESCRIPTION
UWP apps can't access environment variables, so this just skips that part.