### PR TITLE
[rcl_action] Implement init/fini functions for types

### DIFF
--- a/rcl_action/CMakeLists.txt
+++ b/rcl_action/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(test_compile_headers
 
 set(rcl_action_sources
   src/${PROJECT_NAME}/goal_state_machine.c
+  src/${PROJECT_NAME}/types.c
 )
 
 set_source_files_properties(
@@ -79,6 +80,18 @@ if(BUILD_TESTING)
       ${rcl_INCLUDE_DIRS}
     )
     target_link_libraries(test_goal_state_machine
+      ${PROJECT_NAME}
+    )
+  endif()
+  ament_add_gtest(test_types
+    test/rcl_action/test_types.cpp
+  )
+  if(TARGET test_types)
+    target_include_directories(test_types PUBLIC
+      include
+      ${rcl_INCLUDE_DIRS}
+    )
+    target_link_libraries(test_types
       ${PROJECT_NAME}
     )
   endif()

--- a/rcl_action/CMakeLists.txt
+++ b/rcl_action/CMakeLists.txt
@@ -41,16 +41,17 @@ set_source_files_properties(
   PROPERTIES language "C"
 )
 
-add_library(
-  ${PROJECT_NAME}
+add_library(${PROJECT_NAME}
   ${rcl_action_sources}
+)
+target_link_libraries(${PROJECT_NAME}
+  ${rcl_LIBRARIES}
 )
 
 ament_target_dependencies(${PROJECT_NAME}
   "rcl"
   "action_msgs"
 )
-
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(${PROJECT_NAME} PRIVATE "RCL_ACTION_BUILDING_DLL")

--- a/rcl_action/src/rcl_action/types.c
+++ b/rcl_action/src/rcl_action/types.c
@@ -1,0 +1,132 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rcl_action/types.h"
+
+#include "rcl/error_handling.h"
+
+
+rcl_action_goal_info_t
+rcl_action_get_zero_initialized_goal_info(void)
+{
+  static rcl_action_goal_info_t goal_info = {
+    {0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u},
+    {0, 0u}
+  };
+  return goal_info;
+}
+
+rcl_action_goal_status_array_t
+rcl_action_get_zero_initialized_goal_status_array(void)
+{
+  static rcl_action_goal_status_array_t status_array;
+  return status_array;
+}
+
+rcl_action_cancel_request_t
+rcl_action_get_zero_initialized_cancel_request(void)
+{
+  static rcl_action_cancel_request_t request;
+  request.goal_info = rcl_action_get_zero_initialized_goal_info();
+  return request;
+}
+
+rcl_action_cancel_response_t
+rcl_action_get_zero_initialized_cancel_response(void)
+{
+  static rcl_action_cancel_response_t response;
+  return response;
+}
+
+rcl_ret_t
+rcl_action_goal_status_array_init(
+  rcl_action_goal_status_array_t * status_array,
+  const size_t num_status,
+  const rcl_allocator_t allocator)
+{
+  RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(status_array, RCL_RET_INVALID_ARGUMENT, allocator);
+  // Ensure status array is zero initialized
+  if (status_array->status_list.size > 0) {
+    RCL_SET_ERROR_MSG("status_array already inititalized", allocator);
+    return RCL_RET_ALREADY_INIT;
+  }
+  // Allocate space for status array
+  status_array->status_list.data = (rcl_action_goal_status_t *) allocator.zero_allocate(
+    num_status, sizeof(rcl_action_goal_status_t), allocator.state);
+  if (!status_array->status_list.data) {
+    return RCL_RET_BAD_ALLOC;
+  }
+  status_array->status_list.size = num_status;
+  return RCL_RET_OK;
+}
+
+rcl_ret_t
+rcl_action_goal_status_array_fini(
+  rcl_action_goal_status_array_t * status_array,
+  const rcl_allocator_t allocator)
+{
+  RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(status_array, RCL_RET_INVALID_ARGUMENT, allocator);
+  if (!status_array->status_list.data) {
+    return RCL_RET_INVALID_ARGUMENT;
+  }
+  allocator.deallocate(status_array->status_list.data, allocator.state);
+  return RCL_RET_OK;
+}
+
+rcl_ret_t
+rcl_action_cancel_response_init(
+  rcl_action_cancel_response_t * cancel_response,
+  const size_t num_goals_canceling,
+  const rcl_allocator_t allocator)
+{
+  RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(cancel_response, RCL_RET_INVALID_ARGUMENT, allocator);
+  // Ensure cancel response is zero initialized
+  if (cancel_response->goals_canceling.size > 0) {
+    RCL_SET_ERROR_MSG("cancel_response already inititalized", allocator);
+    return RCL_RET_ALREADY_INIT;
+  }
+  // Allocate space for cancel response
+  cancel_response->goals_canceling.data = (rcl_action_goal_info_t *) allocator.zero_allocate(
+    num_goals_canceling, sizeof(rcl_action_goal_info_t), allocator.state);
+  if (!cancel_response->goals_canceling.data) {
+    return RCL_RET_BAD_ALLOC;
+  }
+  cancel_response->goals_canceling.size = num_goals_canceling;
+  return RCL_RET_OK;
+}
+
+rcl_ret_t
+rcl_action_cancel_response_fini(
+  rcl_action_cancel_response_t * cancel_response,
+  const rcl_allocator_t allocator)
+{
+  RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(cancel_response, RCL_RET_INVALID_ARGUMENT, allocator);
+  if (!cancel_response->goals_canceling.data) {
+    return RCL_RET_INVALID_ARGUMENT;
+  }
+  allocator.deallocate(cancel_response->goals_canceling.data, allocator.state);
+  return RCL_RET_OK;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/rcl_action/src/rcl_action/types.c
+++ b/rcl_action/src/rcl_action/types.c
@@ -24,10 +24,7 @@ extern "C"
 rcl_action_goal_info_t
 rcl_action_get_zero_initialized_goal_info(void)
 {
-  static rcl_action_goal_info_t goal_info = {
-    {0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u},
-    {0, 0u}
-  };
+  static rcl_action_goal_info_t goal_info = {0};
   return goal_info;
 }
 
@@ -41,15 +38,14 @@ rcl_action_get_zero_initialized_goal_status_array(void)
 rcl_action_cancel_request_t
 rcl_action_get_zero_initialized_cancel_request(void)
 {
-  static rcl_action_cancel_request_t request;
-  request.goal_info = rcl_action_get_zero_initialized_goal_info();
+  static rcl_action_cancel_request_t request = {0};
   return request;
 }
 
 rcl_action_cancel_response_t
 rcl_action_get_zero_initialized_cancel_response(void)
 {
-  static rcl_action_cancel_response_t response;
+  static rcl_action_cancel_response_t response = {0};
   return response;
 }
 

--- a/rcl_action/src/rcl_action/types.c
+++ b/rcl_action/src/rcl_action/types.c
@@ -24,28 +24,28 @@ extern "C"
 rcl_action_goal_info_t
 rcl_action_get_zero_initialized_goal_info(void)
 {
-  static rcl_action_goal_info_t goal_info = {{0}, {0}};
+  static rcl_action_goal_info_t goal_info = {{0}, {0, 0}};
   return goal_info;
 }
 
 rcl_action_goal_status_array_t
 rcl_action_get_zero_initialized_goal_status_array(void)
 {
-  static rcl_action_goal_status_array_t status_array = {0};
+  static rcl_action_goal_status_array_t status_array = {{0, 0, 0}};
   return status_array;
 }
 
 rcl_action_cancel_request_t
 rcl_action_get_zero_initialized_cancel_request(void)
 {
-  static rcl_action_cancel_request_t request = {{{0}, {0}}};
+  static rcl_action_cancel_request_t request = {{{0}, {0, 0}}};
   return request;
 }
 
 rcl_action_cancel_response_t
 rcl_action_get_zero_initialized_cancel_response(void)
 {
-  static rcl_action_cancel_response_t response = {{0}};
+  static rcl_action_cancel_response_t response = {{0, 0, 0}};
   return response;
 }
 

--- a/rcl_action/src/rcl_action/types.c
+++ b/rcl_action/src/rcl_action/types.c
@@ -31,7 +31,7 @@ rcl_action_get_zero_initialized_goal_info(void)
 rcl_action_goal_status_array_t
 rcl_action_get_zero_initialized_goal_status_array(void)
 {
-  static rcl_action_goal_status_array_t status_array;
+  static rcl_action_goal_status_array_t status_array = {0};
   return status_array;
 }
 

--- a/rcl_action/src/rcl_action/types.c
+++ b/rcl_action/src/rcl_action/types.c
@@ -24,7 +24,7 @@ extern "C"
 rcl_action_goal_info_t
 rcl_action_get_zero_initialized_goal_info(void)
 {
-  static rcl_action_goal_info_t goal_info = {0};
+  static rcl_action_goal_info_t goal_info = {{0}, {0}};
   return goal_info;
 }
 
@@ -38,14 +38,14 @@ rcl_action_get_zero_initialized_goal_status_array(void)
 rcl_action_cancel_request_t
 rcl_action_get_zero_initialized_cancel_request(void)
 {
-  static rcl_action_cancel_request_t request = {0};
+  static rcl_action_cancel_request_t request = {{{0}, {0}}};
   return request;
 }
 
 rcl_action_cancel_response_t
 rcl_action_get_zero_initialized_cancel_response(void)
 {
-  static rcl_action_cancel_response_t response = {0};
+  static rcl_action_cancel_response_t response = {{0}};
   return response;
 }
 

--- a/rcl_action/test/rcl_action/test_types.cpp
+++ b/rcl_action/test/rcl_action/test_types.cpp
@@ -1,0 +1,145 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include <gtest/gtest.h>
+
+#include "rcl_action/types.h"
+
+
+TEST(TestActionTypes, test_get_zero_inititalized_goal_info)
+{
+  rcl_action_goal_info_t goal_info = rcl_action_get_zero_initialized_goal_info();
+  ASSERT_EQ(sizeof(goal_info.uuid) / sizeof(uint8_t), 16lu);
+  for (int i = 0; i < 16; ++i) {
+    EXPECT_EQ(goal_info.uuid[i], 0u);
+  }
+  EXPECT_EQ(goal_info.stamp.sec, 0);
+  EXPECT_EQ(goal_info.stamp.nanosec, 0u);
+
+  // Modify the first, get another zero initialized goal info struct
+  for (int i = 0; i < 16; ++i) {
+    goal_info.uuid[i] = static_cast<uint8_t>(i);
+  }
+  goal_info.stamp.sec = 1234;
+  goal_info.stamp.nanosec = 4567u;
+  rcl_action_goal_info_t another_goal_info = rcl_action_get_zero_initialized_goal_info();
+  for (int i = 0; i < 16; ++i) {
+    EXPECT_EQ(goal_info.uuid[i], i);
+    EXPECT_EQ(another_goal_info.uuid[i], 0u);
+  }
+  EXPECT_EQ(goal_info.stamp.sec, 1234);
+  EXPECT_EQ(goal_info.stamp.nanosec, 4567u);
+  EXPECT_EQ(another_goal_info.stamp.sec, 0);
+  EXPECT_EQ(another_goal_info.stamp.nanosec, 0u);
+}
+
+TEST(TestActionTypes, test_get_zero_initialized_goal_status_array)
+{
+  rcl_action_goal_status_array_t status_array =
+    rcl_action_get_zero_initialized_goal_status_array();
+  ASSERT_EQ(sizeof(status_array.status_list) / sizeof(rcl_action_goal_status_t), 0lu);
+}
+
+TEST(TestActionTypes, test_get_zero_inititalized_cancel_request)
+{
+  rcl_action_cancel_request_t cancel_request = rcl_action_get_zero_initialized_cancel_request();
+  ASSERT_EQ(sizeof(cancel_request.goal_info.uuid) / sizeof(uint8_t), 16lu);
+  for (int i = 0; i < 16; ++i) {
+    EXPECT_EQ(cancel_request.goal_info.uuid[i], 0u);
+  }
+  EXPECT_EQ(cancel_request.goal_info.stamp.sec, 0);
+  EXPECT_EQ(cancel_request.goal_info.stamp.nanosec, 0u);
+}
+
+TEST(TestActionTypes, test_get_zero_initialized_cancel_response)
+{
+  rcl_action_cancel_response_t cancel_response = rcl_action_get_zero_initialized_cancel_response();
+  ASSERT_EQ(cancel_response.goals_canceling.size, 0lu);
+}
+
+TEST(TestActionTypes, test_init_fini_goal_status_array)
+{
+  // Initialize with invalid status array
+  rcl_ret_t ret = rcl_action_goal_status_array_init(
+    nullptr,
+    (size_t) 3,
+    rcl_get_default_allocator());
+  EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT);
+
+  // Initialize with invalid allocator
+  rcl_allocator_t invalid_allocator = rcl_get_default_allocator();
+  invalid_allocator.allocate = nullptr;
+  rcl_action_goal_status_array_t status_array =
+    rcl_action_get_zero_initialized_goal_status_array();
+  ASSERT_EQ(status_array.status_list.size, 0lu);
+  ret = rcl_action_goal_status_array_init(&status_array, (size_t) 3, invalid_allocator);
+  EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT);
+
+  // Initialize with valid arguments
+  status_array = rcl_action_get_zero_initialized_goal_status_array();
+  ASSERT_EQ(status_array.status_list.size, 0lu);
+  ret = rcl_action_goal_status_array_init(&status_array, (size_t) 3, rcl_get_default_allocator());
+  EXPECT_EQ(ret, RCL_RET_OK);
+  EXPECT_EQ((size_t) 3, status_array.status_list.size);
+  EXPECT_NE(nullptr, status_array.status_list.data);
+
+  // Finalize with invalid status array
+  ret = rcl_action_goal_status_array_fini(nullptr, rcl_get_default_allocator());
+  EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT);
+
+  // Finalize with invalid allocator
+  ret = rcl_action_goal_status_array_fini(&status_array, invalid_allocator);
+  EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT);
+
+  // Finalize with valid arguments
+  ret = rcl_action_goal_status_array_fini(&status_array, rcl_get_default_allocator());
+  EXPECT_EQ(ret, RCL_RET_OK);
+}
+
+TEST(TestActionTypes, test_init_fini_cancel_response)
+{
+  // Initialize with invalid cancel response
+  rcl_ret_t ret = rcl_action_cancel_response_init(
+    nullptr,
+    (size_t) 3,
+    rcl_get_default_allocator());
+  EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT);
+
+  // Initialize with invalid allocator
+  rcl_allocator_t invalid_allocator = rcl_get_default_allocator();
+  invalid_allocator.allocate = nullptr;
+  rcl_action_cancel_response_t cancel_response = rcl_action_get_zero_initialized_cancel_response();
+  ASSERT_EQ(cancel_response.goals_canceling.size, 0lu);
+  ret = rcl_action_cancel_response_init(&cancel_response, (size_t) 3, invalid_allocator);
+  EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT);
+
+  // Initialize with valid arguments
+  cancel_response = rcl_action_get_zero_initialized_cancel_response();
+  ASSERT_EQ(cancel_response.goals_canceling.size, 0lu);
+  ret = rcl_action_cancel_response_init(&cancel_response, (size_t) 3, rcl_get_default_allocator());
+  EXPECT_EQ(ret, RCL_RET_OK);
+  EXPECT_EQ((size_t) 3, cancel_response.goals_canceling.size);
+  EXPECT_NE(nullptr, cancel_response.goals_canceling.data);
+
+  // Finalize with invalid cancel response
+  ret = rcl_action_cancel_response_fini(nullptr, rcl_get_default_allocator());
+  EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT);
+
+  // Finalize with invalid allocator
+  ret = rcl_action_cancel_response_fini(&cancel_response, invalid_allocator);
+  EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT);
+
+  // Finalize with valid arguments
+  ret = rcl_action_cancel_response_fini(&cancel_response, rcl_get_default_allocator());
+  EXPECT_EQ(ret, RCL_RET_OK);
+}

--- a/rcl_action/test/rcl_action/test_types.cpp
+++ b/rcl_action/test/rcl_action/test_types.cpp
@@ -26,7 +26,8 @@ TEST(TestActionTypes, test_get_zero_inititalized_goal_info)
   EXPECT_EQ(goal_info.stamp.sec, 0);
   EXPECT_EQ(goal_info.stamp.nanosec, 0u);
 
-  // Modify the first, get another zero initialized goal info struct
+  // Modify the first and get another zero initialized goal info struct
+  // to confirm they are independent objects
   for (int i = 0; i < 16; ++i) {
     goal_info.uuid[i] = static_cast<uint8_t>(i);
   }

--- a/rcl_action/test/rcl_action/test_types.cpp
+++ b/rcl_action/test/rcl_action/test_types.cpp
@@ -19,7 +19,7 @@
 TEST(TestActionTypes, test_get_zero_inititalized_goal_info)
 {
   rcl_action_goal_info_t goal_info = rcl_action_get_zero_initialized_goal_info();
-  ASSERT_EQ(sizeof(goal_info.uuid) / sizeof(uint8_t), 16lu);
+  ASSERT_EQ(sizeof(goal_info.uuid) / sizeof(uint8_t), 16u);
   for (int i = 0; i < 16; ++i) {
     EXPECT_EQ(goal_info.uuid[i], 0u);
   }
@@ -47,13 +47,13 @@ TEST(TestActionTypes, test_get_zero_initialized_goal_status_array)
 {
   rcl_action_goal_status_array_t status_array =
     rcl_action_get_zero_initialized_goal_status_array();
-  ASSERT_EQ(sizeof(status_array.status_list) / sizeof(rcl_action_goal_status_t), 0lu);
+  ASSERT_EQ(sizeof(status_array.status_list) / sizeof(rcl_action_goal_status_t), 0u);
 }
 
 TEST(TestActionTypes, test_get_zero_inititalized_cancel_request)
 {
   rcl_action_cancel_request_t cancel_request = rcl_action_get_zero_initialized_cancel_request();
-  ASSERT_EQ(sizeof(cancel_request.goal_info.uuid) / sizeof(uint8_t), 16lu);
+  ASSERT_EQ(sizeof(cancel_request.goal_info.uuid) / sizeof(uint8_t), 16u);
   for (int i = 0; i < 16; ++i) {
     EXPECT_EQ(cancel_request.goal_info.uuid[i], 0u);
   }
@@ -64,15 +64,17 @@ TEST(TestActionTypes, test_get_zero_inititalized_cancel_request)
 TEST(TestActionTypes, test_get_zero_initialized_cancel_response)
 {
   rcl_action_cancel_response_t cancel_response = rcl_action_get_zero_initialized_cancel_response();
-  ASSERT_EQ(cancel_response.goals_canceling.size, 0lu);
+  EXPECT_EQ(cancel_response.goals_canceling.size, 0u);
+  EXPECT_EQ(cancel_response.goals_canceling.data, nullptr);
 }
 
 TEST(TestActionTypes, test_init_fini_goal_status_array)
 {
+  const size_t num_status = 3;
   // Initialize with invalid status array
   rcl_ret_t ret = rcl_action_goal_status_array_init(
     nullptr,
-    (size_t) 3,
+    num_status,
     rcl_get_default_allocator());
   EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT);
 
@@ -81,16 +83,16 @@ TEST(TestActionTypes, test_init_fini_goal_status_array)
   invalid_allocator.allocate = nullptr;
   rcl_action_goal_status_array_t status_array =
     rcl_action_get_zero_initialized_goal_status_array();
-  ASSERT_EQ(status_array.status_list.size, 0lu);
-  ret = rcl_action_goal_status_array_init(&status_array, (size_t) 3, invalid_allocator);
+  ASSERT_EQ(status_array.status_list.size, 0u);
+  ret = rcl_action_goal_status_array_init(&status_array, num_status, invalid_allocator);
   EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT);
 
   // Initialize with valid arguments
   status_array = rcl_action_get_zero_initialized_goal_status_array();
-  ASSERT_EQ(status_array.status_list.size, 0lu);
-  ret = rcl_action_goal_status_array_init(&status_array, (size_t) 3, rcl_get_default_allocator());
+  ASSERT_EQ(status_array.status_list.size, 0u);
+  ret = rcl_action_goal_status_array_init(&status_array, num_status, rcl_get_default_allocator());
   EXPECT_EQ(ret, RCL_RET_OK);
-  EXPECT_EQ((size_t) 3, status_array.status_list.size);
+  EXPECT_EQ(num_status, status_array.status_list.size);
   EXPECT_NE(nullptr, status_array.status_list.data);
 
   // Finalize with invalid status array
@@ -108,10 +110,11 @@ TEST(TestActionTypes, test_init_fini_goal_status_array)
 
 TEST(TestActionTypes, test_init_fini_cancel_response)
 {
+  const size_t num_goals_canceling = 3;
   // Initialize with invalid cancel response
   rcl_ret_t ret = rcl_action_cancel_response_init(
     nullptr,
-    (size_t) 3,
+    num_goals_canceling,
     rcl_get_default_allocator());
   EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT);
 
@@ -119,16 +122,19 @@ TEST(TestActionTypes, test_init_fini_cancel_response)
   rcl_allocator_t invalid_allocator = rcl_get_default_allocator();
   invalid_allocator.allocate = nullptr;
   rcl_action_cancel_response_t cancel_response = rcl_action_get_zero_initialized_cancel_response();
-  ASSERT_EQ(cancel_response.goals_canceling.size, 0lu);
-  ret = rcl_action_cancel_response_init(&cancel_response, (size_t) 3, invalid_allocator);
+  ASSERT_EQ(cancel_response.goals_canceling.size, 0u);
+  ret = rcl_action_cancel_response_init(&cancel_response, num_goals_canceling, invalid_allocator);
   EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT);
 
   // Initialize with valid arguments
   cancel_response = rcl_action_get_zero_initialized_cancel_response();
-  ASSERT_EQ(cancel_response.goals_canceling.size, 0lu);
-  ret = rcl_action_cancel_response_init(&cancel_response, (size_t) 3, rcl_get_default_allocator());
+  ASSERT_EQ(cancel_response.goals_canceling.size, 0u);
+  ret = rcl_action_cancel_response_init(
+    &cancel_response,
+    num_goals_canceling,
+    rcl_get_default_allocator());
   EXPECT_EQ(ret, RCL_RET_OK);
-  EXPECT_EQ((size_t) 3, cancel_response.goals_canceling.size);
+  EXPECT_EQ(num_goals_canceling, cancel_response.goals_canceling.size);
   EXPECT_NE(nullptr, cancel_response.goals_canceling.data);
 
   // Finalize with invalid cancel response

--- a/rcl_action/test/rcl_action/test_types.cpp
+++ b/rcl_action/test/rcl_action/test_types.cpp
@@ -48,7 +48,6 @@ TEST(TestActionTypes, test_get_zero_initialized_goal_status_array)
 {
   rcl_action_goal_status_array_t status_array =
     rcl_action_get_zero_initialized_goal_status_array();
-  // ASSERT_EQ(sizeof(status_array.status_list.data) / sizeof(rcl_action_goal_status_t), 0u);
   EXPECT_EQ(status_array.status_list.size, 0u);
   EXPECT_EQ(status_array.status_list.data, nullptr);
 }

--- a/rcl_action/test/rcl_action/test_types.cpp
+++ b/rcl_action/test/rcl_action/test_types.cpp
@@ -47,7 +47,9 @@ TEST(TestActionTypes, test_get_zero_initialized_goal_status_array)
 {
   rcl_action_goal_status_array_t status_array =
     rcl_action_get_zero_initialized_goal_status_array();
-  ASSERT_EQ(sizeof(status_array.status_list) / sizeof(rcl_action_goal_status_t), 0u);
+  // ASSERT_EQ(sizeof(status_array.status_list.data) / sizeof(rcl_action_goal_status_t), 0u);
+  EXPECT_EQ(status_array.status_list.size, 0u);
+  EXPECT_EQ(status_array.status_list.data, nullptr);
 }
 
 TEST(TestActionTypes, test_get_zero_inititalized_cancel_request)


### PR DESCRIPTION
Connects to #306.

Refactored API. Removed init/fini functions for types that do not necessarily need allocation on the heap.
Added unit tests for implementation.