### PR TITLE
[yaml parser] Fix FQN=//node_name when ns is /

### DIFF
--- a/rcl_yaml_param_parser/src/parser.c
+++ b/rcl_yaml_param_parser/src/parser.c
@@ -187,11 +187,13 @@ static rcl_ret_t add_name_to_ns(
       ns_len = strlen(cur_ns);
       name_len = strlen(name);
       sep_len = strlen(sep_str);
-      if (ns_len == sep_len) {
-        // Current NS is only the separator: don't put another separator in.
+      // Check the last sep_len characters of the current NS against the separator string.
+      if (strcmp(cur_ns + ns_len - sep_len, sep_str) == 0) {
+        // Current NS already ends with the separator: don't put another separator in.
         sep_len = 0;
         sep_str = "";
       }
+
       tot_len = ns_len + sep_len + name_len + 1U;
 
       if (tot_len > MAX_STRING_SIZE) {

--- a/rcl_yaml_param_parser/src/parser.c
+++ b/rcl_yaml_param_parser/src/parser.c
@@ -187,7 +187,12 @@ static rcl_ret_t add_name_to_ns(
       ns_len = strlen(cur_ns);
       name_len = strlen(name);
       sep_len = strlen(sep_str);
-      tot_len = ns_len + name_len + sep_len + 1U;
+      if (ns_len == sep_len) {
+        // Current NS is only the separator: don't put another separator in.
+        sep_len = 0;
+        sep_str = "";
+      }
+      tot_len = ns_len + sep_len + name_len + 1U;
 
       if (tot_len > MAX_STRING_SIZE) {
         RCL_SET_ERROR_MSG("New namespace string is exceeding max string size",

--- a/rcl_yaml_param_parser/test/root_ns.yaml
+++ b/rcl_yaml_param_parser/test/root_ns.yaml
@@ -1,0 +1,7 @@
+# config/test_yaml
+---
+
+/:
+  my_node:
+    ros__parameters:
+      param_name: 'value'


### PR DESCRIPTION
Consider the parameters file:

```
/:
    talker:
        ros__parameters:
            some_int: 42
```

Without this PR, the parameters are stored under the FQN of `//talker`, so passing the file to a node with `ros2 run demo_nodes_cpp talker __params:=demo_parameters.yaml` will not set the parameters on the node (`ros2 param list /talker` is empty).

With this PR, `ros2 param list /talker` returns the parameter `some_int` as expected.

---

Without this change, the parameter file will work if the root namespace is left out completely, but in some cases the user may want to specify explicitly that it is in the root namespace. (I am doing that in https://github.com/ros2/launch/pull/138/files#diff-d78062ac1f3a77c95190e470302b7e69R237 where I write the namespace to a file without considering if it is `/ns` or just `/`).