### PR TITLE
Enforce non-null argv values on rcl_init().

### DIFF
--- a/rcl/src/rcl/init.c
+++ b/rcl/src/rcl/init.c
@@ -43,6 +43,9 @@ rcl_init(
 
   if (argc > 0) {
     RCL_CHECK_ARGUMENT_FOR_NULL(argv, RCL_RET_INVALID_ARGUMENT);
+    for (int i = 0; i < argc; ++i) {
+      RCL_CHECK_ARGUMENT_FOR_NULL(argv[i], RCL_RET_INVALID_ARGUMENT);
+    }
   } else {
     if (NULL != argv) {
       RCL_SET_ERROR_MSG("argc is <= 0, but argv is not NULL");

--- a/rcl/test/rcl/test_init.cpp
+++ b/rcl/test/rcl/test_init.cpp
@@ -116,6 +116,12 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_init_and_ok_and_s
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
   rcl_reset_error();
   ASSERT_FALSE(rcl_context_is_valid(&context));
+  // If argc is not 0, argv is not null but contains one, it should be an invalid argument.
+  const char * invalid_args[] = {"some-arg", nullptr};
+  ret = rcl_init(2, invalid_args, &init_options, &context);
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
+  rcl_reset_error();
+  ASSERT_FALSE(rcl_context_is_valid(&context));
   // If either the allocate or deallocate function pointers are not set, it should be invalid arg.
   init_options.impl->allocator.allocate = nullptr;
   ret = rcl_init(0, nullptr, &init_options, &context);


### PR DESCRIPTION
Fixes #374.