### PR TITLE
Guard against bad allocation calling rcl_arguments_copy()

### DIFF
--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -592,11 +592,9 @@ rcl_arguments_fini(
       args->impl->num_remap_rules = 0;
     }
 
-    if (args->impl->unparsed_args) {
-      args->impl->allocator.deallocate(args->impl->unparsed_args, args->impl->allocator.state);
-      args->impl->num_unparsed_args = 0;
-      args->impl->unparsed_args = NULL;
-    }
+    args->impl->allocator.deallocate(args->impl->unparsed_args, args->impl->allocator.state);
+    args->impl->num_unparsed_args = 0;
+    args->impl->unparsed_args = NULL;
 
     if (args->impl->parameter_files) {
       for (int p = 0; p < args->impl->num_param_files_args; ++p) {

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -202,6 +202,21 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_copy) {
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&copied_args));
 }
 
+TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_copy_no_args) {
+  rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
+  rcl_ret_t ret = rcl_parse_arguments(0, NULL, rcl_get_default_allocator(), &parsed_args);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  EXPECT_EQ(0, rcl_arguments_get_count_unparsed(&parsed_args));
+
+  rcl_arguments_t copied_args = rcl_get_zero_initialized_arguments();
+  ret = rcl_arguments_copy(&parsed_args, &copied_args);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  EXPECT_EQ(0, rcl_arguments_get_count_unparsed(&copied_args));
+
+  EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
+  EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&copied_args));
+}
+
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_two_namespace) {
   const char * argv[] = {"process_name", "__ns:=/foo/bar", "__ns:=/fiz/buz"};
   int argc = sizeof(argv) / sizeof(const char *);

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -202,9 +202,24 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_copy) {
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&copied_args));
 }
 
+// Similar to the default allocator, but returns NULL when size is zero.
+// This is useful for emulating systems where `malloc(0)` return NULL.
+// TODO(jacobperron): Consider using this allocate function in other tests
+static void *
+__return_null_on_zero_allocate(size_t size, void * state)
+{
+  RCUTILS_UNUSED(state);
+  if (size == 0) {
+    return NULL;
+  }
+  return malloc(size);
+}
+
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_copy_no_args) {
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  allocator.allocate = __return_null_on_zero_allocate;
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
-  rcl_ret_t ret = rcl_parse_arguments(0, NULL, rcl_get_default_allocator(), &parsed_args);
+  rcl_ret_t ret = rcl_parse_arguments(0, NULL, allocator, &parsed_args);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   EXPECT_EQ(0, rcl_arguments_get_count_unparsed(&parsed_args));
 


### PR DESCRIPTION
Closes #362 

If the implementation of `malloc(0)` returns `NULL` then `rcl_arguments_copy()` will return `RCL_BAD_ALLOC` when the input has `args->impl->num_unparsed_args == 0` or `args->impl->num_remap_rules == 0`.

---

This raises another concern.
It doesn't appear that we have test cases for when `malloc(0)` returns `NULL` (which is a valid implementation). Perhaps we should have a CI job that overrides the default allocate function in `rcutils` to uncover other bugs similar in nature to this one.