### PR TITLE
Fini Action Server and Client when node context is invalid + reset error

### DIFF
--- a/rcl_action/src/rcl_action/action_client.c
+++ b/rcl_action/src/rcl_action/action_client.c
@@ -199,7 +199,7 @@ rcl_action_client_fini(rcl_action_client_t * action_client, rcl_node_t * node)
   if (!rcl_action_client_is_valid(action_client)) {
     return RCL_RET_ACTION_CLIENT_INVALID;  // error already set
   }
-  if (!rcl_node_is_valid(node)) {
+  if (!rcl_node_is_valid_except_context(node)) {
     return RCL_RET_NODE_INVALID;  // error already set
   }
   rcl_ret_t ret = RCL_RET_OK;
@@ -396,22 +396,27 @@ rcl_action_client_is_valid(const rcl_action_client_t * action_client)
   RCL_CHECK_FOR_NULL_WITH_MSG(
     action_client->impl, "action client implementation is invalid", return false);
   if (!rcl_client_is_valid(&action_client->impl->goal_client)) {
+    rcl_reset_error();
     RCL_SET_ERROR_MSG("goal client is invalid");
     return false;
   }
   if (!rcl_client_is_valid(&action_client->impl->cancel_client)) {
+    rcl_reset_error();
     RCL_SET_ERROR_MSG("cancel client is invalid");
     return false;
   }
   if (!rcl_client_is_valid(&action_client->impl->result_client)) {
+    rcl_reset_error();
     RCL_SET_ERROR_MSG("result client is invalid");
     return false;
   }
   if (!rcl_subscription_is_valid(&action_client->impl->feedback_subscription)) {
+    rcl_reset_error();
     RCL_SET_ERROR_MSG("feedback subscription is invalid");
     return false;
   }
   if (!rcl_subscription_is_valid(&action_client->impl->status_subscription)) {
+    rcl_reset_error();
     RCL_SET_ERROR_MSG("status subscription is invalid");
     return false;
   }

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -213,7 +213,7 @@ rcl_ret_t
 rcl_action_server_fini(rcl_action_server_t * action_server, rcl_node_t * node)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(action_server, RCL_RET_ACTION_SERVER_INVALID);
-  if (!rcl_node_is_valid(node)) {
+  if (!rcl_node_is_valid_except_context(node)) {
     return RCL_RET_NODE_INVALID;  // error already set
   }
 
@@ -787,22 +787,27 @@ rcl_action_server_is_valid(const rcl_action_server_t * action_server)
   RCL_CHECK_FOR_NULL_WITH_MSG(
     action_server->impl, "action server implementation is invalid", return false);
   if (!rcl_service_is_valid(&action_server->impl->goal_service)) {
+    rcl_reset_error();
     RCL_SET_ERROR_MSG("goal service is invalid");
     return false;
   }
   if (!rcl_service_is_valid(&action_server->impl->cancel_service)) {
+    rcl_reset_error();
     RCL_SET_ERROR_MSG("cancel service is invalid");
     return false;
   }
   if (!rcl_service_is_valid(&action_server->impl->result_service)) {
+    rcl_reset_error();
     RCL_SET_ERROR_MSG("result service is invalid");
     return false;
   }
   if (!rcl_publisher_is_valid(&action_server->impl->feedback_publisher)) {
+    rcl_reset_error();
     RCL_SET_ERROR_MSG("feedback publisher is invalid");
     return false;
   }
   if (!rcl_publisher_is_valid(&action_server->impl->status_publisher)) {
+    rcl_reset_error();
     RCL_SET_ERROR_MSG("status publisher is invalid");
     return false;
   }


### PR DESCRIPTION
This makes `rcl_action_server_fini()` and `rcl_action_client_fini()` clean up even if the node context is invalid.

Also it resets the error message in `rcl_action_server_is_valid()` and `rcl_action_client_is_valid()` before setting a more specific error.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5722)](http://ci.ros2.org/job/ci_linux/5722/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2315)](http://ci.ros2.org/job/ci_linux-aarch64/2315/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4730)](http://ci.ros2.org/job/ci_osx/4730/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5630)](http://ci.ros2.org/job/ci_windows/5630/)