### PR TITLE
Avoid timer period being set to 0

### DIFF
--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -431,7 +431,7 @@ _recalculate_expire_timer(
   rcl_clock_t * clock)
 {
   size_t num_inactive_goals = 0u;
-  int64_t minimum_period = 0;
+  int64_t minimum_period = timeout;
 
   // Get current time (nanosec)
   int64_t current_time;


### PR DESCRIPTION
Fixes ros2/examples#221

`_recalculate_expire_timer()` checks the time left on each of the goal handles and is supposed to set the timer period to the smallest one. The bug is it currently starts the minimum_period at 0, so the timer period is always set to 0 causing 100% CPU usage. 

This starts the minimum period at the goal expiration timeout since that's the maximum time the server might have to wait to expire a goal.

connects to https://github.com/ros2/examples/issues/221