### PR TITLE
Prepare 0.6.0

### DIFF
--- a/rcl/CHANGELOG.rst
+++ b/rcl/CHANGELOG.rst
@@ -2,6 +2,48 @@
 Changelog for package rcl
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2018-11-16)
+------------------
+* Updated to expand node_secure_root using local_namespace (`#300 <https://github.com/ros2/rcl/issues/300>`_)
+* Moved stdatomic helper to rcutils (`#324 <https://github.com/ros2/rcl/issues/324>`_)
+* Added subfolder argument to the ROSIDL_GET_SRV_TYPE_SUPPORT macro (`#322 <https://github.com/ros2/rcl/issues/322>`_)
+* Updated to use new error handling API from rcutils (`#314 <https://github.com/ros2/rcl/issues/314>`_)
+* Fixed minor documentation issues (`#305 <https://github.com/ros2/rcl/issues/305>`_)
+* Added macro semicolons (`#303 <https://github.com/ros2/rcl/issues/303>`_)
+* Added Rcl timer with ros time (`#286 <https://github.com/ros2/rcl/issues/286>`_)
+* Updated to ensure that timer period is non-negative (`#295 <https://github.com/ros2/rcl/issues/295>`_)
+* Fixed calculation of next timer call (`#291 <https://github.com/ros2/rcl/issues/291>`_)
+* Updated to null deallocated jump callbacks (`#294 <https://github.com/ros2/rcl/issues/294>`_)
+* Included namespaces in get_node_names. (`#287 <https://github.com/ros2/rcl/issues/287>`_)
+* Fixed documentation issues (`#288 <https://github.com/ros2/rcl/issues/288>`_)
+* Updated to check if pointers are null before calling memset (`#290 <https://github.com/ros2/rcl/issues/290>`_)
+* Added multiple time jump callbacks to clock (`#284 <https://github.com/ros2/rcl/issues/284>`_)
+* Consolidated wait set functions (`#285 <https://github.com/ros2/rcl/issues/285>`_)
+  * Consolidate functions to clear wait set
+  Added rcl_wait_set_clear()
+  Added rcl_wait_set_resize()
+  Removed
+  rcl_wait_set_clear_subscriptions()
+  rcl_wait_set_clear_guard_conditions()
+  rcl_wait_set_clear_clients()
+  rcl_wait_set_clear_services()
+  rcl_wait_set_clear_timers()
+  rcl_wait_set_resize_subscriptions()
+  rcl_wait_set_resize_guard_conditions()
+  rcl_wait_set_resize_timers()
+  rcl_wait_set_resize_clients()
+  rcl_wait_set_resize_services()
+* ROS clock storage initially set to zero (`#283 <https://github.com/ros2/rcl/issues/283>`_)
+* Fixed issue with deallocation of parameter_files (`#279 <https://github.com/ros2/rcl/issues/279>`_)
+* Update to initialize memory before sending a message (`#277 <https://github.com/ros2/rcl/issues/277>`_)
+* Set error message when clock type is not ROS_TIME (`#275 <https://github.com/ros2/rcl/issues/275>`_)
+* Copy allocator passed in to clock init (`#274 <https://github.com/ros2/rcl/issues/274>`_)
+* Update to initialize timer with clock (`#272 <https://github.com/ros2/rcl/issues/272>`_)
+* Updated to use test_msgs instead of std_msgs in tests (`#270 <https://github.com/ros2/rcl/issues/270>`_)
+* Added regression test for node:__ns remapping (`#263 <https://github.com/ros2/rcl/issues/263>`_)
+* Updated to support Uncrustify 0.67 (`#266 <https://github.com/ros2/rcl/issues/266>`_)
+* Contributors: Chris Lalancette, Chris Ye, Dirk Thomas, Jacob Perron, Michael Carroll, Mikael Arguedas, Ruffin, Shane Loretz, William Woodall, dhood
+
 0.5.0 (2018-06-25)
 ------------------
 * Updated code to only use ``rcutils_allocator_t`` and not use system memory functions directly. (`#261 <https://github.com/ros2/rcl/issues/261>`_)

--- a/rcl/package.xml
+++ b/rcl/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rcl</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>The ROS client library common implementation.
     This package contains an API which builds on the ROS middleware API and is optionally built upon by the other ROS client libraries.
   </description>

--- a/rcl_action/CHANGELOG.rst
+++ b/rcl_action/CHANGELOG.rst
@@ -1,0 +1,15 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package rcl_action
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.6.0 (2018-11-16)
+------------------
+* Added function to check if goal can be transitioned to CANCELING (`#325 <https://github.com/ros2/rcl/issues/325>`_)
+* Implement goal handle (`#320 <https://github.com/ros2/rcl/issues/320>`_)
+* Update to use new error handling API from rcutils (`#314 <https://github.com/ros2/rcl/issues/314>`_)
+* Add action services and topics name getters `#317 <https://github.com/ros2/rcl/issues/317>`_
+* Implement init/fini functions for types (`#312 <https://github.com/ros2/rcl/issues/312>`_)
+* Refactor goal state machine implementation and add unit tests (`#311 <https://github.com/ros2/rcl/issues/311>`_)
+* Add missing visibilty control definitions (`#315 <https://github.com/ros2/rcl/issues/315>`_)
+* Add rcl_action package and headers (`#307 <https://github.com/ros2/rcl/issues/307>`_)
+* Contributors: Jacob Perron, Michel Hidalgo, William Woodall

--- a/rcl_action/package.xml
+++ b/rcl_action/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rcl_action</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>Package containing a C-based ROS action implementation</description>
   <maintainer email="jacob@openrobotics.org">Jacob Perron</maintainer>
   <license>Apache License 2.0</license>

--- a/rcl_lifecycle/CHANGELOG.rst
+++ b/rcl_lifecycle/CHANGELOG.rst
@@ -2,6 +2,28 @@
 Changelog for package rcl_lifecycle
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2018-11-16)
+-----------
+* Updated use new error handling API from rcutils (`#314 <https://github.com/ros2/rcl/issues/314>`_)
+* Deleted TRANSITION_SHUTDOWN (`#313 <https://github.com/ros2/rcl/issues/313>`_)
+* Refactored lifecycle (`#298 <https://github.com/ros2/rcl/issues/298>`_)
+  * no static initialization of states anymore
+  * make transition labels more descriptive
+  * introduce labeled keys
+  * define default transition keys
+  * fix memory management
+  * introduce service for transition graph
+  * export transition keys
+  * remove keys, transition id unique, label ambiguous
+  * semicolon for macro call
+* Added macro semicolons (`#303 <https://github.com/ros2/rcl/issues/303>`_)
+* Fixed naming of configure_error transition (`#292 <https://github.com/ros2/rcl/issues/292>`_)
+* Removed use of uninitialized CMake var (`#268 <https://github.com/ros2/rcl/issues/268>`_)
+* Fixed rosidl dependencies (`#265 <https://github.com/ros2/rcl/issues/265>`_)
+  * [rcl_lifecycle] remove rosidl deps as this package doesnt generate any messages
+  * depend on rosidl_generator_c
+* Contributors: Chris Lalancette, Dirk Thomas, Karsten Knese, Mikael Arguedas, William Woodall
+
 0.5.0 (2018-06-25)
 ------------------
 * Updated code to use private substitution (``~``) in lifecycle topics and services (`#260 <https://github.com/ros2/rcl/issues/260>`_)

--- a/rcl_lifecycle/package.xml
+++ b/rcl_lifecycle/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rcl_lifecycle</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>Package containing a C-based lifecycle implementation</description>
   <maintainer email="karsten@osrfoundation.org">Karsten Knese</maintainer>
   <license>Apache License 2.0</license>

--- a/rcl_yaml_param_parser/CHANGELOG.rst
+++ b/rcl_yaml_param_parser/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package rcl_yaml_param_parser
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.6.0 (2018-11-16)
+------------------
+* Updated to use new error handling API from rcutils (`#314 <https://github.com/ros2/rcl/issues/314>`_)
+* Fixed FQN=//node_name when ns is / (`#299 <https://github.com/ros2/rcl/issues/299>`_)
+* Fixed documentation issues (`#288 <https://github.com/ros2/rcl/issues/288>`_)
+* Fixed to deallocate ret_val to avoid memory leak (`#278 <https://github.com/ros2/rcl/issues/278>`_)
+* Contributors: Chris Ye, William Woodall, dhood
+
 0.5.0 (2018-06-25)
 ------------------
 * Added functions to parse YAML parameter files. (`#235 <https://github.com/ros2/rcl/issues/235>`_)

--- a/rcl_yaml_param_parser/package.xml
+++ b/rcl_yaml_param_parser/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="2">
   <name>rcl_yaml_param_parser</name>
-  <version>0.5.0</version>
+  <version>0.6.0</version>
   <description>Package containing various utility types and functions for C</description>
   <maintainer email="anup.pemmaiah@apex.ai">Anup Pemmaiah</maintainer>
   <license>Apache License 2.0</license>


### PR DESCRIPTION
I generated and edited changelogs for this repository using my best judgement but I think it would be optimal of folks with more context also gave them a once-over.

I may release this as-is over the weekend to unblock further crystal releases but changelog modifications can come after-the-fact too.