### PR TITLE
Change UUID type in action msgs

### DIFF
--- a/rcl_action/CMakeLists.txt
+++ b/rcl_action/CMakeLists.txt
@@ -9,7 +9,6 @@ find_package(action_msgs REQUIRED)
 find_package(rcl REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
-find_package(unique_identifier_msgs REQUIRED)
 
 include_directories(
   include
@@ -59,7 +58,6 @@ ament_target_dependencies(${PROJECT_NAME}
   "rcutils"
   "rmw"
   "rosidl_generator_c"
-  "unique_identifier_msgs"
 )
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/rcl_action/CMakeLists.txt
+++ b/rcl_action/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(action_msgs REQUIRED)
 find_package(rcl REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
+find_package(unique_identifier_msgs REQUIRED)
 
 include_directories(
   include
@@ -58,6 +59,7 @@ ament_target_dependencies(${PROJECT_NAME}
   "rcutils"
   "rmw"
   "rosidl_generator_c"
+  "unique_identifier_msgs"
 )
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -734,7 +734,7 @@ rcl_action_process_cancel_request(
 
   // Request data
   const rcl_action_goal_info_t * request_goal_info = &cancel_request->goal_info;
-  const uint8_t * request_uuid = request_goal_info->uuid;
+  const uint8_t * request_uuid = request_goal_info->goal_id.uuid;
   int64_t request_nanosec = _goal_info_stamp_to_nanosec(request_goal_info);
 
   rcl_ret_t ret_final = RCL_RET_OK;
@@ -751,7 +751,7 @@ rcl_action_process_cancel_request(
         continue;
       }
 
-      if (uuidcmp(request_uuid, goal_info.uuid)) {
+      if (uuidcmp(request_uuid, goal_info.goal_id.uuid)) {
         if (rcl_action_goal_handle_is_cancelable(goal_handle)) {
           goal_handles_to_cancel[num_goals_to_cancel++] = goal_handle;
         }
@@ -779,7 +779,7 @@ rcl_action_process_cancel_request(
 
       const int64_t goal_nanosec = _goal_info_stamp_to_nanosec(&goal_info);
       if (rcl_action_goal_handle_is_cancelable(goal_handle) &&
-        ((goal_nanosec <= request_nanosec) || uuidcmp(request_uuid, goal_info.uuid)))
+        ((goal_nanosec <= request_nanosec) || uuidcmp(request_uuid, goal_info.goal_id.uuid)))
       {
         goal_handles_to_cancel[num_goals_to_cancel++] = goal_handle;
       }
@@ -880,7 +880,7 @@ rcl_action_server_goal_exists(
       return false;
     }
     // Compare UUIDs
-    if (uuidcmp(gh_goal_info.uuid, goal_info->uuid)) {
+    if (uuidcmp(gh_goal_info.goal_id.uuid, goal_info->goal_id.uuid)) {
       return true;
     }
   }

--- a/rcl_action/src/rcl_action/types.c
+++ b/rcl_action/src/rcl_action/types.c
@@ -23,7 +23,7 @@ extern "C"
 rcl_action_goal_info_t
 rcl_action_get_zero_initialized_goal_info(void)
 {
-  static rcl_action_goal_info_t goal_info = {{0}, {0, 0}};
+  static rcl_action_goal_info_t goal_info = {{{0}}, {0, 0}};
   return goal_info;
 }
 
@@ -37,7 +37,7 @@ rcl_action_get_zero_initialized_goal_status_array(void)
 rcl_action_cancel_request_t
 rcl_action_get_zero_initialized_cancel_request(void)
 {
-  static rcl_action_cancel_request_t request = {{{0}, {0, 0}}};
+  static rcl_action_cancel_request_t request = {{{{0}}, {0, 0}}};
   return request;
 }
 

--- a/rcl_action/test/rcl_action/test_action_communication.cpp
+++ b/rcl_action/test/rcl_action/test_action_communication.cpp
@@ -284,7 +284,7 @@ TEST_F(CLASSNAME(TestActionCommunication, RMW_IMPLEMENTATION), test_valid_cancel
   action_msgs__srv__CancelGoal_Response__init(&incoming_cancel_response);
 
   // Initialize cancel request
-  init_test_uuid0(outgoing_cancel_request.goal_info.uuid);
+  init_test_uuid0(outgoing_cancel_request.goal_info.goal_id.uuid);
   outgoing_cancel_request.goal_info.stamp.sec = 321;
   outgoing_cancel_request.goal_info.stamp.nanosec = 987654u;
 
@@ -326,8 +326,8 @@ TEST_F(CLASSNAME(TestActionCommunication, RMW_IMPLEMENTATION), test_valid_cancel
 
   // Check that the cancel request was received correctly
   EXPECT_TRUE(uuidcmp(
-      outgoing_cancel_request.goal_info.uuid,
-      incoming_cancel_request.goal_info.uuid));
+      outgoing_cancel_request.goal_info.goal_id.uuid,
+      incoming_cancel_request.goal_info.goal_id.uuid));
   EXPECT_EQ(
     outgoing_cancel_request.goal_info.stamp.sec,
     incoming_cancel_request.goal_info.stamp.sec);
@@ -338,10 +338,10 @@ TEST_F(CLASSNAME(TestActionCommunication, RMW_IMPLEMENTATION), test_valid_cancel
   // Initialize cancel request
   ASSERT_TRUE(action_msgs__msg__GoalInfo__Sequence__init(
       &outgoing_cancel_response.goals_canceling, 2));
-  init_test_uuid0(outgoing_cancel_response.goals_canceling.data[0].uuid);
+  init_test_uuid0(outgoing_cancel_response.goals_canceling.data[0].goal_id.uuid);
   outgoing_cancel_response.goals_canceling.data[0].stamp.sec = 102;
   outgoing_cancel_response.goals_canceling.data[0].stamp.nanosec = 9468u;
-  init_test_uuid1(outgoing_cancel_response.goals_canceling.data[1].uuid);
+  init_test_uuid1(outgoing_cancel_response.goals_canceling.data[1].goal_id.uuid);
   outgoing_cancel_response.goals_canceling.data[1].stamp.sec = 867;
   outgoing_cancel_response.goals_canceling.data[1].stamp.nanosec = 6845u;
 
@@ -395,7 +395,7 @@ TEST_F(CLASSNAME(TestActionCommunication, RMW_IMPLEMENTATION), test_valid_cancel
       &outgoing_cancel_response.goals_canceling.data[i];
     const action_msgs__msg__GoalInfo * incoming_goal_info =
       &incoming_cancel_response.goals_canceling.data[i];
-    EXPECT_TRUE(uuidcmp(outgoing_goal_info->uuid, incoming_goal_info->uuid));
+    EXPECT_TRUE(uuidcmp(outgoing_goal_info->goal_id.uuid, incoming_goal_info->goal_id.uuid));
     EXPECT_EQ(outgoing_goal_info->stamp.sec, incoming_goal_info->stamp.sec);
     EXPECT_EQ(outgoing_goal_info->stamp.nanosec, incoming_goal_info->stamp.nanosec);
   }
@@ -592,7 +592,8 @@ TEST_F(CLASSNAME(TestActionCommunication, RMW_IMPLEMENTATION), test_valid_status
       &status_array.msg.status_list.data[i];
     const action_msgs__msg__GoalStatus * incoming_status =
       &incoming_status_array.status_list.data[i];
-    EXPECT_TRUE(uuidcmp(outgoing_status->goal_info.uuid, incoming_status->goal_info.uuid));
+    EXPECT_TRUE(
+      uuidcmp(outgoing_status->goal_info.goal_id.uuid, incoming_status->goal_info.goal_id.uuid));
     EXPECT_EQ(outgoing_status->goal_info.stamp.sec, incoming_status->goal_info.stamp.sec);
     EXPECT_EQ(outgoing_status->goal_info.stamp.nanosec, incoming_status->goal_info.stamp.nanosec);
     EXPECT_EQ(outgoing_status->status, incoming_status->status);
@@ -794,7 +795,7 @@ TEST_F(CLASSNAME(TestActionCommunication, RMW_IMPLEMENTATION), test_invalid_canc
   action_msgs__srv__CancelGoal_Request__init(&incoming_cancel_request);
 
   // Initialize cancel request
-  init_test_uuid0(outgoing_cancel_request.goal_info.uuid);
+  init_test_uuid0(outgoing_cancel_request.goal_info.goal_id.uuid);
   outgoing_cancel_request.goal_info.stamp.sec = 321;
   outgoing_cancel_request.goal_info.stamp.nanosec = 987654u;
 
@@ -855,10 +856,10 @@ TEST_F(CLASSNAME(TestActionCommunication, RMW_IMPLEMENTATION), test_invalid_canc
   // Initialize cancel request
   ASSERT_TRUE(action_msgs__msg__GoalInfo__Sequence__init(
       &outgoing_cancel_response.goals_canceling, 2));
-  init_test_uuid0(outgoing_cancel_response.goals_canceling.data[0].uuid);
+  init_test_uuid0(outgoing_cancel_response.goals_canceling.data[0].goal_id.uuid);
   outgoing_cancel_response.goals_canceling.data[0].stamp.sec = 102;
   outgoing_cancel_response.goals_canceling.data[0].stamp.nanosec = 9468u;
-  init_test_uuid1(outgoing_cancel_response.goals_canceling.data[1].uuid);
+  init_test_uuid1(outgoing_cancel_response.goals_canceling.data[1].goal_id.uuid);
   outgoing_cancel_response.goals_canceling.data[1].stamp.sec = 867;
   outgoing_cancel_response.goals_canceling.data[1].stamp.nanosec = 6845u;
 

--- a/rcl_action/test/rcl_action/test_action_server.cpp
+++ b/rcl_action/test/rcl_action/test_action_server.cpp
@@ -322,7 +322,7 @@ TEST_F(TestActionServer, test_action_clear_expired_goals)
   ASSERT_EQ(RCL_RET_OK, rcl_set_ros_time_override(&this->clock, RCUTILS_S_TO_NS(1)));
   // Accept a goal to create a new handle
   rcl_action_goal_info_t goal_info_in = rcl_action_get_zero_initialized_goal_info();
-  init_test_uuid1(goal_info_in.uuid);
+  init_test_uuid1(goal_info_in.goal_id.uuid);
   rcl_action_goal_handle_t * goal_handle =
     rcl_action_accept_new_goal(&this->action_server, &goal_info_in);
   ASSERT_NE(goal_handle, nullptr) << rcl_get_error_string().str;
@@ -336,7 +336,7 @@ TEST_F(TestActionServer, test_action_clear_expired_goals)
   ret = rcl_action_expire_goals(&this->action_server, expired_goals, capacity, &num_expired);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
   EXPECT_EQ(num_expired, 1u);
-  EXPECT_TRUE(uuidcmp(expired_goals[0].uuid, goal_info_in.uuid));
+  EXPECT_TRUE(uuidcmp(expired_goals[0].goal_id.uuid, goal_info_in.goal_id.uuid));
 
   for (auto & handle : handles) {
     EXPECT_EQ(RCL_RET_OK, rcl_action_goal_handle_fini(&handle));

--- a/rcl_action/test/rcl_action/test_action_server.cpp
+++ b/rcl_action/test/rcl_action/test_action_server.cpp
@@ -227,7 +227,7 @@ TEST_F(TestActionServer, test_action_accept_new_goal)
 {
   // Initialize a goal info
   rcl_action_goal_info_t goal_info_in = rcl_action_get_zero_initialized_goal_info();
-  init_test_uuid0(goal_info_in.uuid);
+  init_test_uuid0(goal_info_in.goal_id.uuid);
 
   // Accept goal with a null action server
   rcl_action_goal_handle_t * goal_handle = rcl_action_accept_new_goal(nullptr, &goal_info_in);
@@ -254,7 +254,7 @@ TEST_F(TestActionServer, test_action_accept_new_goal)
   rcl_action_goal_info_t goal_info_out = rcl_action_get_zero_initialized_goal_info();
   rcl_ret_t ret = rcl_action_goal_handle_get_info(goal_handle, &goal_info_out);
   ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
-  EXPECT_TRUE(uuidcmp(goal_info_out.uuid, goal_info_in.uuid));
+  EXPECT_TRUE(uuidcmp(goal_info_out.goal_id.uuid, goal_info_in.goal_id.uuid));
   size_t num_goals = 0u;
   rcl_action_goal_handle_t ** goal_handle_array = {nullptr};
   ret = rcl_action_server_get_goal_handles(&this->action_server, &goal_handle_array, &num_goals);
@@ -270,13 +270,13 @@ TEST_F(TestActionServer, test_action_accept_new_goal)
 
   // Accept a different goal
   goal_info_in = rcl_action_get_zero_initialized_goal_info();
-  init_test_uuid1(goal_info_in.uuid);
+  init_test_uuid1(goal_info_in.goal_id.uuid);
   goal_handle = rcl_action_accept_new_goal(&this->action_server, &goal_info_in);
   EXPECT_NE(goal_handle, nullptr) << rcl_get_error_string().str;
   handles.push_back(*goal_handle);
   ret = rcl_action_goal_handle_get_info(goal_handle, &goal_info_out);
   ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
-  EXPECT_TRUE(uuidcmp(goal_info_out.uuid, goal_info_in.uuid));
+  EXPECT_TRUE(uuidcmp(goal_info_out.goal_id.uuid, goal_info_in.goal_id.uuid));
   ret = rcl_action_server_get_goal_handles(&this->action_server, &goal_handle_array, &num_goals);
   ASSERT_EQ(ret, RCL_RET_OK);
   EXPECT_EQ(num_goals, 2u);
@@ -410,7 +410,7 @@ TEST_F(TestActionServer, test_action_server_get_goal_status_array)
 
   // Add a goal before getting the status array
   rcl_action_goal_info_t goal_info_in = rcl_action_get_zero_initialized_goal_info();
-  init_test_uuid0(goal_info_in.uuid);
+  init_test_uuid0(goal_info_in.goal_id.uuid);
   rcl_action_goal_handle_t * goal_handle;
   goal_handle = rcl_action_accept_new_goal(&this->action_server, &goal_info_in);
   ASSERT_NE(goal_handle, nullptr) << rcl_get_error_string().str;
@@ -420,14 +420,14 @@ TEST_F(TestActionServer, test_action_server_get_goal_status_array)
   EXPECT_NE(status_array.msg.status_list.data, nullptr);
   EXPECT_EQ(status_array.msg.status_list.size, 1u);
   rcl_action_goal_info_t * goal_info_out = &status_array.msg.status_list.data[0].goal_info;
-  EXPECT_TRUE(uuidcmp(goal_info_out->uuid, goal_info_in.uuid));
+  EXPECT_TRUE(uuidcmp(goal_info_out->goal_id.uuid, goal_info_in.goal_id.uuid));
   ret = rcl_action_goal_status_array_fini(&status_array);
   ASSERT_EQ(ret, RCL_RET_OK);
 
   // Add nine more goals
   for (int i = 1; i < 10; ++i) {
     for (int j = 0; j < UUID_SIZE; ++j) {
-      goal_info_in.uuid[j] = static_cast<uint8_t>(i + j);
+      goal_info_in.goal_id.uuid[j] = static_cast<uint8_t>(i + j);
     }
     goal_handle = rcl_action_accept_new_goal(&this->action_server, &goal_info_in);
     ASSERT_NE(goal_handle, nullptr) << rcl_get_error_string().str;
@@ -440,7 +440,7 @@ TEST_F(TestActionServer, test_action_server_get_goal_status_array)
   for (int i = 0; i < 10; ++i) {
     goal_info_out = &status_array.msg.status_list.data[i].goal_info;
     for (int j = 0; j < UUID_SIZE; ++j) {
-      EXPECT_EQ(goal_info_out->uuid[j], i + j);
+      EXPECT_EQ(goal_info_out->goal_id.uuid[j], i + j);
     }
   }
   ret = rcl_action_goal_status_array_fini(&status_array);
@@ -499,7 +499,7 @@ protected:
     rcl_ret_t ret;
     for (int i = 0; i < NUM_GOALS; ++i) {
       for (int j = 0; j < UUID_SIZE; ++j) {
-        goal_info_in.uuid[j] = static_cast<uint8_t>(i + j);
+        goal_info_in.goal_id.uuid[j] = static_cast<uint8_t>(i + j);
       }
       goal_handle = rcl_action_accept_new_goal(&this->action_server, &goal_info_in);
       ASSERT_NE(goal_handle, nullptr) << rcl_get_error_string().str;
@@ -541,7 +541,7 @@ TEST_F(TestActionServerCancelPolicy, test_action_process_cancel_request_all_goal
   for (int i = 0; i < NUM_GOALS; ++i) {
     goal_info_out = &cancel_response.msg.goals_canceling.data[i];
     for (int j = 0; j < UUID_SIZE; ++j) {
-      EXPECT_EQ(goal_info_out->uuid[j], static_cast<uint8_t>(i + j));
+      EXPECT_EQ(goal_info_out->goal_id.uuid[j], static_cast<uint8_t>(i + j));
     }
   }
   EXPECT_EQ(RCL_RET_OK, rcl_action_cancel_response_fini(&cancel_response));
@@ -551,7 +551,7 @@ TEST_F(TestActionServerCancelPolicy, test_action_process_cancel_request_single_g
 {
   // Request to cancel a specific goal
   rcl_action_cancel_request_t cancel_request = rcl_action_get_zero_initialized_cancel_request();
-  init_test_uuid0(cancel_request.goal_info.uuid);
+  init_test_uuid0(cancel_request.goal_info.goal_id.uuid);
   rcl_action_cancel_response_t cancel_response = rcl_action_get_zero_initialized_cancel_response();
   rcl_ret_t ret = rcl_action_process_cancel_request(
     &this->action_server, &cancel_request, &cancel_response);
@@ -559,7 +559,7 @@ TEST_F(TestActionServerCancelPolicy, test_action_process_cancel_request_single_g
   EXPECT_NE(cancel_response.msg.goals_canceling.data, nullptr);
   ASSERT_EQ(cancel_response.msg.goals_canceling.size, 1u);
   rcl_action_goal_info_t * goal_info = &cancel_response.msg.goals_canceling.data[0];
-  EXPECT_TRUE(uuidcmp(goal_info->uuid, cancel_request.goal_info.uuid));
+  EXPECT_TRUE(uuidcmp(goal_info->goal_id.uuid, cancel_request.goal_info.goal_id.uuid));
   EXPECT_EQ(RCL_RET_OK, rcl_action_cancel_response_fini(&cancel_response));
 }
 
@@ -579,7 +579,7 @@ TEST_F(TestActionServerCancelPolicy, test_action_process_cancel_request_by_time)
   for (size_t i = 0; i < cancel_response.msg.goals_canceling.size; ++i) {
     goal_info_out = &cancel_response.msg.goals_canceling.data[i];
     for (size_t j = 0; j < UUID_SIZE; ++j) {
-      EXPECT_EQ(goal_info_out->uuid[j], static_cast<uint8_t>(i + j));
+      EXPECT_EQ(goal_info_out->goal_id.uuid[j], static_cast<uint8_t>(i + j));
     }
   }
   EXPECT_EQ(RCL_RET_OK, rcl_action_cancel_response_fini(&cancel_response));
@@ -593,7 +593,7 @@ TEST_F(TestActionServerCancelPolicy, test_action_process_cancel_request_by_time_
   rcl_action_cancel_request_t cancel_request = rcl_action_get_zero_initialized_cancel_request();
   cancel_request.goal_info = this->goal_infos_out[time_index];
   for (int i = 0; i < UUID_SIZE; ++i) {
-    cancel_request.goal_info.uuid[i] = static_cast<uint8_t>(i + goal_index);
+    cancel_request.goal_info.goal_id.uuid[i] = static_cast<uint8_t>(i + goal_index);
   }
   rcl_action_cancel_response_t cancel_response = rcl_action_get_zero_initialized_cancel_response();
   rcl_ret_t ret = rcl_action_process_cancel_request(
@@ -606,10 +606,10 @@ TEST_F(TestActionServerCancelPolicy, test_action_process_cancel_request_by_time_
   for (size_t i = 0; i < num_goals_canceling - 1; ++i) {
     goal_info_out = &cancel_response.msg.goals_canceling.data[i];
     for (size_t j = 0; j < UUID_SIZE; ++j) {
-      EXPECT_EQ(goal_info_out->uuid[j], static_cast<uint8_t>(i + j));
+      EXPECT_EQ(goal_info_out->goal_id.uuid[j], static_cast<uint8_t>(i + j));
     }
   }
   goal_info_out = &cancel_response.msg.goals_canceling.data[num_goals_canceling - 1];
-  EXPECT_TRUE(uuidcmp(goal_info_out->uuid, cancel_request.goal_info.uuid));
+  EXPECT_TRUE(uuidcmp(goal_info_out->goal_id.uuid, cancel_request.goal_info.goal_id.uuid));
   EXPECT_EQ(RCL_RET_OK, rcl_action_cancel_response_fini(&cancel_response));
 }

--- a/rcl_action/test/rcl_action/test_goal_handle.cpp
+++ b/rcl_action/test/rcl_action/test_goal_handle.cpp
@@ -96,7 +96,7 @@ TEST(TestGoalHandle, test_goal_handle_get_info)
   // Initialize a goal info message to test
   rcl_action_goal_info_t goal_info_input = rcl_action_get_zero_initialized_goal_info();
   for (int i = 0; i < 16; ++i) {
-    goal_info_input.uuid[i] = static_cast<uint8_t>(i);
+    goal_info_input.goal_id.uuid[i] = static_cast<uint8_t>(i);
   }
   goal_info_input.stamp.sec = 123;
   goal_info_input.stamp.nanosec = 456u;
@@ -124,7 +124,7 @@ TEST(TestGoalHandle, test_goal_handle_get_info)
   ret = rcl_action_goal_handle_get_info(&goal_handle, &goal_info_output);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
   for (int i = 0; i < 16; ++i) {
-    EXPECT_EQ(goal_info_input.uuid[i], goal_info_output.uuid[i]);
+    EXPECT_EQ(goal_info_input.goal_id.uuid[i], goal_info_output.goal_id.uuid[i]);
   }
   EXPECT_EQ(goal_info_input.stamp.sec, goal_info_output.stamp.sec);
   EXPECT_EQ(goal_info_input.stamp.nanosec, goal_info_output.stamp.nanosec);

--- a/rcl_action/test/rcl_action/test_types.cpp
+++ b/rcl_action/test/rcl_action/test_types.cpp
@@ -18,9 +18,9 @@
 TEST(TestActionTypes, test_get_zero_inititalized_goal_info)
 {
   rcl_action_goal_info_t goal_info = rcl_action_get_zero_initialized_goal_info();
-  ASSERT_EQ(sizeof(goal_info.uuid) / sizeof(uint8_t), 16u);
+  ASSERT_EQ(sizeof(goal_info.goal_id.uuid) / sizeof(uint8_t), 16u);
   for (int i = 0; i < 16; ++i) {
-    EXPECT_EQ(goal_info.uuid[i], 0u);
+    EXPECT_EQ(goal_info.goal_id.uuid[i], 0u);
   }
   EXPECT_EQ(goal_info.stamp.sec, 0);
   EXPECT_EQ(goal_info.stamp.nanosec, 0u);
@@ -28,14 +28,14 @@ TEST(TestActionTypes, test_get_zero_inititalized_goal_info)
   // Modify the first and get another zero initialized goal info struct
   // to confirm they are independent objects
   for (int i = 0; i < 16; ++i) {
-    goal_info.uuid[i] = static_cast<uint8_t>(i);
+    goal_info.goal_id.uuid[i] = static_cast<uint8_t>(i);
   }
   goal_info.stamp.sec = 1234;
   goal_info.stamp.nanosec = 4567u;
   rcl_action_goal_info_t another_goal_info = rcl_action_get_zero_initialized_goal_info();
   for (int i = 0; i < 16; ++i) {
-    EXPECT_EQ(goal_info.uuid[i], i);
-    EXPECT_EQ(another_goal_info.uuid[i], 0u);
+    EXPECT_EQ(goal_info.goal_id.uuid[i], i);
+    EXPECT_EQ(another_goal_info.goal_id.uuid[i], 0u);
   }
   EXPECT_EQ(goal_info.stamp.sec, 1234);
   EXPECT_EQ(goal_info.stamp.nanosec, 4567u);
@@ -54,9 +54,9 @@ TEST(TestActionTypes, test_get_zero_initialized_goal_status_array)
 TEST(TestActionTypes, test_get_zero_inititalized_cancel_request)
 {
   rcl_action_cancel_request_t cancel_request = rcl_action_get_zero_initialized_cancel_request();
-  ASSERT_EQ(sizeof(cancel_request.goal_info.uuid) / sizeof(uint8_t), 16u);
+  ASSERT_EQ(sizeof(cancel_request.goal_info.goal_id.uuid) / sizeof(uint8_t), 16u);
   for (int i = 0; i < 16; ++i) {
-    EXPECT_EQ(cancel_request.goal_info.uuid[i], 0u);
+    EXPECT_EQ(cancel_request.goal_info.goal_id.uuid[i], 0u);
   }
   EXPECT_EQ(cancel_request.goal_info.stamp.sec, 0);
   EXPECT_EQ(cancel_request.goal_info.stamp.nanosec, 0u);


### PR DESCRIPTION
This PR is part of a series of three that together close https://github.com/ros2/rcl_interfaces/issues/49
EDIT: Depends on https://github.com/ros2/ros2/pull/609
- Make use of unique_identifier_msgs/uuid in rcl_action

connects to ros2/rcl_interfaces#49