### PR TITLE
ensure that timer period is non-negative

### DIFF
--- a/rcl/include/rcl/timer.h
+++ b/rcl/include/rcl/timer.h
@@ -81,7 +81,8 @@ rcl_get_zero_initialized_timer(void);
  * The clock handle must be a pointer to an initialized rcl_clock_t struct.
  * The life time of the clock must exceed the life time of the timer.
  *
- * The period is a duration (rather an absolute time in the future).
+ * The period is a non-negative duration (rather an absolute time in the
+ * future).
  * If the period is `0` then it will always be ready.
  *
  * The callback is an optional argument.

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -60,6 +60,10 @@ rcl_timer_init(
   RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(timer, RCL_RET_INVALID_ARGUMENT, allocator);
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT, allocator);
+  if (period < 0) {
+    RCL_SET_ERROR_MSG("timer period must be non-negative", allocator);
+    return RCL_RET_INVALID_ARGUMENT;
+  }
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Initializing timer with period: %" PRIu64 "ns", period)
   if (timer->impl) {
     RCL_SET_ERROR_MSG("timer already initailized, or memory was uninitialized", allocator);


### PR DESCRIPTION
Follow up of https://github.com/ros2/rcl/pull/208#discussion_r215797370.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5146)](http://ci.ros2.org/job/ci_linux/5146/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=1923)](http://ci.ros2.org/job/ci_linux-aarch64/1923/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4271)](http://ci.ros2.org/job/ci_osx/4271/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5125)](http://ci.ros2.org/job/ci_windows/5125/)
  * Unrelated test failure: ros2/rmw_fastrtps#226