### PR TITLE
rebase of rcl rcl_node_get_fully_qualified_name implementation

### DIFF
--- a/rcl/include/rcl/node.h
+++ b/rcl/include/rcl/node.h
@@ -362,7 +362,7 @@ rcl_node_get_namespace(const rcl_node_t * node);
  * <hr>
  * Attribute          | Adherence
  * ------------------ | -------------
- * Allocates Memory   | Yes
+ * Allocates Memory   | No
  * Thread-Safe        | No
  * Uses Atomics       | No
  * Lock-Free          | Yes

--- a/rcl/include/rcl/node.h
+++ b/rcl/include/rcl/node.h
@@ -352,6 +352,29 @@ RCL_WARN_UNUSED
 const char *
 rcl_node_get_namespace(const rcl_node_t * node);
 
+/// Return the fully qualified name of the node.
+/**
+ * This function returns the node's internal namespace and name combined string.
+ * This function can fail, and therefore return `NULL`, if:
+ *   - node is `NULL`
+ *   - node has not been initialized (the implementation is invalid)
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] node pointer to the node
+ * \return fully qualified name string if successful, otherwise `NULL`
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+const char *
+rcl_node_get_fully_qualified_name(const rcl_node_t * node);
+
 /// Return the rcl node options.
 /**
  * This function returns the node's internal options struct.

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -59,6 +59,7 @@ typedef struct rcl_node_impl_t
   rmw_node_t * rmw_node_handle;
   rcl_guard_condition_t * graph_guard_condition;
   const char * logger_name;
+  const char * fq_name;
 } rcl_node_impl_t;
 
 
@@ -284,6 +285,7 @@ rcl_node_init(
   node->impl->rmw_node_handle = NULL;
   node->impl->graph_guard_condition = NULL;
   node->impl->logger_name = NULL;
+  node->impl->fq_name = NULL;
   node->impl->options = rcl_node_get_default_options();
   node->context = context;
   // Initialize node impl.
@@ -318,6 +320,9 @@ rcl_node_init(
     should_free_local_namespace_ = true;
     local_namespace_ = remapped_namespace;
   }
+
+  // compute fully qualified name of the node
+  node->impl->fq_name = rcutils_format_string(*allocator, "%s/%s", local_namespace_, name);
 
   // node logger name
   node->impl->logger_name = rcl_create_node_logger_name(name, local_namespace_, allocator);
@@ -440,6 +445,9 @@ fail:
         ROS_PACKAGE_NAME, "Failed to fini publisher for node: %i", ret);
       allocator->deallocate((char *)node->impl->logger_name, allocator->state);
     }
+    if (node->impl->fq_name) {
+      allocator->deallocate((char *)node->impl->fq_name, allocator->state);
+    }
     if (node->impl->rmw_node_handle) {
       ret = rmw_destroy_node(node->impl->rmw_node_handle);
       if (ret != RMW_RET_OK) {
@@ -514,6 +522,7 @@ rcl_node_fini(rcl_node_t * node)
   allocator.deallocate(node->impl->graph_guard_condition, allocator.state);
   // assuming that allocate and deallocate are ok since they are checked in init
   allocator.deallocate((char *)node->impl->logger_name, allocator.state);
+  allocator.deallocate((char *)node->impl->fq_name, allocator.state);
   if (NULL != node->impl->options.arguments.impl) {
     rcl_ret_t ret = rcl_arguments_fini(&(node->impl->options.arguments));
     if (ret != RCL_RET_OK) {
@@ -609,23 +618,7 @@ rcl_node_get_fully_qualified_name(const rcl_node_t * node)
   if (!rcl_node_is_valid_except_context(node)) {
     return NULL;  // error already set
   }
-
-  const char * name = rcl_node_get_name(node);
-  const char * ns = rcl_node_get_namespace(node);
-  char * fq_name = NULL;
-
-  if ('/' == ns[strlen(ns) - 1]) {
-    fq_name = (char *)calloc(strlen(ns) + strlen(name), sizeof(char));
-    strcpy(fq_name, ns);
-    strcat(fq_name, name);
-  }
-  else {
-    fq_name = (char *)calloc(strlen(ns) + strlen(name) + 1, sizeof(char));
-    strcpy(fq_name, ns);
-    strcat(fq_name, "/");
-    strcat(fq_name, name);
-  }
-  return fq_name;
+  return node->impl->fq_name;
 }
 
 const rcl_node_options_t *

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -603,6 +603,31 @@ rcl_node_get_namespace(const rcl_node_t * node)
   return node->impl->rmw_node_handle->namespace_;
 }
 
+const char *
+rcl_node_get_fully_qualified_name(const rcl_node_t * node)
+{
+  if (!rcl_node_is_valid_except_context(node)) {
+    return NULL;  // error already set
+  }
+
+  const char * name = rcl_node_get_name(node);
+  const char * ns = rcl_node_get_namespace(node);
+  char * fq_name = NULL;
+
+  if ('/' == ns[strlen(ns) - 1]) {
+    fq_name = (char *)calloc(strlen(ns) + strlen(name), sizeof(char));
+    strcpy(fq_name, ns);
+    strcat(fq_name, name);
+  }
+  else {
+    fq_name = (char *)calloc(strlen(ns) + strlen(name) + 1, sizeof(char));
+    strcpy(fq_name, ns);
+    strcat(fq_name, "/");
+    strcat(fq_name, name);
+  }
+  return fq_name;
+}
+
 const rcl_node_options_t *
 rcl_node_get_options(const rcl_node_t * node)
 {

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -16,6 +16,7 @@
 
 #include <regex>
 #include <string>
+#include <cstdlib>
 
 #include "rcl/rcl.h"
 #include "rcl/node.h"
@@ -99,6 +100,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   rcl_node_t invalid_node = rcl_get_zero_initialized_node();
   const char * name = "test_rcl_node_accessors_node";
   const char * namespace_ = "/ns";
+  const char * fq_name = "/ns/test_rcl_node_accessors_node";
   rcl_node_options_t default_options = rcl_node_get_default_options();
   default_options.domain_id = 42;  // Set the domain id to something explicit.
   ret = rcl_node_init(&invalid_node, name, namespace_, &invalid_context, &default_options);
@@ -203,6 +205,27 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   EXPECT_TRUE(actual_node_namespace ? true : false);
   if (actual_node_namespace) {
     EXPECT_EQ(std::string(namespace_), std::string(actual_node_namespace));
+  }
+  // Test rcl_node_get_fully_qualified_name().
+  const char * actual_fq_node_name;
+  actual_fq_node_name = rcl_node_get_fully_qualified_name(nullptr);
+  EXPECT_EQ(nullptr, actual_fq_node_name);
+  rcl_reset_error();
+  actual_fq_node_name = rcl_node_get_fully_qualified_name(&zero_node);
+  EXPECT_EQ(nullptr, actual_fq_node_name);
+  rcl_reset_error();
+  actual_fq_node_name = rcl_node_get_fully_qualified_name(&invalid_node);
+  EXPECT_TRUE(actual_fq_node_name ? true : false);
+  if (actual_fq_node_name) {
+    EXPECT_STREQ(fq_name, actual_fq_node_name);
+    free((char *)actual_fq_node_name);
+  }
+  rcl_reset_error();
+  actual_fq_node_name = rcl_node_get_fully_qualified_name(&node);
+  EXPECT_TRUE(actual_fq_node_name ? true : false);
+  if (actual_fq_node_name) {
+    EXPECT_EQ(std::string(fq_name), std::string(actual_fq_node_name));
+    free((char *)actual_fq_node_name);
   }
   // Test rcl_node_get_logger_name().
   const char * actual_node_logger_name;

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -218,14 +218,14 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   EXPECT_TRUE(actual_fq_node_name ? true : false);
   if (actual_fq_node_name) {
     EXPECT_STREQ(fq_name, actual_fq_node_name);
-    free((char *)actual_fq_node_name);
   }
   rcl_reset_error();
-  actual_fq_node_name = rcl_node_get_fully_qualified_name(&node);
+  EXPECT_NO_MEMORY_OPERATIONS({
+    actual_fq_node_name = rcl_node_get_fully_qualified_name(&node);
+  });
   EXPECT_TRUE(actual_fq_node_name ? true : false);
   if (actual_fq_node_name) {
     EXPECT_EQ(std::string(fq_name), std::string(actual_fq_node_name));
-    free((char *)actual_fq_node_name);
   }
   // Test rcl_node_get_logger_name().
   const char * actual_node_logger_name;


### PR DESCRIPTION
Connects to #255 

This is a rebase of #369 from @rarvolt which is missing some of the recent refactorings. Without these changes it was failing CI.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6105)](http://ci.ros2.org/job/ci_linux/6105/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2580)](http://ci.ros2.org/job/ci_linux-aarch64/2580/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5033)](http://ci.ros2.org/job/ci_osx/5033/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=5974)](http://ci.ros2.org/job/ci_windows/5974/)