### PR TITLE
[lifecycle] Add transitions from some states to shutting_down

### DIFF
--- a/rcl_lifecycle/src/default_state_machine.c
+++ b/rcl_lifecycle/src/default_state_machine.c
@@ -503,6 +503,54 @@ _register_transitions(
     }
   }
 
+  // register transition from generic (actually active) to shuttingdown
+  {
+    rcl_lifecycle_transition_t rcl_transition_generic_active_shutdown = {
+      rcl_lifecycle_shutdown_label,
+      lifecycle_msgs__msg__Transition__TRANSITION_SHUTDOWN,
+      active_state, shuttingdown_state
+    };
+    ret = rcl_lifecycle_register_transition(
+      transition_map,
+      rcl_transition_generic_active_shutdown,
+      allocator);
+    if (ret != RCL_RET_OK) {
+      return ret;
+    }
+  }
+
+  // register transition from generic (actually inactive) to shuttingdown
+  {
+    rcl_lifecycle_transition_t rcl_transition_generic_inactive_shutdown = {
+      rcl_lifecycle_shutdown_label,
+      lifecycle_msgs__msg__Transition__TRANSITION_SHUTDOWN,
+      inactive_state, shuttingdown_state
+    };
+    ret = rcl_lifecycle_register_transition(
+      transition_map,
+      rcl_transition_generic_inactive_shutdown,
+      allocator);
+    if (ret != RCL_RET_OK) {
+      return ret;
+    }
+  }
+
+  // register transition from generic (actually unconfigured) to shuttingdown
+  {
+    rcl_lifecycle_transition_t rcl_transition_generic_unconfigured_shutdown = {
+      rcl_lifecycle_shutdown_label,
+      lifecycle_msgs__msg__Transition__TRANSITION_SHUTDOWN,
+      unconfigured_state, shuttingdown_state
+    };
+    ret = rcl_lifecycle_register_transition(
+      transition_map,
+      rcl_transition_generic_unconfigured_shutdown,
+      allocator);
+    if (ret != RCL_RET_OK) {
+      return ret;
+    }
+  }
+
   // register transition from unconfigured to shuttingdown
   {
     rcl_lifecycle_transition_t rcl_transition_unconfigured_shutdown = {

--- a/rcl_lifecycle/test/test_default_state_machine.cpp
+++ b/rcl_lifecycle/test/test_default_state_machine.cpp
@@ -175,6 +175,114 @@ TEST_F(TestDefaultStateMachine, default_sequence) {
     rcl_lifecycle_state_machine_fini(&state_machine, this->node_ptr, this->allocator));
 }
 
+TEST_F(TestDefaultStateMachine, generic_shutdown_on_unconfigured) {
+  rcl_ret_t ret;
+
+  rcl_lifecycle_state_machine_t state_machine = rcl_lifecycle_get_zero_initialized_state_machine();
+  ret = rcl_lifecycle_init_default_state_machine(&state_machine, this->allocator);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
+
+  test_trigger_transition(
+    &state_machine,
+    lifecycle_msgs__msg__Transition__TRANSITION_SHUTDOWN,
+    lifecycle_msgs__msg__State__PRIMARY_STATE_UNCONFIGURED,
+    lifecycle_msgs__msg__State__TRANSITION_STATE_SHUTTINGDOWN);
+
+  test_trigger_transition(
+    &state_machine,
+    lifecycle_msgs__msg__Transition__TRANSITION_ON_SHUTDOWN_SUCCESS,
+    lifecycle_msgs__msg__State__TRANSITION_STATE_SHUTTINGDOWN,
+    lifecycle_msgs__msg__State__PRIMARY_STATE_FINALIZED);
+
+
+  EXPECT_EQ(RCL_RET_OK,
+    rcl_lifecycle_state_machine_fini(&state_machine, this->node_ptr, this->allocator));
+}
+
+TEST_F(TestDefaultStateMachine, generic_shutdown_on_inactive) {
+  rcl_ret_t ret;
+
+  rcl_lifecycle_state_machine_t state_machine = rcl_lifecycle_get_zero_initialized_state_machine();
+  ret = rcl_lifecycle_init_default_state_machine(&state_machine, this->allocator);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
+
+  test_trigger_transition(
+    &state_machine,
+    lifecycle_msgs__msg__Transition__TRANSITION_CONFIGURE,
+    lifecycle_msgs__msg__State__PRIMARY_STATE_UNCONFIGURED,
+    lifecycle_msgs__msg__State__TRANSITION_STATE_CONFIGURING);
+
+  test_trigger_transition(
+    &state_machine,
+    lifecycle_msgs__msg__Transition__TRANSITION_ON_CONFIGURE_SUCCESS,
+    lifecycle_msgs__msg__State__TRANSITION_STATE_CONFIGURING,
+    lifecycle_msgs__msg__State__PRIMARY_STATE_INACTIVE);
+
+  test_trigger_transition(
+    &state_machine,
+    lifecycle_msgs__msg__Transition__TRANSITION_SHUTDOWN,
+    lifecycle_msgs__msg__State__PRIMARY_STATE_INACTIVE,
+    lifecycle_msgs__msg__State__TRANSITION_STATE_SHUTTINGDOWN);
+
+  test_trigger_transition(
+    &state_machine,
+    lifecycle_msgs__msg__Transition__TRANSITION_ON_SHUTDOWN_SUCCESS,
+    lifecycle_msgs__msg__State__TRANSITION_STATE_SHUTTINGDOWN,
+    lifecycle_msgs__msg__State__PRIMARY_STATE_FINALIZED);
+
+
+  EXPECT_EQ(RCL_RET_OK,
+    rcl_lifecycle_state_machine_fini(&state_machine, this->node_ptr, this->allocator));
+}
+
+TEST_F(TestDefaultStateMachine, generic_shutdown_on_active) {
+  rcl_ret_t ret;
+
+  rcl_lifecycle_state_machine_t state_machine = rcl_lifecycle_get_zero_initialized_state_machine();
+  ret = rcl_lifecycle_init_default_state_machine(&state_machine, this->allocator);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string_safe();
+
+  test_trigger_transition(
+    &state_machine,
+    lifecycle_msgs__msg__Transition__TRANSITION_CONFIGURE,
+    lifecycle_msgs__msg__State__PRIMARY_STATE_UNCONFIGURED,
+    lifecycle_msgs__msg__State__TRANSITION_STATE_CONFIGURING);
+
+  test_trigger_transition(
+    &state_machine,
+    lifecycle_msgs__msg__Transition__TRANSITION_ON_CONFIGURE_SUCCESS,
+    lifecycle_msgs__msg__State__TRANSITION_STATE_CONFIGURING,
+    lifecycle_msgs__msg__State__PRIMARY_STATE_INACTIVE);
+
+  test_trigger_transition(
+    &state_machine,
+    lifecycle_msgs__msg__Transition__TRANSITION_ACTIVATE,
+    lifecycle_msgs__msg__State__PRIMARY_STATE_INACTIVE,
+    lifecycle_msgs__msg__State__TRANSITION_STATE_ACTIVATING);
+
+  test_trigger_transition(
+    &state_machine,
+    lifecycle_msgs__msg__Transition__TRANSITION_ON_ACTIVATE_SUCCESS,
+    lifecycle_msgs__msg__State__TRANSITION_STATE_ACTIVATING,
+    lifecycle_msgs__msg__State__PRIMARY_STATE_ACTIVE);
+
+  test_trigger_transition(
+    &state_machine,
+    lifecycle_msgs__msg__Transition__TRANSITION_SHUTDOWN,
+    lifecycle_msgs__msg__State__PRIMARY_STATE_ACTIVE,
+    lifecycle_msgs__msg__State__TRANSITION_STATE_SHUTTINGDOWN);
+
+  test_trigger_transition(
+    &state_machine,
+    lifecycle_msgs__msg__Transition__TRANSITION_ON_SHUTDOWN_SUCCESS,
+    lifecycle_msgs__msg__State__TRANSITION_STATE_SHUTTINGDOWN,
+    lifecycle_msgs__msg__State__PRIMARY_STATE_FINALIZED);
+
+  EXPECT_EQ(RCL_RET_OK,
+    rcl_lifecycle_state_machine_fini(&state_machine, this->node_ptr, this->allocator));
+}
+
+
 TEST_F(TestDefaultStateMachine, wrong_default_sequence) {
   rcl_ret_t ret;
 


### PR DESCRIPTION
Hi all,

If #309 is considered a bug, this PR fixed it. Otherwise, discard it.

TRANSITION_SHUTDOWN was specfied in messages, but this transition was not implemented.

http://design.ros2.org/articles/node_lifecycle.html specifies transitions from Unconfigured, Inactive and Active transitions to Shuttingdown state. This PR provides these transitions.

Best