### PR TITLE
Avoid C4703 error on UWP

### DIFF
--- a/rcl_yaml_param_parser/src/parser.c
+++ b/rcl_yaml_param_parser/src/parser.c
@@ -168,7 +168,6 @@ static rcutils_ret_t add_name_to_ns(
   size_t sep_len;
   size_t tot_len;
 
-  rcutils_ret_t ret = RCUTILS_RET_OK;
   switch (namespace_type) {
     case NS_TYPE_NODE:
       cur_ns = ns_tracker->node_ns;
@@ -181,54 +180,51 @@ static rcutils_ret_t add_name_to_ns(
       sep_str = PARAMETER_NS_SEPERATOR;
       break;
     default:
-      ret = RCUTILS_RET_ERROR;
-      break;
+      return RCUTILS_RET_ERROR;
   }
 
-  if (RCUTILS_RET_OK == ret) {
-    /// Add a name to ns
-    if (NULL == name) {
-      return RCUTILS_RET_INVALID_ARGUMENT;
-    }
-    if (0U == *cur_count) {
-      cur_ns = rcutils_strdup(name, allocator);
-      if (NULL == cur_ns) {
-        return RCUTILS_RET_BAD_ALLOC;
-      }
-    } else {
-      ns_len = strlen(cur_ns);
-      name_len = strlen(name);
-      sep_len = strlen(sep_str);
-      // Check the last sep_len characters of the current NS against the separator string.
-      if (strcmp(cur_ns + ns_len - sep_len, sep_str) == 0) {
-        // Current NS already ends with the separator: don't put another separator in.
-        sep_len = 0;
-        sep_str = "";
-      }
-
-      tot_len = ns_len + sep_len + name_len + 1U;
-
-      if (tot_len > MAX_STRING_SIZE) {
-        RCUTILS_SET_ERROR_MSG("New namespace string is exceeding max string size");
-        return RCUTILS_RET_ERROR;
-      }
-      cur_ns = allocator.reallocate(cur_ns, tot_len, allocator.state);
-      if (NULL == cur_ns) {
-        return RCUTILS_RET_BAD_ALLOC;
-      }
-      memmove((cur_ns + ns_len), sep_str, sep_len);
-      memmove((cur_ns + ns_len + sep_len), name, name_len);
-      cur_ns[tot_len - 1U] = '\0';
-    }
-    *cur_count = (*cur_count + 1U);
-
-    if (NS_TYPE_NODE == namespace_type) {
-      ns_tracker->node_ns = cur_ns;
-    } else {
-      ns_tracker->parameter_ns = cur_ns;
-    }
+  /// Add a name to ns
+  if (NULL == name) {
+    return RCUTILS_RET_INVALID_ARGUMENT;
   }
-  return ret;
+  if (0U == *cur_count) {
+    cur_ns = rcutils_strdup(name, allocator);
+    if (NULL == cur_ns) {
+      return RCUTILS_RET_BAD_ALLOC;
+    }
+  } else {
+    ns_len = strlen(cur_ns);
+    name_len = strlen(name);
+    sep_len = strlen(sep_str);
+    // Check the last sep_len characters of the current NS against the separator string.
+    if (strcmp(cur_ns + ns_len - sep_len, sep_str) == 0) {
+      // Current NS already ends with the separator: don't put another separator in.
+      sep_len = 0;
+      sep_str = "";
+    }
+
+    tot_len = ns_len + sep_len + name_len + 1U;
+
+    if (tot_len > MAX_STRING_SIZE) {
+      RCUTILS_SET_ERROR_MSG("New namespace string is exceeding max string size");
+      return RCUTILS_RET_ERROR;
+    }
+    cur_ns = allocator.reallocate(cur_ns, tot_len, allocator.state);
+    if (NULL == cur_ns) {
+      return RCUTILS_RET_BAD_ALLOC;
+    }
+    memmove((cur_ns + ns_len), sep_str, sep_len);
+    memmove((cur_ns + ns_len + sep_len), name, name_len);
+    cur_ns[tot_len - 1U] = '\0';
+  }
+  *cur_count = (*cur_count + 1U);
+
+  if (NS_TYPE_NODE == namespace_type) {
+    ns_tracker->node_ns = cur_ns;
+  } else {
+    ns_tracker->parameter_ns = cur_ns;
+  }
+  return RCUTILS_RET_OK;
 }
 
 ///
@@ -245,7 +241,6 @@ static rcutils_ret_t rem_name_from_ns(
   size_t ns_len;
   size_t tot_len;
 
-  rcutils_ret_t ret = RCUTILS_RET_OK;
   switch (namespace_type) {
     case NS_TYPE_NODE:
       cur_ns = ns_tracker->node_ns;
@@ -258,50 +253,47 @@ static rcutils_ret_t rem_name_from_ns(
       sep_str = PARAMETER_NS_SEPERATOR;
       break;
     default:
-      ret = RCUTILS_RET_ERROR;
-      break;
+      return RCUTILS_RET_ERROR;
   }
 
-  if (RCUTILS_RET_OK == ret) {
-    /// Remove last name from ns
-    if (*cur_count > 0U) {
-      if (1U == *cur_count) {
-        allocator.deallocate(cur_ns, allocator.state);
-        cur_ns = NULL;
-      } else {
-        ns_len = strlen(cur_ns);
-        char * last_idx = NULL;
-        char * next_str = NULL;
-        const char * end_ptr = (cur_ns + ns_len);
-
-        next_str = strstr(cur_ns, sep_str);
-        while (NULL != next_str) {
-          if (next_str > end_ptr) {
-            RCUTILS_SET_ERROR_MSG("Internal error. Crossing arrau boundary");
-            return RCUTILS_RET_ERROR;
-          }
-          last_idx = next_str;
-          next_str = (next_str + strlen(sep_str));
-          next_str = strstr(next_str, sep_str);
-        }
-        if (NULL != last_idx) {
-          tot_len = ((size_t)(last_idx - cur_ns) + 1U);
-          cur_ns = allocator.reallocate(cur_ns, tot_len, allocator.state);
-          if (NULL == cur_ns) {
-            return RCUTILS_RET_BAD_ALLOC;
-          }
-          cur_ns[tot_len - 1U] = '\0';
-        }
-      }
-      *cur_count = (*cur_count - 1U);
-    }
-    if (NS_TYPE_NODE == namespace_type) {
-      ns_tracker->node_ns = cur_ns;
+  /// Remove last name from ns
+  if (*cur_count > 0U) {
+    if (1U == *cur_count) {
+      allocator.deallocate(cur_ns, allocator.state);
+      cur_ns = NULL;
     } else {
-      ns_tracker->parameter_ns = cur_ns;
+      ns_len = strlen(cur_ns);
+      char * last_idx = NULL;
+      char * next_str = NULL;
+      const char * end_ptr = (cur_ns + ns_len);
+
+      next_str = strstr(cur_ns, sep_str);
+      while (NULL != next_str) {
+        if (next_str > end_ptr) {
+          RCUTILS_SET_ERROR_MSG("Internal error. Crossing arrau boundary");
+          return RCUTILS_RET_ERROR;
+        }
+        last_idx = next_str;
+        next_str = (next_str + strlen(sep_str));
+        next_str = strstr(next_str, sep_str);
+      }
+      if (NULL != last_idx) {
+        tot_len = ((size_t)(last_idx - cur_ns) + 1U);
+        cur_ns = allocator.reallocate(cur_ns, tot_len, allocator.state);
+        if (NULL == cur_ns) {
+          return RCUTILS_RET_BAD_ALLOC;
+        }
+        cur_ns[tot_len - 1U] = '\0';
+      }
     }
+    *cur_count = (*cur_count - 1U);
   }
-  return ret;
+  if (NS_TYPE_NODE == namespace_type) {
+    ns_tracker->node_ns = cur_ns;
+  } else {
+    ns_tracker->parameter_ns = cur_ns;
+  }
+  return RCUTILS_RET_OK;
 }
 
 ///


### PR DESCRIPTION
MSVC with stricter flags complains that some variables might be used uninitialized. See:

https://ci.appveyor.com/project/esteve/ros2-dotnet/build/1.0.70/job/g7nnyq1huwyml1hp

https://msdn.microsoft.com/en-us/library/jj851030.aspx?f=255&MSPPError=-2147217396

Connect to ros2/rcl#280