### PR TITLE
Clock has multiple time jump callbacks

### DIFF
--- a/rcl/include/rcl/time.h
+++ b/rcl/include/rcl/time.h
@@ -83,6 +83,10 @@ typedef struct rcl_time_jump_t
 } rcl_time_jump_t;
 
 /// Signature of a time jump callback.
+/// \param[in] time_jump A description of the jump in time.
+/// \param[in] before_jump Every jump callback is called twice: once before the clock changes and
+/// once after. This is true the first call and false the second.
+/// \param[in] user_data A pointer given at callback registration which is passed to the callback.
 typedef void (* rcl_jump_callback_t)(
   const struct rcl_time_jump_t * time_jump,
   bool before_jump,
@@ -93,9 +97,11 @@ typedef struct rcl_jump_threshold_t
 {
   /// True to call callback when the clock type changes.
   bool on_clock_change;
-  /// Minimum jump forwards to be considered exceeded, or zero to disable.
+  /// A positive duration indicating the minimum jump forwards to be considered exceeded, or zero
+  /// to disable.
   rcl_duration_t min_forward;
-  /// Minimum jump backwards to be considered exceeded, or zero to disable.
+  /// A negative duration indicating the minimum jump backwards to be considered exceeded, or zero
+  /// to disable.
   rcl_duration_t min_backward;
 } rcl_jump_threshold_t;
 

--- a/rcl/include/rcl/time.h
+++ b/rcl/include/rcl/time.h
@@ -60,38 +60,38 @@ typedef struct rcl_duration_t
   rcl_duration_value_t nanoseconds;
 } rcl_duration_t;
 
-/// An enumeration for use in rcl_time_jump_t
+/// Enumeration to describe the type of time jump.
 typedef enum rcl_clock_change_t
 {
-  /// The time type before and after the jump is ROS_TIME
+  /// The source before and after the jump is ROS_TIME.
   RCL_ROS_TIME_NO_CHANGE = 1,
-  /// The time type switched to ROS_TIME from SYSTEM_TIME
+  /// The source switched to ROS_TIME from SYSTEM_TIME.
   RCL_ROS_TIME_ACTIVATED = 2,
-  /// The time type switched to SYSTEM_TIME from ROS_TIME
+  /// The source switched to SYSTEM_TIME from ROS_TIME.
   RCL_ROS_TIME_DEACTIVATED = 3,
-  /// The time type before and after the jump is SYSTEM_TIME
+  /// The source before and after the jump is SYSTEM_TIME.
   RCL_SYSTEM_TIME_NO_CHANGE = 4
 } rcl_clock_change_t;
 
-/// A jump in the passage of time
+/// Struct to describe a jump in time.
 typedef struct rcl_time_jump_t
 {
-  /// Indicate whether the source of time changed.
+  /// Indicate whether or not the source of time changed.
   rcl_clock_change_t clock_change;
-  /// The current time minus the last time before the jump.
-  /// This is value is zero if the time jump is caused by a clock change
+  /// The new time minus the last time before the jump.
   rcl_duration_t delta;
 } rcl_time_jump_t;
 
-/// A callback called when time changes
+/// Signature of a time jump callback.
 typedef void (* rcl_jump_callback_t)(
   const struct rcl_time_jump_t * time_jump,
   bool before_jump,
   void * user_data);
 
+/// Describe the prerequisites for calling a time jump callback.
 typedef struct rcl_jump_threshold_t
 {
-  /// True to call callbacks when the clock type changes.
+  /// True to call callback when the clock type changes.
   bool on_clock_change;
   /// Minimum jump forwards to be considered exceeded, or zero to disable.
   rcl_duration_t min_forward;
@@ -99,7 +99,7 @@ typedef struct rcl_jump_threshold_t
   rcl_duration_t min_backward;
 } rcl_jump_threshold_t;
 
-/// Struct to hold added jump callbacks to make allocation code easier
+/// Struct to describe an added callback.
 typedef struct rcl_jump_callback_info_t
 {
   rcl_jump_callback_t callback;
@@ -111,7 +111,9 @@ typedef struct rcl_jump_callback_info_t
 typedef struct rcl_clock_t
 {
   enum rcl_clock_type_t type;
+  /// An array of added jump callbacks.
   rcl_jump_callback_info_t * jump_callbacks;
+  /// Number of callbacks in jump_callbacks.
   size_t num_jump_callbacks;
   rcl_ret_t (* get_now)(void * data, rcl_time_point_value_t * now);
   // void (*set_now) (rcl_time_point_value_t);
@@ -405,17 +407,16 @@ rcl_ret_t
 rcl_set_ros_time_override(
   rcl_clock_t * clock, rcl_time_point_value_t time_value);
 
-/// Add a callback to be called when time changes.
+/// Add a callback to be called when a time jump exceeds a threshold.
 /**
- * This adds a callback which will be called twice when the threshold is exceeded.
- * It will be called once before the clock is updated, and once after.
- * The callback must not be null.
- * The callback will be passed the user_data pointer when it is called.
+ * The callback is called twice when the threshold is exceeded: once before the clock is
+ * updated, and once after.
+ * The user_data pointer is passed to the callback as the last argument.
  * A callback and user_data pair must be unique among the callbacks added to a clock.
  *
- * \param[in] clock The clock to add a jump callback to.
- * \param[in] threshold Criteria indicating when to call callback.
- * \param[in] callback The callback to call.
+ * \param[in] clock A clock to add a jump callback to.
+ * \param[in] threshold Criteria indicating when to call the callback.
+ * \param[in] callback A callback to call.
  * \param[in] user_data A pointer to be passed to the callback.
  * \return `RCL_RET_OK` if the callback was added successfully, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or

--- a/rcl/include/rcl/time.h
+++ b/rcl/include/rcl/time.h
@@ -97,11 +97,11 @@ typedef struct rcl_jump_threshold_t
 {
   /// True to call callback when the clock type changes.
   bool on_clock_change;
-  /// A positive duration indicating the minimum magnitude of a jump forwards to be considered
-  /// exceeded, or zero to disable.
+  /// A positive duration indicating the minimum jump forwards to be considered exceeded, or zero
+  /// to disable.
   rcl_duration_t min_forward;
-  /// A positive duration indicating the minimum magnitude of a jump backwards to be considered
-  /// exceeded, or zero to disable.
+  /// A negative duration indicating the minimum jump backwards to be considered exceeded, or zero
+  /// to disable.
   rcl_duration_t min_backward;
 } rcl_jump_threshold_t;
 

--- a/rcl/include/rcl/time.h
+++ b/rcl/include/rcl/time.h
@@ -97,12 +97,11 @@ typedef struct rcl_jump_threshold_t
 {
   /// True to call callback when the clock type changes.
   bool on_clock_change;
-  /// A positive duration indicating the minimum jump forwards to be considered exceeded, or zero
-  /// to disable.
-  /// The struct is invalid if this value is negative.
+  /// A positive duration indicating the minimum magnitude of a jump forwards to be considered
+  /// exceeded, or zero to disable.
   rcl_duration_t min_forward;
-  /// The minimum jump backwards to be considered exceeded, or zero to disable.
-  /// The duration may be positive or negative; the absolute value will be used.
+  /// A positive duration indicating the minimum magnitude of a jump backwards to be considered
+  /// exceeded, or zero to disable.
   rcl_duration_t min_backward;
 } rcl_jump_threshold_t;
 

--- a/rcl/include/rcl/time.h
+++ b/rcl/include/rcl/time.h
@@ -99,9 +99,11 @@ typedef struct rcl_jump_threshold_t
   bool on_clock_change;
   /// A positive duration indicating the minimum jump forwards to be considered exceeded, or zero
   /// to disable.
+  /// The struct is invalid if this value is negative.
   rcl_duration_t min_forward;
   /// A negative duration indicating the minimum jump backwards to be considered exceeded, or zero
   /// to disable.
+  /// The struct is invalid if this value is positive.
   rcl_duration_t min_backward;
 } rcl_jump_threshold_t;
 

--- a/rcl/include/rcl/time.h
+++ b/rcl/include/rcl/time.h
@@ -101,9 +101,8 @@ typedef struct rcl_jump_threshold_t
   /// to disable.
   /// The struct is invalid if this value is negative.
   rcl_duration_t min_forward;
-  /// A negative duration indicating the minimum jump backwards to be considered exceeded, or zero
-  /// to disable.
-  /// The struct is invalid if this value is positive.
+  /// The minimum jump backwards to be considered exceeded, or zero to disable.
+  /// The duration may be positive or negative; the absolute value will be used.
   rcl_duration_t min_backward;
 } rcl_jump_threshold_t;
 

--- a/rcl/src/rcl/time.c
+++ b/rcl/src/rcl/time.c
@@ -163,11 +163,11 @@ rcl_ros_clock_fini(
   rcl_clock_t * clock)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  _rcl_clock_generic_fini(clock);
   if (clock->type != RCL_ROS_TIME) {
     RCL_SET_ERROR_MSG("clock not of type RCL_ROS_TIME", rcl_get_default_allocator());
     return RCL_RET_ERROR;
   }
+  _rcl_clock_generic_fini(clock);
   if (!clock->data) {
     RCL_SET_ERROR_MSG("clock data invalid", rcl_get_default_allocator());
     return RCL_RET_ERROR;
@@ -195,11 +195,11 @@ rcl_steady_clock_fini(
   rcl_clock_t * clock)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  _rcl_clock_generic_fini(clock);
   if (clock->type != RCL_STEADY_TIME) {
     RCL_SET_ERROR_MSG("clock not of type RCL_STEADY_TIME", rcl_get_default_allocator());
     return RCL_RET_ERROR;
   }
+  _rcl_clock_generic_fini(clock);
   return RCL_RET_OK;
 }
 
@@ -222,11 +222,11 @@ rcl_system_clock_fini(
   rcl_clock_t * clock)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  _rcl_clock_generic_fini(clock);
   if (clock->type != RCL_SYSTEM_TIME) {
     RCL_SET_ERROR_MSG("clock not of type RCL_SYSTEM_TIME", rcl_get_default_allocator());
     return RCL_RET_ERROR;
   }
+  _rcl_clock_generic_fini(clock);
   return RCL_RET_OK;
 }
 

--- a/rcl/src/rcl/time.c
+++ b/rcl/src/rcl/time.c
@@ -399,7 +399,7 @@ rcl_clock_add_jump_callback(
 {
   // Make sure parameters are valid
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  RCL_CHECK_ALLOCATOR_WITH_MSG(clock->allocator, "invalid allocator",
+  RCL_CHECK_ALLOCATOR_WITH_MSG(&(clock->allocator), "invalid allocator",
     return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(callback, RCL_RET_INVALID_ARGUMENT, clock->allocator);
   if (threshold.min_forward.nanoseconds < 0) {
@@ -441,7 +441,7 @@ rcl_clock_remove_jump_callback(
 {
   // Make sure parameters are valid
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
-  RCL_CHECK_ALLOCATOR_WITH_MSG(clock->allocator, "invalid allocator",
+  RCL_CHECK_ALLOCATOR_WITH_MSG(&(clock->allocator), "invalid allocator",
     return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(callback, RCL_RET_INVALID_ARGUMENT, clock->allocator);
 

--- a/rcl/src/rcl/time.c
+++ b/rcl/src/rcl/time.c
@@ -405,9 +405,10 @@ rcl_clock_add_jump_callback(
   if (threshold.min_forward.nanoseconds < 0) {
     RCL_SET_ERROR_MSG("forward jump theshold must be positive", clock->allocator);
     return RCL_RET_INVALID_ARGUMENT;
-  } else if (threshold.min_backward.nanoseconds > 0) {
-    RCL_SET_ERROR_MSG("backward jump theshold must be negative", clock->allocator);
-    return RCL_RET_INVALID_ARGUMENT;
+  }
+  if (threshold.min_backward.nanoseconds > 0) {
+    // store threshold with a negative value for convenience
+    threshold.min_backward.nanoseconds *= -1;
   }
 
   // Callback/user_data pair must be unique

--- a/rcl/src/rcl/time.c
+++ b/rcl/src/rcl/time.c
@@ -376,7 +376,7 @@ rcl_set_ros_time_override(
   rcl_time_jump_t time_jump;
   rcl_ros_clock_storage_t * storage = (rcl_ros_clock_storage_t *)clock->data;
   if (storage->active) {
-    time_jump.clock_change = storage->active ? RCL_ROS_TIME_NO_CHANGE : RCL_SYSTEM_TIME_NO_CHANGE;
+    time_jump.clock_change = RCL_ROS_TIME_NO_CHANGE;
     rcl_time_point_value_t current_time;
     rcl_ret_t ret = rcl_get_ros_time(storage, &current_time);
     if (RCL_RET_OK != ret) {
@@ -397,8 +397,10 @@ rcl_clock_add_jump_callback(
   rcl_clock_t * clock, rcl_jump_threshold_t threshold, rcl_jump_callback_t callback,
   void * user_data)
 {
-  // Make sure parameters are legal
+  // Make sure parameters are valid
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
+  RCL_CHECK_ALLOCATOR_WITH_MSG(clock->allocator, "invalid allocator",
+    return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(callback, RCL_RET_INVALID_ARGUMENT, clock->allocator);
   if (threshold.min_forward.nanoseconds < 0) {
     RCL_SET_ERROR_MSG("forward jump theshold must be positive", clock->allocator);
@@ -437,8 +439,10 @@ rcl_ret_t
 rcl_clock_remove_jump_callback(
   rcl_clock_t * clock, rcl_jump_callback_t callback, void * user_data)
 {
-  // Make sure parameters are legal
+  // Make sure parameters are valid
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT, rcl_get_default_allocator());
+  RCL_CHECK_ALLOCATOR_WITH_MSG(clock->allocator, "invalid allocator",
+    return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(callback, RCL_RET_INVALID_ARGUMENT, clock->allocator);
 
   // Delete callback if found, moving all callbacks after back one

--- a/rcl/src/rcl/time.c
+++ b/rcl/src/rcl/time.c
@@ -276,7 +276,6 @@ _rcl_clock_call_callbacks(
     if (
       (is_clock_change && info->threshold.on_clock_change) ||
       (time_jump->delta.nanoseconds < 0 &&
-      // Note: min_backward was stored as a negative duration
       time_jump->delta.nanoseconds <= info->threshold.min_backward.nanoseconds) ||
       (time_jump->delta.nanoseconds > 0 &&
       time_jump->delta.nanoseconds >= info->threshold.min_forward.nanoseconds))
@@ -404,11 +403,11 @@ rcl_clock_add_jump_callback(
     return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(callback, RCL_RET_INVALID_ARGUMENT, clock->allocator);
   if (threshold.min_forward.nanoseconds < 0) {
-    RCL_SET_ERROR_MSG("forward jump theshold must be positive", clock->allocator);
+    RCL_SET_ERROR_MSG("forward jump theshold must be positive or zero", clock->allocator);
     return RCL_RET_INVALID_ARGUMENT;
   }
-  if (threshold.min_backward.nanoseconds < 0) {
-    RCL_SET_ERROR_MSG("backward jump theshold must be positive", clock->allocator);
+  if (threshold.min_backward.nanoseconds > 0) {
+    RCL_SET_ERROR_MSG("backward jump theshold must be negative or zero", clock->allocator);
     return RCL_RET_INVALID_ARGUMENT;
   }
 
@@ -432,8 +431,6 @@ rcl_clock_add_jump_callback(
   clock->jump_callbacks = callbacks;
   clock->jump_callbacks[clock->num_jump_callbacks].callback = callback;
   clock->jump_callbacks[clock->num_jump_callbacks].threshold = threshold;
-  // store backwards jump threshold with a negative value for convenience
-  clock->jump_callbacks[clock->num_jump_callbacks].threshold.min_backward.nanoseconds *= -1;
   clock->jump_callbacks[clock->num_jump_callbacks].user_data = user_data;
   ++(clock->num_jump_callbacks);
   return RCL_RET_OK;

--- a/rcl/src/rcl/time.c
+++ b/rcl/src/rcl/time.c
@@ -403,11 +403,11 @@ rcl_clock_add_jump_callback(
     return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(callback, RCL_RET_INVALID_ARGUMENT, clock->allocator);
   if (threshold.min_forward.nanoseconds < 0) {
-    RCL_SET_ERROR_MSG("forward jump theshold must be positive or zero", clock->allocator);
+    RCL_SET_ERROR_MSG("forward jump threshold must be positive or zero", clock->allocator);
     return RCL_RET_INVALID_ARGUMENT;
   }
   if (threshold.min_backward.nanoseconds > 0) {
-    RCL_SET_ERROR_MSG("backward jump theshold must be negative or zero", clock->allocator);
+    RCL_SET_ERROR_MSG("backward jump threshold must be negative or zero", clock->allocator);
     return RCL_RET_INVALID_ARGUMENT;
   }
 

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -547,7 +547,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_backward_jump_callbacks) 
   rcl_jump_threshold_t threshold;
   threshold.on_clock_change = false;
   threshold.min_forward.nanoseconds = 0;
-  threshold.min_backward.nanoseconds = 1;
+  threshold.min_backward.nanoseconds = -1;
   ASSERT_EQ(RCL_RET_OK,
     rcl_clock_add_jump_callback(ros_clock, threshold, clock_callback, &time_jump)) <<
     rcl_get_error_string_safe();

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -383,13 +383,13 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_clock_change_callbacks) {
     rcl_get_error_string_safe();
   reset_callback_triggers();
 
-  // Query it to do something different. no changes expected
+  // Query time, no changes expected.
   ret = rcl_clock_get_now(ros_clock, &query_now);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   EXPECT_FALSE(pre_callback_called);
   EXPECT_FALSE(post_callback_called);
 
-  // enable
+  // Clock change callback called when ROS time is enabled
   ret = rcl_enable_ros_time_override(ros_clock);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   EXPECT_TRUE(pre_callback_called);
@@ -397,12 +397,26 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_clock_change_callbacks) {
   EXPECT_EQ(RCL_ROS_TIME_ACTIVATED, time_jump.clock_change);
   reset_callback_triggers();
 
-  // disable
+  // Clock change callback not called because ROS time is already enabled.
+  ret = rcl_enable_ros_time_override(ros_clock);
+  EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
+  EXPECT_FALSE(pre_callback_called);
+  EXPECT_FALSE(post_callback_called);
+  reset_callback_triggers();
+
+  // Clock change callback called when ROS time is disabled
   ret = rcl_disable_ros_time_override(ros_clock);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
   EXPECT_TRUE(pre_callback_called);
   EXPECT_TRUE(post_callback_called);
   EXPECT_EQ(RCL_ROS_TIME_DEACTIVATED, time_jump.clock_change);
+  reset_callback_triggers();
+
+  // Clock change callback not called because ROS time is already disabled.
+  ret = rcl_disable_ros_time_override(ros_clock);
+  EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string_safe();
+  EXPECT_FALSE(pre_callback_called);
+  EXPECT_FALSE(post_callback_called);
   reset_callback_triggers();
 
   EXPECT_EQ(RCL_RET_OK, rcl_clock_fini(ros_clock));

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -547,7 +547,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_backward_jump_callbacks) 
   rcl_jump_threshold_t threshold;
   threshold.on_clock_change = false;
   threshold.min_forward.nanoseconds = 0;
-  threshold.min_backward.nanoseconds = -1;
+  threshold.min_backward.nanoseconds = 1;
   ASSERT_EQ(RCL_RET_OK,
     rcl_clock_add_jump_callback(ros_clock, threshold, clock_callback, &time_jump)) <<
     rcl_get_error_string_safe();

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -602,8 +602,8 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_clock_add_jump_callback) {
 
   rcl_jump_threshold_t threshold;
   threshold.on_clock_change = false;
-  threshold.min_forward.nanoseconds = 0u;
-  threshold.min_backward.nanoseconds = 0u;
+  threshold.min_forward.nanoseconds = 0;
+  threshold.min_backward.nanoseconds = 0;
   rcl_jump_callback_t cb = reinterpret_cast<rcl_jump_callback_t>(0xBEEF);
   void * user_data = reinterpret_cast<void *>(0xCAFE);
 
@@ -638,8 +638,8 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_clock_remove_jump_callback) {
 
   rcl_jump_threshold_t threshold;
   threshold.on_clock_change = false;
-  threshold.min_forward.nanoseconds = 0u;
-  threshold.min_backward.nanoseconds = 0u;
+  threshold.min_forward.nanoseconds = 0;
+  threshold.min_backward.nanoseconds = 0;
   rcl_jump_callback_t cb = reinterpret_cast<rcl_jump_callback_t>(0xBEEF);
   void * user_data1 = reinterpret_cast<void *>(0xCAFE);
   void * user_data2 = reinterpret_cast<void *>(0xFACE);


### PR DESCRIPTION
~~In review because it seems to work, but I haven't self-reviewed yet so there might be obvious issues.~~

This allows multiple time jump callbacks to be registered on a clock. It replaces `pre_update` and `post_update` with a list of callbacks that get called both before and after a jump when a threshold is exceeded.

The reason for doing multiple callbacks here and not in an executor in a client library is a PR (todo create PR and link here) where multiple `rcl_timer_t` could need to register jump callbacks on the same ROS clock.

CI only testing RCL because I don't think anything uses clock jump callbacks yet
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5087)](http://ci.ros2.org/job/ci_linux/5087/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1871)](http://ci.ros2.org/job/ci_linux-aarch64/1871/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4217)](http://ci.ros2.org/job/ci_osx/4217/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5068)](http://ci.ros2.org/job/ci_windows/5068/)
