### PR TITLE
Check if pointers are null before calling memset

### DIFF
--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -211,21 +211,25 @@ rcl_wait_set_get_allocator(const rcl_wait_set_t * wait_set, rcl_allocator_t * al
 
 #define SET_CLEAR(Type) \
   do { \
-    memset( \
-      (void *)wait_set->Type ## s, \
-      0, \
-      sizeof(rcl_ ## Type ## _t *) * wait_set->size_of_ ## Type ## s); \
-    wait_set->impl->Type ## _index = 0; \
+    if (NULL != wait_set->Type ## s) { \
+      memset( \
+        (void *)wait_set->Type ## s, \
+        0, \
+        sizeof(rcl_ ## Type ## _t *) * wait_set->size_of_ ## Type ## s); \
+      wait_set->impl->Type ## _index = 0; \
+    } \
   } while (false)
 
 #define SET_CLEAR_RMW(Type, RMWStorage, RMWCount) \
   do { \
-    /* Also clear the rmw storage. */ \
-    memset( \
-      wait_set->impl->RMWStorage, \
-      0, \
-      sizeof(void *) * wait_set->impl->RMWCount); \
-    wait_set->impl->RMWCount = 0; \
+    if (NULL != wait_set->impl->RMWStorage) { \
+      /* Also clear the rmw storage. */ \
+      memset( \
+        wait_set->impl->RMWStorage, \
+        0, \
+        sizeof(void *) * wait_set->impl->RMWCount); \
+      wait_set->impl->RMWCount = 0; \
+    } \
   } while (false)
 
 #define SET_RESIZE(Type, ExtraDealloc, ExtraRealloc) \


### PR DESCRIPTION
`rcl_wait_set_clear()` calls memset with a null pointer when a wait set does not have any entities of one type. Ubsan reports this as undefined behavior. This PR adds a check for `NULL`.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5127)](http://ci.ros2.org/job/ci_linux/5127/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1908)](http://ci.ros2.org/job/ci_linux-aarch64/1908/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4251)](http://ci.ros2.org/job/ci_osx/4251/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5108)](http://ci.ros2.org/job/ci_windows/5108/)