### PR TITLE
add rcl_action_server_is_valid_except_context

### DIFF
--- a/rcl_action/include/rcl_action/action_server.h
+++ b/rcl_action/include/rcl_action/action_server.h
@@ -905,6 +905,30 @@ RCL_WARN_UNUSED
 bool
 rcl_action_server_is_valid(const rcl_action_server_t * action_server);
 
+/// Check if an action server is valid without erroring if the library is shutting down.
+/**
+ * In the case where `false` is returned (ie. the action server is invalid),
+ * an error message is set.
+ *
+ * This function cannot fail.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] action_server handle to the action server
+ * \return `true` if `action_server` is valid, or
+ * \return `false` otherwise.
+ */
+RCL_ACTION_PUBLIC
+RCL_WARN_UNUSED
+bool
+rcl_action_server_is_valid_except_context(const rcl_action_server_t * action_server);
+
 #ifdef __cplusplus
 }
 #endif

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -916,6 +916,35 @@ rcl_action_server_is_valid(const rcl_action_server_t * action_server)
   return true;
 }
 
+bool
+rcl_action_server_is_valid_except_context(const rcl_action_server_t * action_server)
+{
+  RCL_CHECK_FOR_NULL_WITH_MSG(action_server, "action server pointer is invalid", return false);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    action_server->impl, "action server implementation is invalid", return false);
+  if (!rcl_service_is_valid(&action_server->impl->goal_service)) {
+    RCL_SET_ERROR_MSG("goal service is invalid");
+    return false;
+  }
+  if (!rcl_service_is_valid(&action_server->impl->cancel_service)) {
+    RCL_SET_ERROR_MSG("cancel service is invalid");
+    return false;
+  }
+  if (!rcl_service_is_valid(&action_server->impl->result_service)) {
+    RCL_SET_ERROR_MSG("result service is invalid");
+    return false;
+  }
+  if (!rcl_publisher_is_valid_except_context(&action_server->impl->feedback_publisher)) {
+    RCL_SET_ERROR_MSG("feedback publisher is invalid");
+    return false;
+  }
+  if (!rcl_publisher_is_valid_except_context(&action_server->impl->status_publisher)) {
+    RCL_SET_ERROR_MSG("status publisher is invalid");
+    return false;
+  }
+  return true;
+}
+
 rcl_ret_t
 rcl_action_wait_set_add_action_server(
   rcl_wait_set_t * wait_set,
@@ -923,7 +952,7 @@ rcl_action_wait_set_add_action_server(
   size_t * service_index)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(wait_set, RCL_RET_WAIT_SET_INVALID);
-  if (!rcl_action_server_is_valid(action_server)) {
+  if (!rcl_action_server_is_valid_except_context(action_server)) {
     return RCL_RET_ACTION_SERVER_INVALID;  // error already set
   }
 
@@ -972,7 +1001,7 @@ rcl_action_server_wait_set_get_num_entities(
   size_t * num_clients,
   size_t * num_services)
 {
-  if (!rcl_action_server_is_valid(action_server)) {
+  if (!rcl_action_server_is_valid_except_context(action_server)) {
     return RCL_RET_ACTION_SERVER_INVALID;  // error already set
   }
   RCL_CHECK_ARGUMENT_FOR_NULL(num_subscriptions, RCL_RET_INVALID_ARGUMENT);
@@ -998,7 +1027,7 @@ rcl_action_server_wait_set_get_entities_ready(
   bool * is_goal_expired)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(wait_set, RCL_RET_WAIT_SET_INVALID);
-  if (!rcl_action_server_is_valid(action_server)) {
+  if (!rcl_action_server_is_valid_except_context(action_server)) {
     return RCL_RET_ACTION_SERVER_INVALID;  // error already set
   }
   RCL_CHECK_ARGUMENT_FOR_NULL(is_goal_request_ready, RCL_RET_INVALID_ARGUMENT);


### PR DESCRIPTION
This adds a function to check if the action server is valid except for the rcl context and uses it in the wait set apis. This gets rid of an exception thrown by the C++ action server when SIGINT invalidates the context but the wait set tries to check the action server entities and finds that the server has reported itself as invalid.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=5728)](http://ci.ros2.org/job/ci_linux/5728/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2317)](http://ci.ros2.org/job/ci_linux-aarch64/2317/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=4734)](http://ci.ros2.org/job/ci_osx/4734/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5633)](http://ci.ros2.org/job/ci_windows/5633/)