### PR TITLE
Add action services and topics name getters

### DIFF
--- a/rcl_action/CMakeLists.txt
+++ b/rcl_action/CMakeLists.txt
@@ -96,6 +96,7 @@ if(BUILD_TESTING)
     target_link_libraries(test_types
       ${PROJECT_NAME}
     )
+  endif()
   ament_add_gtest(test_names
     test/rcl_action/test_names.cpp
   )

--- a/rcl_action/CMakeLists.txt
+++ b/rcl_action/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(test_compile_headers
 
 set(rcl_action_sources
   src/${PROJECT_NAME}/goal_state_machine.c
+  src/${PROJECT_NAME}/names.c
   src/${PROJECT_NAME}/types.c
 )
 
@@ -93,6 +94,16 @@ if(BUILD_TESTING)
       ${rcl_INCLUDE_DIRS}
     )
     target_link_libraries(test_types
+      ${PROJECT_NAME}
+    )
+  ament_add_gtest(test_names
+    test/rcl_action/test_names.cpp
+  )
+  if(TARGET test_names)
+    target_include_directories(test_names PUBLIC
+      ${rcl_INCLUDE_DIRS}
+    )
+    target_link_libraries(test_names
       ${PROJECT_NAME}
     )
   endif()

--- a/rcl_action/include/rcl_action/names.h
+++ b/rcl_action/include/rcl_action/names.h
@@ -46,7 +46,7 @@ extern "C"
  * \param[in] allocator A valid allocator to be used.
  * \param[out] goal_service_name Either an allocated string with the action
  *   goal service name, or `NULL` if the function failed to allocate memory
- *   for it.
+ *   for it. Must refer to a `NULL` pointer upon call.
  * \return `RCL_RET_OK` if the action goal service name was returned, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
  * \return `RCL_RET_BAD_ALLOC` if allocating memory failed.
@@ -78,7 +78,7 @@ rcl_action_get_goal_service_name(
  * \param[in] allocator A valid allocator to be used.
  * \param[out] cancel_service_name Either an allocated string with the action
  *   cancel service name, or `NULL` if the function failed to allocate memory
- *   for it.
+ *   for it. Must refer to a `NULL` pointer upon call.
  * \return `RCL_RET_OK` if the action cancel service name was returned, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
  * \return `RCL_RET_BAD_ALLOC` if allocating memory failed.
@@ -110,7 +110,7 @@ rcl_action_get_cancel_service_name(
  * \param[in] allocator A valid allocator to be used.
  * \param[out] result_service_name Either an allocated string with the action
  *   result service name, or `NULL` if the function failed to allocate memory
- *   for it.
+ *   for it. Must refer to a `NULL` pointer upon call.
  * \return `RCL_RET_OK` if the action result service name was returned, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
  * \return `RCL_RET_BAD_ALLOC` if allocating memory failed.
@@ -142,7 +142,7 @@ rcl_action_get_result_service_name(
  * \param[in] allocator A valid allocator to be used.
  * \param[out] result_service_name Either an allocated string with the action
  *   feedback topic name, or `NULL` if the function failed to allocate memory
- *   for it.
+ *   for it. Must refer to a `NULL` pointer upon call.
  * \return `RCL_RET_OK` if the action feedback topic name was returned, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
  * \return `RCL_RET_BAD_ALLOC` if allocating memory failed.
@@ -174,7 +174,7 @@ rcl_action_get_feedback_topic_name(
  * \param[in] allocator A valid allocator to be used.
  * \param[out] result_service_name Either an allocated string with the action
  *   status topic name, or `NULL` if the function failed to allocate memory
- *   for it.
+ *   for it. Must refer to a `NULL` pointer upon call.
  * \return `RCL_RET_OK` if the action status topic name was returned, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
  * \return `RCL_RET_BAD_ALLOC` if allocating memory failed.

--- a/rcl_action/include/rcl_action/names.h
+++ b/rcl_action/include/rcl_action/names.h
@@ -1,0 +1,194 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCL_ACTION__NAMES_H_
+#define RCL_ACTION__NAMES_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rcl_action/visibility_control.h"
+
+#include "rcl/allocator.h"
+#include "rcl/macros.h"
+#include "rcl/types.h"
+
+
+/// Get the goal service name of an action.
+/**
+ * This function returns the goal service name for a given action name
+ * that must be used by action clients and action servers to successfully
+ * communicate with each other.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] action_name The name of the action whose goal service name is
+ *   being returned.
+ * \param[in] allocator A valid allocator to be used.
+ * \param[out] goal_service_name Either an allocated string with the action
+ *   goal service name, or `NULL` if the function failed to allocate memory
+ *   for it.
+ * \return `RCL_RET_OK` if the action goal service name was returned, or
+ * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
+ * \return `RCL_RET_BAD_ALLOC` if allocating memory failed.
+ */
+RCL_ACTION_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_action_get_goal_service_name(
+  const char * action_name,
+  rcl_allocator_t allocator,
+  char ** goal_service_name);
+
+/// Get the cancel service name of an action.
+/**
+ * This function returns the cancel service name for a given action name
+ * that must be used by action clients and action servers to successfully
+ * communicate with each other.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] action_name The name of the action whose cancel service name is
+ *   being returned.
+ * \param[in] allocator A valid allocator to be used.
+ * \param[out] cancel_service_name Either an allocated string with the action
+ *   cancel service name, or `NULL` if the function failed to allocate memory
+ *   for it.
+ * \return `RCL_RET_OK` if the action cancel service name was returned, or
+ * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
+ * \return `RCL_RET_BAD_ALLOC` if allocating memory failed.
+ */
+RCL_ACTION_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_action_get_cancel_service_name(
+  const char * action_name,
+  rcl_allocator_t allocator,
+  char ** cancel_service_name);
+
+/// Get the result service name of an action.
+/**
+ * This function returns the result service name for a given action name
+ * that must be used by action clients and action servers to successfully
+ * communicate with each other.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] action_name The name of the action whose result service name is
+ *   being returned.
+ * \param[in] allocator A valid allocator to be used.
+ * \param[out] result_service_name Either an allocated string with the action
+ *   result service name, or `NULL` if the function failed to allocate memory
+ *   for it.
+ * \return `RCL_RET_OK` if the action result service name was returned, or
+ * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
+ * \return `RCL_RET_BAD_ALLOC` if allocating memory failed.
+ */
+RCL_ACTION_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_action_get_result_service_name(
+  const char * action_name,
+  rcl_allocator_t allocator,
+  char ** result_service_name);
+
+/// Get the feedback topic name of an action.
+/**
+ * This function returns the feedback topic name for a given action name
+ * that must be used by action clients and action servers to successfully
+ * communicate with each other.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] action_name The name of the action whose feedback topic name is
+ *   being returned.
+ * \param[in] allocator A valid allocator to be used.
+ * \param[out] result_service_name Either an allocated string with the action
+ *   feedback topic name, or `NULL` if the function failed to allocate memory
+ *   for it.
+ * \return `RCL_RET_OK` if the action feedback topic name was returned, or
+ * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
+ * \return `RCL_RET_BAD_ALLOC` if allocating memory failed.
+ */
+RCL_ACTION_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_action_get_feedback_topic_name(
+  const char * action_name,
+  rcl_allocator_t allocator,
+  char ** feedback_topic_name);
+
+/// Get the status topic name of an action.
+/**
+ * This function returns the status topic name for a given action name
+ * that must be used by action clients and action servers to successfully
+ * communicate with each other.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] action_name The name of the action whose status topic name is
+ *   being returned.
+ * \param[in] allocator A valid allocator to be used.
+ * \param[out] result_service_name Either an allocated string with the action
+ *   status topic name, or `NULL` if the function failed to allocate memory
+ *   for it.
+ * \return `RCL_RET_OK` if the action status topic name was returned, or
+ * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
+ * \return `RCL_RET_BAD_ALLOC` if allocating memory failed.
+ */
+RCL_ACTION_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_action_get_status_topic_name(
+  const char * action_name,
+  rcl_allocator_t allocator,
+  char ** status_topic_name);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RCL_ACTION__NAMES_H_

--- a/rcl_action/src/rcl_action/names.c
+++ b/rcl_action/src/rcl_action/names.c
@@ -1,0 +1,112 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rcl_action/names.h"
+
+#include "rcl/error_handling.h"
+#include "rcutils/format_string.h"
+
+rcl_ret_t
+rcl_action_get_goal_service_name(
+  const char * action_name,
+  rcl_allocator_t allocator,
+  char ** goal_service_name)
+{
+  RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "allocator is invalid", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(action_name, RCL_RET_INVALID_ARGUMENT, allocator);
+  RCL_CHECK_ARGUMENT_FOR_NULL(goal_service_name, RCL_RET_INVALID_ARGUMENT, allocator);
+  *goal_service_name = rcutils_format_string(allocator, "%s/_action/send_goal", action_name);
+  if (*goal_service_name == NULL) {
+    RCL_SET_ERROR_MSG("failed to allocate memory for action goal service name", allocator);
+    return RCL_RET_BAD_ALLOC;
+  }
+  return RCL_RET_OK;
+}
+
+rcl_ret_t
+rcl_action_get_cancel_service_name(
+  const char * action_name,
+  rcl_allocator_t allocator,
+  char ** cancel_service_name)
+{
+  RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "allocator is invalid", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(action_name, RCL_RET_INVALID_ARGUMENT, allocator);
+  RCL_CHECK_ARGUMENT_FOR_NULL(cancel_service_name, RCL_RET_INVALID_ARGUMENT, allocator);
+  *cancel_service_name = rcutils_format_string(allocator, "%s/_action/cancel_goal", action_name);
+  if (*cancel_service_name == NULL) {
+    RCL_SET_ERROR_MSG("failed to allocate memory for action cancel service name", allocator);
+    return RCL_RET_BAD_ALLOC;
+  }
+  return RCL_RET_OK;
+}
+
+rcl_ret_t
+rcl_action_get_result_service_name(
+  const char * action_name,
+  rcl_allocator_t allocator,
+  char ** result_service_name)
+{
+  RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "allocator is invalid", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(action_name, RCL_RET_INVALID_ARGUMENT, allocator);
+  RCL_CHECK_ARGUMENT_FOR_NULL(result_service_name, RCL_RET_INVALID_ARGUMENT, allocator);
+  *result_service_name = rcutils_format_string(allocator, "%s/_action/get_result", action_name);
+  if (*result_service_name == NULL) {
+    RCL_SET_ERROR_MSG("failed to allocate memory for action result service name", allocator);
+    return RCL_RET_BAD_ALLOC;
+  }
+  return RCL_RET_OK;
+}
+
+rcl_ret_t
+rcl_action_get_feedback_topic_name(
+  const char * action_name,
+  rcl_allocator_t allocator,
+  char ** feedback_topic_name)
+{
+  RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "allocator is invalid", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(action_name, RCL_RET_INVALID_ARGUMENT, allocator);
+  RCL_CHECK_ARGUMENT_FOR_NULL(feedback_topic_name, RCL_RET_INVALID_ARGUMENT, allocator);
+  *feedback_topic_name = rcutils_format_string(allocator, "%s/_action/feedback", action_name);
+  if (*feedback_topic_name == NULL) {
+    RCL_SET_ERROR_MSG("failed to allocate memory for action feedback topic name", allocator);
+    return RCL_RET_BAD_ALLOC;
+  }
+  return RCL_RET_OK;
+}
+
+rcl_ret_t
+rcl_action_get_status_topic_name(
+  const char * action_name,
+  rcl_allocator_t allocator,
+  char ** status_topic_name)
+{
+  RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "allocator is invalid", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(action_name, RCL_RET_INVALID_ARGUMENT, allocator);
+  RCL_CHECK_ARGUMENT_FOR_NULL(status_topic_name, RCL_RET_INVALID_ARGUMENT, allocator);
+  *status_topic_name = rcutils_format_string(allocator, "%s/_action/status", action_name);
+  if (*status_topic_name == NULL) {
+    RCL_SET_ERROR_MSG("failed to allocate memory for action status topic name", allocator);
+    return RCL_RET_BAD_ALLOC;
+  }
+  return RCL_RET_OK;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/rcl_action/src/rcl_action/names.c
+++ b/rcl_action/src/rcl_action/names.c
@@ -31,8 +31,12 @@ rcl_action_get_goal_service_name(
   RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "allocator is invalid", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(action_name, RCL_RET_INVALID_ARGUMENT, allocator);
   RCL_CHECK_ARGUMENT_FOR_NULL(goal_service_name, RCL_RET_INVALID_ARGUMENT, allocator);
+  if (NULL != *goal_service_name) {
+    RCL_SET_ERROR_MSG("writing action goal service name may leak memory", allocator);
+    return RCL_RET_INVALID_ARGUMENT;
+  }
   *goal_service_name = rcutils_format_string(allocator, "%s/_action/send_goal", action_name);
-  if (*goal_service_name == NULL) {
+  if (NULL == *goal_service_name) {
     RCL_SET_ERROR_MSG("failed to allocate memory for action goal service name", allocator);
     return RCL_RET_BAD_ALLOC;
   }
@@ -48,8 +52,12 @@ rcl_action_get_cancel_service_name(
   RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "allocator is invalid", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(action_name, RCL_RET_INVALID_ARGUMENT, allocator);
   RCL_CHECK_ARGUMENT_FOR_NULL(cancel_service_name, RCL_RET_INVALID_ARGUMENT, allocator);
+  if (NULL != *cancel_service_name) {
+    RCL_SET_ERROR_MSG("writing action cancel service name may leak memory", allocator);
+    return RCL_RET_INVALID_ARGUMENT;
+  }
   *cancel_service_name = rcutils_format_string(allocator, "%s/_action/cancel_goal", action_name);
-  if (*cancel_service_name == NULL) {
+  if (NULL == *cancel_service_name) {
     RCL_SET_ERROR_MSG("failed to allocate memory for action cancel service name", allocator);
     return RCL_RET_BAD_ALLOC;
   }
@@ -65,8 +73,13 @@ rcl_action_get_result_service_name(
   RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "allocator is invalid", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(action_name, RCL_RET_INVALID_ARGUMENT, allocator);
   RCL_CHECK_ARGUMENT_FOR_NULL(result_service_name, RCL_RET_INVALID_ARGUMENT, allocator);
+  if (NULL != *result_service_name) {
+    RCL_SET_ERROR_MSG("writing action result service name may leak memory", allocator);
+    return RCL_RET_INVALID_ARGUMENT;
+  }
+
   *result_service_name = rcutils_format_string(allocator, "%s/_action/get_result", action_name);
-  if (*result_service_name == NULL) {
+  if (NULL == *result_service_name) {
     RCL_SET_ERROR_MSG("failed to allocate memory for action result service name", allocator);
     return RCL_RET_BAD_ALLOC;
   }
@@ -82,8 +95,12 @@ rcl_action_get_feedback_topic_name(
   RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "allocator is invalid", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(action_name, RCL_RET_INVALID_ARGUMENT, allocator);
   RCL_CHECK_ARGUMENT_FOR_NULL(feedback_topic_name, RCL_RET_INVALID_ARGUMENT, allocator);
+  if (NULL != *feedback_topic_name) {
+    RCL_SET_ERROR_MSG("writing action feedback topic name may leak memory", allocator);
+    return RCL_RET_INVALID_ARGUMENT;
+  }
   *feedback_topic_name = rcutils_format_string(allocator, "%s/_action/feedback", action_name);
-  if (*feedback_topic_name == NULL) {
+  if (NULL == *feedback_topic_name) {
     RCL_SET_ERROR_MSG("failed to allocate memory for action feedback topic name", allocator);
     return RCL_RET_BAD_ALLOC;
   }
@@ -99,8 +116,12 @@ rcl_action_get_status_topic_name(
   RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "allocator is invalid", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(action_name, RCL_RET_INVALID_ARGUMENT, allocator);
   RCL_CHECK_ARGUMENT_FOR_NULL(status_topic_name, RCL_RET_INVALID_ARGUMENT, allocator);
+  if (NULL != *status_topic_name) {
+    RCL_SET_ERROR_MSG("writing action status topic name may leak memory", allocator);
+    return RCL_RET_INVALID_ARGUMENT;
+  }
   *status_topic_name = rcutils_format_string(allocator, "%s/_action/status", action_name);
-  if (*status_topic_name == NULL) {
+  if (NULL == *status_topic_name) {
     RCL_SET_ERROR_MSG("failed to allocate memory for action status topic name", allocator);
     return RCL_RET_BAD_ALLOC;
   }

--- a/rcl_action/test/rcl_action/test_names.cpp
+++ b/rcl_action/test/rcl_action/test_names.cpp
@@ -1,0 +1,91 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "rcl_action/names.h"
+
+#include "rcl/allocator.h"
+#include "rcl/types.h"
+
+
+TEST(TestActionNames, test_action_goal_service_name)
+{
+  rcl_ret_t ret;
+  const char * const action_name = "test_it";
+  rcl_allocator_t default_allocator = rcl_get_default_allocator();
+
+  char * action_goal_service_name;
+  ret = rcl_action_get_goal_service_name(
+    action_name, default_allocator, &action_goal_service_name);
+  ASSERT_EQ(RCL_RET_OK, ret);
+  EXPECT_STREQ("test_it/_action/send_goal", action_goal_service_name);
+  default_allocator.deallocate(action_goal_service_name, default_allocator.state);
+}
+
+TEST(TestActionNames, test_action_cancel_service_name)
+{
+  rcl_ret_t ret;
+  const char * const action_name = "test_it";
+  rcl_allocator_t default_allocator = rcl_get_default_allocator();
+
+  char * action_cancel_service_name;
+  ret = rcl_action_get_cancel_service_name(
+    action_name, default_allocator, &action_cancel_service_name);
+  ASSERT_EQ(RCL_RET_OK, ret);
+  EXPECT_STREQ("test_it/_action/cancel_goal", action_cancel_service_name);
+  default_allocator.deallocate(action_cancel_service_name, default_allocator.state);
+}
+
+TEST(TestActionNames, test_action_result_service_name)
+{
+  rcl_ret_t ret;
+  const char * const action_name = "test_it";
+  rcl_allocator_t default_allocator = rcl_get_default_allocator();
+
+  char * action_result_service_name;
+  ret = rcl_action_get_result_service_name(
+    action_name, default_allocator, &action_result_service_name);
+  ASSERT_EQ(RCL_RET_OK, ret);
+  EXPECT_STREQ("test_it/_action/get_result", action_result_service_name);
+  default_allocator.deallocate(action_result_service_name, default_allocator.state);
+}
+
+TEST(TestActionNames, test_action_feedback_topic_name)
+{
+  rcl_ret_t ret;
+  const char * const action_name = "test_it";
+  rcl_allocator_t default_allocator = rcl_get_default_allocator();
+
+  char * action_feedback_topic_name;
+  ret = rcl_action_get_feedback_topic_name(
+    action_name, default_allocator, &action_feedback_topic_name);
+  ASSERT_EQ(RCL_RET_OK, ret);
+  EXPECT_STREQ("test_it/_action/feedback", action_feedback_topic_name);
+  default_allocator.deallocate(action_feedback_topic_name, default_allocator.state);
+}
+
+TEST(TestActionNames, test_action_status_topic_name)
+{
+  rcl_ret_t ret;
+  const char * const action_name = "test_it";
+  rcl_allocator_t default_allocator = rcl_get_default_allocator();
+
+  char * action_status_topic_name;
+  ret = rcl_action_get_status_topic_name(
+    action_name, default_allocator, &action_status_topic_name);
+  ASSERT_EQ(RCL_RET_OK, ret);
+  EXPECT_STREQ("test_it/_action/status", action_status_topic_name);
+  default_allocator.deallocate(action_status_topic_name, default_allocator.state);
+}


### PR DESCRIPTION
Connected to #306. This pull request introduces basic utility functions to avoid duplicating action service and topic names computations in both client and server implementations.