### PR TITLE
ROS clock storage initially set to zero

### DIFF
--- a/rcl/src/rcl/time.c
+++ b/rcl/src/rcl/time.c
@@ -137,6 +137,8 @@ rcl_ros_clock_init(
   rcl_init_generic_clock(clock);
   clock->data = allocator->allocate(sizeof(rcl_ros_clock_storage_t), allocator->state);
   rcl_ros_clock_storage_t * storage = (rcl_ros_clock_storage_t *)clock->data;
+  // 0 is a special value meaning time has not been set
+  atomic_init(&(storage->current_time), 0);
   storage->active = false;
   clock->get_now = rcl_get_ros_time;
   clock->type = RCL_ROS_TIME;

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -20,6 +20,7 @@
 #include <thread>
 
 #include "osrf_testing_tools_cpp/memory_tools/memory_tools.hpp"
+#include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcl/error_handling.h"
 #include "rcl/time.h"
 
@@ -173,6 +174,19 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_init_for_clock_a
   rcl_clock_t ros_clock;
   rcl_ret_t retval = rcl_ros_clock_init(&ros_clock, &allocator);
   EXPECT_EQ(retval, RCL_RET_OK) << rcl_get_error_string_safe();
+}
+
+TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_ros_clock_initially_zero) {
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  rcl_clock_t ros_clock;
+  ASSERT_EQ(RCL_RET_OK, rcl_ros_clock_init(&ros_clock, &allocator)) << rcl_get_error_string_safe();
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    EXPECT_EQ(RCL_RET_OK, rcl_clock_fini(&ros_clock)) << rcl_get_error_string_safe();
+  });
+  ASSERT_EQ(RCL_RET_OK, rcl_enable_ros_time_override(&ros_clock)) << rcl_get_error_string_safe();
+  rcl_time_point_value_t query_now = 5;
+  ASSERT_EQ(RCL_RET_OK, rcl_clock_get_now(&ros_clock, &query_now)) << rcl_get_error_string_safe();
+  EXPECT_EQ(0, query_now);
 }
 
 TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), clock_validation) {


### PR DESCRIPTION
Since 0 means time is uninitialized, `rcl_clock_get_now()` should report 0 on a clock that has ROS time enabled but no time set. This PR makes that happen by setting the storage to zero in `rcl_ros_clock_init()`.

CI just testing RCL
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5085)](http://ci.ros2.org/job/ci_linux/5085/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1869)](http://ci.ros2.org/job/ci_linux-aarch64/1869/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4215)](http://ci.ros2.org/job/ci_osx/4215/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5066)](http://ci.ros2.org/job/ci_windows/5066/)