### PR TITLE
Ensure that context instance id storage is aligned correctly

### DIFF
--- a/rcl/include/rcl/context.h
+++ b/rcl/include/rcl/context.h
@@ -30,10 +30,10 @@ extern "C"
 #include "rcl/visibility_control.h"
 
 #ifdef _MSC_VER
-#define ALIGNAS_(N) __declspec(align(N))
+#define RCL_ALIGNAS(N) __declspec(align(N))
 #else
 #include <stdalign.h>
-#define ALIGNAS_(N) alignas(N)
+#define RCL_ALIGNAS(N) alignas(N)
 #endif
 
 typedef uint64_t rcl_context_instance_id_t;
@@ -139,7 +139,7 @@ typedef struct rcl_context_t
    * See this paper for an effort to make this possible in the future:
    *   http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0943r1.html
    */
-  ALIGNAS_(8) uint8_t instance_id_storage[RCL_CONTEXT_ATOMIC_INSTANCE_ID_STORAGE_SIZE];
+  RCL_ALIGNAS(8) uint8_t instance_id_storage[RCL_CONTEXT_ATOMIC_INSTANCE_ID_STORAGE_SIZE];
 } rcl_context_t;
 
 /// Return a zero initialization context object.

--- a/rcl/include/rcl/context.h
+++ b/rcl/include/rcl/context.h
@@ -29,7 +29,12 @@ extern "C"
 #include "rcl/types.h"
 #include "rcl/visibility_control.h"
 
+#ifdef _MSC_VER
+#define ALIGNAS_(N) __declspec(align(N))
+#else
 #include <stdalign.h>
+#define ALIGNAS_(N) alignas(N)
+#endif
 
 typedef uint64_t rcl_context_instance_id_t;
 
@@ -134,7 +139,7 @@ typedef struct rcl_context_t
    * See this paper for an effort to make this possible in the future:
    *   http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0943r1.html
    */
-  alignas(uint_least64_t) uint8_t instance_id_storage[RCL_CONTEXT_ATOMIC_INSTANCE_ID_STORAGE_SIZE];
+  ALIGNAS_(8) uint8_t instance_id_storage[RCL_CONTEXT_ATOMIC_INSTANCE_ID_STORAGE_SIZE];
 } rcl_context_t;
 
 /// Return a zero initialization context object.

--- a/rcl/include/rcl/context.h
+++ b/rcl/include/rcl/context.h
@@ -29,6 +29,8 @@ extern "C"
 #include "rcl/types.h"
 #include "rcl/visibility_control.h"
 
+#include <stdalign.h>
+
 typedef uint64_t rcl_context_instance_id_t;
 
 struct rcl_context_impl_t;
@@ -132,7 +134,7 @@ typedef struct rcl_context_t
    * See this paper for an effort to make this possible in the future:
    *   http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0943r1.html
    */
-  uint8_t instance_id_storage[RCL_CONTEXT_ATOMIC_INSTANCE_ID_STORAGE_SIZE];
+  alignas(uint_least64_t) uint8_t instance_id_storage[RCL_CONTEXT_ATOMIC_INSTANCE_ID_STORAGE_SIZE];
 } rcl_context_t;
 
 /// Return a zero initialization context object.


### PR DESCRIPTION
On 32 bit ARMv7l, casting of the context instance id to an `atomic_uint_least64_t` and initialising it results in SIGBUS if it is not 8 byte aligned. This change fixes that by ensuring that `instance_id_storage` is aligned as `uint_least64_t`.

Closes #363 