### PR TITLE
rcl_action_expire_goals() outputs goals that expire

### DIFF
--- a/rcl_action/include/rcl_action/action_server.h
+++ b/rcl_action/include/rcl_action/action_server.h
@@ -583,8 +583,12 @@ rcl_action_send_result_response(
  * \attention If one or more goals are expired then a previously returned goal handle
  * array from rcl_action_server_get_goal_handles() becomes invalid.
  *
- * `num_expired` is an optional argument. If it is not `NULL`, then it is set to the
- * number of goals that were expired.
+ * `expired_goals`, `expired_goals_capacity` and `num_expired` are optional arguments.
+ * If set to (`NULL`, 0u, `NULL`) then they are not used.
+ * To use them allocate an array with size equal to the maximum number of goals that you want to
+ * expire.
+ * Pass the number of goals the array can hold in as `expired_goals_capacity`.
+ * This function will set `num_expired` to the number of goals that were expired.
  *
  * <hr>
  * Attribute          | Adherence
@@ -598,6 +602,9 @@ rcl_action_send_result_response(
  *
  * \param[in] action_server handle to the action server from which expired goals
  *   will be cleared.
+ * \param[in] expired_goals_allocator allocator to use to allocate expired_goals output
+ * \param[inout] expired_goals the identifiers of goals that expired, or set to `NULL` if unused
+ * \param[inout] expired_goals_capacity the allocated size of `expired_goals`, or 0 if unused
  * \param[out] num_expired the number of expired goals, or set to `NULL` if unused
  * \return `RCL_RET_OK` if the response was sent successfully, or
  * \return `RCL_RET_ACTION_SERVER_INVALID` if the action server is invalid, or
@@ -610,6 +617,8 @@ RCL_WARN_UNUSED
 rcl_ret_t
 rcl_action_expire_goals(
   const rcl_action_server_t * action_server,
+  rcl_action_goal_info_t * expired_goals,
+  size_t expired_goals_capacity,
   size_t * num_expired);
 
 /// Take a pending cancel request using an action server.

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -534,7 +534,6 @@ rcl_action_expire_goals(
   rcl_action_goal_info_t goal_info;
   int64_t goal_time;
   size_t num_goal_handles = action_server->impl->num_goal_handles;
-
   for (size_t i = 0u; i < num_goal_handles; ++i) {
     if (output_expired && i >= expired_goals_capacity) {
       // no more space to output expired goals, so stop expiring them
@@ -565,7 +564,7 @@ rcl_action_expire_goals(
     }
   }
 
-  // Shrink arrays if some goals expired
+  // Shrink goal handle array if some goals expired
   if (num_goals_expired > 0u) {
     if (0u == num_goal_handles) {
       allocator.deallocate(action_server->impl->goal_handles, allocator.state);

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -501,10 +501,20 @@ rcl_action_send_result_response(
 rcl_ret_t
 rcl_action_expire_goals(
   const rcl_action_server_t * action_server,
+  rcl_action_goal_info_t * expired_goals,
+  size_t expired_goals_capacity,
   size_t * num_expired)
 {
   if (!rcl_action_server_is_valid(action_server)) {
     return RCL_RET_ACTION_SERVER_INVALID;
+  }
+  const bool output_expired =
+    NULL != expired_goals && NULL != num_expired && expired_goals_capacity > 0u;
+  if (!output_expired
+    && (NULL != expired_goals || NULL != num_expired || expired_goals_capacity != 0u)
+  ) {
+    RCL_SET_ERROR_MSG("expired_goals, expired_goals_capacity, and num_expired inconsistent");
+    return RCL_RET_INVALID_ARGUMENT;
   }
 
   // Get current time (nanosec)
@@ -524,18 +534,27 @@ rcl_action_expire_goals(
   rcl_action_goal_info_t goal_info;
   int64_t goal_time;
   size_t num_goal_handles = action_server->impl->num_goal_handles;
+
   for (size_t i = 0u; i < num_goal_handles; ++i) {
+    if (output_expired && i >= expired_goals_capacity) {
+      // no more space to output expired goals, so stop expiring them
+      break;
+    }
     goal_handle = action_server->impl->goal_handles[i];
     // Expiration only applys to terminated goals
     if (rcl_action_goal_handle_is_active(goal_handle)) {
       continue;
     }
-    ret = rcl_action_goal_handle_get_info(goal_handle, &goal_info);
+    rcl_action_goal_info_t * info_ptr = &goal_info;
+    if (output_expired) {
+      info_ptr = &(expired_goals[num_goals_expired]);
+    }
+    ret = rcl_action_goal_handle_get_info(goal_handle, info_ptr);
     if (RCL_RET_OK != ret) {
       ret_final = RCL_RET_ERROR;
       continue;
     }
-    goal_time = _goal_info_stamp_to_nanosec(&goal_info);
+    goal_time = _goal_info_stamp_to_nanosec(info_ptr);
     assert(current_time > goal_time);
     if ((current_time - goal_time) > timeout) {
       // Stop tracking goal handle
@@ -546,7 +565,7 @@ rcl_action_expire_goals(
     }
   }
 
-  // Shrink goal handle array if some goals expired
+  // Shrink arrays if some goals expired
   if (num_goals_expired > 0u) {
     if (0u == num_goal_handles) {
       allocator.deallocate(action_server->impl->goal_handles, allocator.state);

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -510,9 +510,9 @@ rcl_action_expire_goals(
   }
   const bool output_expired =
     NULL != expired_goals && NULL != num_expired && expired_goals_capacity > 0u;
-  if (!output_expired
-    && (NULL != expired_goals || NULL != num_expired || expired_goals_capacity != 0u)
-  ) {
+  if (!output_expired &&
+    (NULL != expired_goals || NULL != num_expired || expired_goals_capacity != 0u))
+  {
     RCL_SET_ERROR_MSG("expired_goals, expired_goals_capacity, and num_expired inconsistent");
     return RCL_RET_INVALID_ARGUMENT;
   }

--- a/rcl_action/test/rcl_action/test_action_server.cpp
+++ b/rcl_action/test/rcl_action/test_action_server.cpp
@@ -172,8 +172,6 @@ protected:
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
     ret = rcl_shutdown();
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    ret = rcl_disable_ros_time_override(&this->clock);
-    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   }
 
   void init_test_uuid0(uint8_t * uuid)

--- a/rcl_action/test/rcl_action/test_action_server.cpp
+++ b/rcl_action/test/rcl_action/test_action_server.cpp
@@ -274,7 +274,7 @@ TEST_F(TestActionServer, test_action_accept_new_goal)
 TEST_F(TestActionServer, test_action_clear_expired_goals)
 {
   const size_t capacity = 1u;
-  rcl_action_goal_info_t expired_goals[capacity];
+  rcl_action_goal_info_t expired_goals[1u];
   size_t num_expired = 1u;
   // Clear expired goals with null action server
   rcl_ret_t ret = rcl_action_expire_goals(nullptr, expired_goals, capacity, &num_expired);


### PR DESCRIPTION
The C++ action server needs to keep around the action result message until the goals expire. In order to know when it can throw away the result it needs to know when the `rcl_action_server_t` decided to expire the goal. This makes the API `rcl_action_expire_goals()` output the list of goals that expired.