### PR TITLE
Add change error to warn for multiple loggers

### DIFF
--- a/rcl/src/rcl/logging_rosout.c
+++ b/rcl/src/rcl/logging_rosout.c
@@ -154,7 +154,8 @@ rcl_ret_t rcl_logging_rosout_init_publisher_for_node(
     return RCL_RET_ERROR;
   }
   if (rcutils_hash_map_key_exists(&__logger_map, &logger_name)) {
-    // @todo: nburek enfornce node name unique
+    // @todo: nburek Update behavior to either enforce unique names or work with non-unique 
+    // names based on the outcome here: https://github.com/ros2/design/issues/187
     RCUTILS_LOG_WARN_NAMED("log_infrastructure", "Publisher already registered for provided node name. If this is due to multiple nodes with the same name then all logs for that logger name will go out over the existing publisher. As soon as any node with that name is destructed it will unregister the publisher, preventing any further logs for that name from going out over the rosout topic.");
     // RCL_SET_ERROR_MSG("Logger already initialized for node.");
     // return RCL_RET_ALREADY_INIT;

--- a/rcl/src/rcl/logging_rosout.c
+++ b/rcl/src/rcl/logging_rosout.c
@@ -157,7 +157,11 @@ rcl_ret_t rcl_logging_rosout_init_publisher_for_node(
     // @TODO(nburek) Update behavior to either enforce unique names or work with non-unique
     // names based on the outcome here: https://github.com/ros2/design/issues/187
     RCUTILS_LOG_WARN_NAMED("rcl.logging_rosout",
-      "Publisher already registered for provided node name. If this is due to multiple nodes with the same name then all logs for that logger name will go out over the existing publisher. As soon as any node with that name is destructed it will unregister the publisher, preventing any further logs for that name from being published on the rosout topic.");
+      "Publisher already registered for provided node name. If this is due to multiple nodes "
+      "with the same name then all logs for that logger name will go out over the existing "
+      "publisher. As soon as any node with that name is destructed it will unregister the "
+      "publisher, preventing any further logs for that name from being published on the rosout "
+      "topic.");
     // RCL_SET_ERROR_MSG("Logger already initialized for node.");
     // return RCL_RET_ALREADY_INIT;
     return RCL_RET_OK;

--- a/rcl/src/rcl/logging_rosout.c
+++ b/rcl/src/rcl/logging_rosout.c
@@ -162,8 +162,6 @@ rcl_ret_t rcl_logging_rosout_init_publisher_for_node(
       "publisher. As soon as any node with that name is destructed it will unregister the "
       "publisher, preventing any further logs for that name from being published on the rosout "
       "topic.");
-    // RCL_SET_ERROR_MSG("Logger already initialized for node.");
-    // return RCL_RET_ALREADY_INIT;
     return RCL_RET_OK;
   }
 

--- a/rcl/src/rcl/logging_rosout.c
+++ b/rcl/src/rcl/logging_rosout.c
@@ -155,7 +155,7 @@ rcl_ret_t rcl_logging_rosout_init_publisher_for_node(
   }
   if (rcutils_hash_map_key_exists(&__logger_map, &logger_name)) {
     // @todo: nburek enfornce node name unique
-    RCUTILS_LOG_WARN_NAMED("log_infrastructure", "Logger already initialized for node");
+    RCUTILS_LOG_WARN_NAMED("log_infrastructure", "Publisher already registered for provided node name. If this is due to multiple nodes with the same name then all logs for that logger name will go out over the existing publisher. As soon as any node with that name is destructed it will unregister the publisher, preventing any further logs for that name from going out over the rosout topic.");
     // RCL_SET_ERROR_MSG("Logger already initialized for node.");
     // return RCL_RET_ALREADY_INIT;
   }

--- a/rcl/src/rcl/logging_rosout.c
+++ b/rcl/src/rcl/logging_rosout.c
@@ -154,9 +154,10 @@ rcl_ret_t rcl_logging_rosout_init_publisher_for_node(
     return RCL_RET_ERROR;
   }
   if (rcutils_hash_map_key_exists(&__logger_map, &logger_name)) {
-    // @todo: nburek Update behavior to either enforce unique names or work with non-unique 
+    // @TODO(nburek) Update behavior to either enforce unique names or work with non-unique
     // names based on the outcome here: https://github.com/ros2/design/issues/187
-    RCUTILS_LOG_WARN_NAMED("log_infrastructure", "Publisher already registered for provided node name. If this is due to multiple nodes with the same name then all logs for that logger name will go out over the existing publisher. As soon as any node with that name is destructed it will unregister the publisher, preventing any further logs for that name from going out over the rosout topic.");
+    RCUTILS_LOG_WARN_NAMED("rcl.logging_rosout",
+      "Publisher already registered for provided node name. If this is due to multiple nodes with the same name then all logs for that logger name will go out over the existing publisher. As soon as any node with that name is destructed it will unregister the publisher, preventing any further logs for that name from being published on the rosout topic.");
     // RCL_SET_ERROR_MSG("Logger already initialized for node.");
     // return RCL_RET_ALREADY_INIT;
   }

--- a/rcl/src/rcl/logging_rosout.c
+++ b/rcl/src/rcl/logging_rosout.c
@@ -160,6 +160,7 @@ rcl_ret_t rcl_logging_rosout_init_publisher_for_node(
       "Publisher already registered for provided node name. If this is due to multiple nodes with the same name then all logs for that logger name will go out over the existing publisher. As soon as any node with that name is destructed it will unregister the publisher, preventing any further logs for that name from being published on the rosout topic.");
     // RCL_SET_ERROR_MSG("Logger already initialized for node.");
     // return RCL_RET_ALREADY_INIT;
+    return RCL_RET_OK;
   }
 
   // Create a new Log message publisher on the node

--- a/rcl/src/rcl/logging_rosout.c
+++ b/rcl/src/rcl/logging_rosout.c
@@ -21,6 +21,7 @@
 #include "rcl/visibility_control.h"
 #include "rcl_interfaces/msg/log.h"
 #include "rcutils/allocator.h"
+#include "rcutils/logging_macros.h"
 #include "rcutils/macros.h"
 #include "rcutils/types/hash_map.h"
 #include "rcutils/types/rcutils_ret.h"
@@ -153,8 +154,10 @@ rcl_ret_t rcl_logging_rosout_init_publisher_for_node(
     return RCL_RET_ERROR;
   }
   if (rcutils_hash_map_key_exists(&__logger_map, &logger_name)) {
-    RCL_SET_ERROR_MSG("Logger already initialized for node.");
-    return RCL_RET_ALREADY_INIT;
+    // @todo: nburek enfornce node name unique
+    RCUTILS_LOG_WARN_NAMED("log_infrastructure", "Logger already initialized for node");
+    // RCL_SET_ERROR_MSG("Logger already initialized for node.");
+    // return RCL_RET_ALREADY_INIT;
   }
 
   // Create a new Log message publisher on the node


### PR DESCRIPTION
**Reproduced issue with the following:**
```
#include "rclcpp/rclcpp.hpp"
  
using namespace std;

int main(int argc, char ** argv)
{
  rclcpp::init(argc, argv);
  auto node1 = rclcpp::Node::make_shared("foo");
  {
    auto node2 = rclcpp::Node::make_shared("bar");
  }
  RCLCPP_INFO(node1->get_logger(), "Bar test complete");
  // rclcpp::spin(node);
  rclcpp::shutdown();

  return 0;
}
```
**Ran with:**
`ros2 run examples_rclcpp_minimal_subscriber multinode __node:=abc`

**Result:**
Before
```
terminate called after throwing an instance of 'rclcpp::exceptions::RCLError'
  what():  failed to initialize rcl node: Logger already initialized for node., at /root/ros2_ws/src/ros2/rcl/rcl/src/rcl/logging_rosout.c:156
```
After
```
[WARN] [log_infrastructure]: Logger already initialized for node
[INFO] [abc]: Bar test complete
```
