### PR TITLE
rcl_action_process_cancel_request no longer changes goal state

### DIFF
--- a/rcl_action/include/rcl_action/action_server.h
+++ b/rcl_action/include/rcl_action/action_server.h
@@ -659,7 +659,8 @@ rcl_action_take_cancel_request(
 /**
  * This is a non-blocking call.
  *
- * This function will transition one or more active goals to the state CANCELING.
+ * This function will compute a list of goals that a cancelation request is attempting to cancel.
+ * It does not change the state of any goal.
  * The following cancel policy applies based on the goal ID and the timestamp
  * contained in the cancel request:
  *
@@ -682,7 +683,7 @@ rcl_action_take_cancel_request(
  * \param[in] action_server handle to the action server that will process the cancel request
  * \param[in] cancel_request a C-typed ROS cancel request to process
  * \param[out] cancel_reponse a zero-initialized cancel response struct
- *   where the response is copied
+ *   where the goal info of goals which should be cancelled are copied
  * \return `RCL_RET_OK` if the response was sent successfully, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
  * \return `RCL_RET_ACTION_SERVER_INVALID` if the action server is invalid, or

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -678,15 +678,12 @@ rcl_action_process_cancel_request(
     goto cleanup;
   }
 
-  // Transition goals to canceling and add to response
+  // Add goal info to output struct
   rcl_action_goal_handle_t * goal_handle;
   for (size_t i = 0u; i < num_goals_to_cancel; ++i) {
     goal_handle = goal_handles_to_cancel[i];
-    ret = rcl_action_update_goal_state(goal_handle, GOAL_EVENT_CANCEL);
-    if (RCL_RET_OK == ret) {
-      ret = rcl_action_goal_handle_get_info(
-        goal_handle, &cancel_response->msg.goals_canceling.data[i]);
-    }
+    ret = rcl_action_goal_handle_get_info(
+      goal_handle, &cancel_response->msg.goals_canceling.data[i]);
     if (RCL_RET_OK != ret) {
       ret_final = RCL_RET_ERROR;  // error already set
     }


### PR DESCRIPTION
`rcl_action_process_cancel_request()` both calculates which goals are being cancelled and transitions them to the `CANCELLING` state. This PR makes it only calculate the list of goals.

The c++ action server needs the list first so it can call a user's cancel callback. The goal should be transitioned to the `CANCELLING` state after the user callback indicates the goal can be cancelled.