### PR TITLE
Set symbol visibility to hidden for rcl

### DIFF
--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -70,6 +70,9 @@ ament_target_dependencies(${PROJECT_NAME}
   "tinydir_vendor"
 )
 
+# Causes the visibility macros to use dllexport rather than dllimport,
+# which is appropriate when building the dll but not consuming it.
+target_compile_definitions(${PROJECT_NAME} PRIVATE "RCL_BUILDING_DLL")
 configure_rcl(${PROJECT_NAME} LANGUAGE "C")
 
 install(

--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(rosidl_generator_c REQUIRED)
 find_package(tinydir_vendor REQUIRED)
 
 include_directories(include)
-include(cmake/configure_rcl.cmake)
+include(cmake/rcl_set_symbol_visibility_hidden.cmake)
 include(cmake/get_default_rcl_logging_implementation.cmake)
 get_default_rcl_logging_implementation(RCL_LOGGING_IMPL)
 
@@ -73,7 +73,7 @@ ament_target_dependencies(${PROJECT_NAME}
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(${PROJECT_NAME} PRIVATE "RCL_BUILDING_DLL")
-configure_rcl(${PROJECT_NAME} LANGUAGE "C")
+rcl_set_symbol_visibility_hidden(${PROJECT_NAME} LANGUAGE "C")
 
 install(
   TARGETS ${PROJECT_NAME}

--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(rosidl_generator_c REQUIRED)
 find_package(tinydir_vendor REQUIRED)
 
 include_directories(include)
-
+include(cmake/configure_rcl.cmake)
 include(cmake/get_default_rcl_logging_implementation.cmake)
 get_default_rcl_logging_implementation(RCL_LOGGING_IMPL)
 
@@ -70,9 +70,7 @@ ament_target_dependencies(${PROJECT_NAME}
   "tinydir_vendor"
 )
 
-# Causes the visibility macros to use dllexport rather than dllimport,
-# which is appropriate when building the dll but not consuming it.
-target_compile_definitions(${PROJECT_NAME} PRIVATE "RCL_BUILDING_DLL")
+configure_rcl(${PROJECT_NAME} LANGUAGE "C")
 
 install(
   TARGETS ${PROJECT_NAME}
@@ -105,8 +103,12 @@ if(BUILD_TESTING)
   add_subdirectory(test)
 endif()
 
-ament_package()
+ament_package(CONFIG_EXTRAS "rcl-extras.cmake")
 
+install(
+  DIRECTORY cmake
+  DESTINATION share/${PROJECT_NAME}
+)
 install(
   DIRECTORY include/
   DESTINATION include

--- a/rcl/cmake/configure_rcl.cmake
+++ b/rcl/cmake/configure_rcl.cmake
@@ -63,11 +63,4 @@ macro(configure_rcl library_target)
   else()
     message(FATAL_ERROR "configure_rcl() called with unsupported LANGUAGE: '${_ARG_LANGUAGE}'")
   endif()
-
-  if(WIN32)
-    # Causes the visibility macros to use dllexport rather than dllimport
-    # which is appropriate when building the dll but not consuming it.
-    target_compile_definitions(${library_target}
-      PRIVATE "RCL_BUILDING_DLL")
-  endif()
 endmacro()

--- a/rcl/cmake/configure_rcl.cmake
+++ b/rcl/cmake/configure_rcl.cmake
@@ -1,0 +1,73 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Configures ros client library with custom settings.
+# The custom settings are all related to library symbol visibility, see:
+# https://gcc.gnu.org/wiki/Visibility
+# http://www.ibm.com/developerworks/aix/library/au-aix-symbol-visibility/
+#
+# Below code is heavily referenced from a similar functionality in rmw:
+# https://github.com/ros2/rmw/blob/master/rmw/cmake/configure_rmw_library.cmake
+#
+# :param library_target: the library target
+# :type library_target: string
+# :param LANGUAGE: Optional flag for the language of the library.
+#   Allowed values are "C" and "CXX". The default is "CXX".
+# :type LANGUAGE: string
+#
+# @public
+#
+macro(configure_rcl library_target)
+  cmake_parse_arguments(_ARG "" "LANGUAGE" "" ${ARGN})
+  if(_ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "configure_rcl() called with unused arguments: ${_ARG_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(NOT _ARG_LANGUAGE)
+    set(_ARG_LANGUAGE "CXX")
+  endif()
+
+  if(_ARG_LANGUAGE STREQUAL "C")
+    # Set the visibility to hidden by default if possible
+    if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
+      # Set the visibility of symbols to hidden by default for gcc and clang
+      # (this is already the default on Windows)
+      set_target_properties(${library_target}
+        PROPERTIES
+        COMPILE_FLAGS "-fvisibility=hidden"
+      )
+    endif()
+
+  elseif(_ARG_LANGUAGE STREQUAL "CXX")
+    # Set the visibility to hidden by default if possible
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+      # Set the visibility of symbols to hidden by default for gcc and clang
+      # (this is already the default on Windows)
+      set_target_properties(${library_target}
+        PROPERTIES
+        COMPILE_FLAGS "-fvisibility=hidden -fvisibility-inlines-hidden"
+      )
+    endif()
+
+  else()
+    message(FATAL_ERROR "configure_rcl() called with unsupported LANGUAGE: '${_ARG_LANGUAGE}'")
+  endif()
+
+  if(WIN32)
+    # Causes the visibility macros to use dllexport rather than dllimport
+    # which is appropriate when building the dll but not consuming it.
+    target_compile_definitions(${library_target}
+      PRIVATE "RCL_BUILDING_DLL")
+  endif()
+endmacro()

--- a/rcl/cmake/rcl_set_symbol_visibility_hidden.cmake
+++ b/rcl/cmake/rcl_set_symbol_visibility_hidden.cmake
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 #
 # Configures ros client library with custom settings.
 # The custom settings are all related to library symbol visibility, see:
@@ -28,17 +29,17 @@
 #
 # @public
 #
-macro(rcl_set_symbol_visibility_hidden library_target)
-  cmake_parse_arguments(_ARG "" "LANGUAGE" "" ${ARGN})
-  if(_ARG_UNPARSED_ARGUMENTS)
-    message(FATAL_ERROR "rcl_set_symbol_visibility_hidden() called with unused arguments: ${_ARG_UNPARSED_ARGUMENTS}")
+function(rcl_set_symbol_visibility_hidden library_target)
+  cmake_parse_arguments(ARG "" "LANGUAGE" "" ${ARGN})
+  if(ARG_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "rcl_set_symbol_visibility_hidden() called with unused arguments: ${ARG_UNPARSED_ARGUMENTS}")
   endif()
 
-  if(NOT _ARG_LANGUAGE)
-    set(_ARG_LANGUAGE "CXX")
+  if(NOT ARG_LANGUAGE)
+    set(ARG_LANGUAGE "CXX")
   endif()
 
-  if(_ARG_LANGUAGE STREQUAL "C")
+  if(ARG_LANGUAGE STREQUAL "C")
     # Set the visibility to hidden by default if possible
     if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
       # Set the visibility of symbols to hidden by default for gcc and clang
@@ -49,7 +50,7 @@ macro(rcl_set_symbol_visibility_hidden library_target)
       )
     endif()
 
-  elseif(_ARG_LANGUAGE STREQUAL "CXX")
+  elseif(ARG_LANGUAGE STREQUAL "CXX")
     # Set the visibility to hidden by default if possible
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
       # Set the visibility of symbols to hidden by default for gcc and clang
@@ -61,6 +62,6 @@ macro(rcl_set_symbol_visibility_hidden library_target)
     endif()
 
   else()
-    message(FATAL_ERROR "rcl_set_symbol_visibility_hidden() called with unsupported LANGUAGE: '${_ARG_LANGUAGE}'")
+    message(FATAL_ERROR "rcl_set_symbol_visibility_hidden() called with unsupported LANGUAGE: '${ARG_LANGUAGE}'")
   endif()
-endmacro()
+endfunction()

--- a/rcl/cmake/rcl_set_symbol_visibility_hidden.cmake
+++ b/rcl/cmake/rcl_set_symbol_visibility_hidden.cmake
@@ -28,10 +28,10 @@
 #
 # @public
 #
-macro(configure_rcl library_target)
+macro(rcl_set_symbol_visibility_hidden library_target)
   cmake_parse_arguments(_ARG "" "LANGUAGE" "" ${ARGN})
   if(_ARG_UNPARSED_ARGUMENTS)
-    message(FATAL_ERROR "configure_rcl() called with unused arguments: ${_ARG_UNPARSED_ARGUMENTS}")
+    message(FATAL_ERROR "rcl_set_symbol_visibility_hidden() called with unused arguments: ${_ARG_UNPARSED_ARGUMENTS}")
   endif()
 
   if(NOT _ARG_LANGUAGE)
@@ -61,6 +61,6 @@ macro(configure_rcl library_target)
     endif()
 
   else()
-    message(FATAL_ERROR "configure_rcl() called with unsupported LANGUAGE: '${_ARG_LANGUAGE}'")
+    message(FATAL_ERROR "rcl_set_symbol_visibility_hidden() called with unsupported LANGUAGE: '${_ARG_LANGUAGE}'")
   endif()
 endmacro()

--- a/rcl/rcl-extras.cmake
+++ b/rcl/rcl-extras.cmake
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include("${rcl_DIR}/configure_rcl.cmake")
+include("${rcl_DIR}/rcl_set_symbol_visibility_hidden.cmake")

--- a/rcl/rcl-extras.cmake
+++ b/rcl/rcl-extras.cmake
@@ -1,0 +1,15 @@
+# Copyright 2019 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include("${rcl_DIR}/configure_rcl.cmake")

--- a/rcl_action/CMakeLists.txt
+++ b/rcl_action/CMakeLists.txt
@@ -57,7 +57,7 @@ ament_target_dependencies(${PROJECT_NAME}
   "rosidl_generator_c"
 )
 
-configure_rcl(${PROJECT_NAME} LANGUAGE "C")
+rcl_set_symbol_visibility_hidden(${PROJECT_NAME} LANGUAGE "C")
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(${PROJECT_NAME} PRIVATE "RCL_ACTION_BUILDING_DLL")

--- a/rcl_action/CMakeLists.txt
+++ b/rcl_action/CMakeLists.txt
@@ -56,6 +56,8 @@ ament_target_dependencies(${PROJECT_NAME}
   "rmw"
   "rosidl_generator_c"
 )
+
+configure_rcl(${PROJECT_NAME} LANGUAGE "C")
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(${PROJECT_NAME} PRIVATE "RCL_ACTION_BUILDING_DLL")

--- a/rcl_lifecycle/CMakeLists.txt
+++ b/rcl_lifecycle/CMakeLists.txt
@@ -48,7 +48,7 @@ ament_target_dependencies(rcl_lifecycle
   "rcutils"
 )
 
-configure_rcl(${PROJECT_NAME} LANGUAGE "C")
+rcl_set_symbol_visibility_hidden(${PROJECT_NAME} LANGUAGE "C")
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(rcl_lifecycle PRIVATE "RCL_LIFECYCLE_BUILDING_DLL")

--- a/rcl_lifecycle/CMakeLists.txt
+++ b/rcl_lifecycle/CMakeLists.txt
@@ -48,6 +48,7 @@ ament_target_dependencies(rcl_lifecycle
   "rcutils"
 )
 
+configure_rcl(${PROJECT_NAME} LANGUAGE "C")
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(rcl_lifecycle PRIVATE "RCL_LIFECYCLE_BUILDING_DLL")

--- a/rcl_yaml_param_parser/CMakeLists.txt
+++ b/rcl_yaml_param_parser/CMakeLists.txt
@@ -28,7 +28,7 @@ add_library(
   ${rcl_yaml_parser_sources})
 ament_target_dependencies(${PROJECT_NAME} "yaml" "rcutils" "rcl")
 
-configure_rcl(${PROJECT_NAME} LANGUAGE "C")
+rcl_set_symbol_visibility_hidden(${PROJECT_NAME} LANGUAGE "C")
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(${PROJECT_NAME} PRIVATE "RCL_YAML_PARAM_PARSER_BUILDING_DLL")

--- a/rcl_yaml_param_parser/CMakeLists.txt
+++ b/rcl_yaml_param_parser/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(
   ${rcl_yaml_parser_sources})
 ament_target_dependencies(${PROJECT_NAME} "yaml" "rcutils" "rcl")
 
+configure_rcl(${PROJECT_NAME} LANGUAGE "C")
 # Causes the visibility macros to use dllexport rather than dllimport,
 # which is appropriate when building the dll but not consuming it.
 target_compile_definitions(${PROJECT_NAME} PRIVATE "RCL_YAML_PARAM_PARSER_BUILDING_DLL")


### PR DESCRIPTION
Enabling symbol visibility feature in gcc and clang compilers.
This will hep find symbol export related issues in linux and
potentially reduce compile times.

Discourse topic link:
https://discourse.ros.org/t/set-symbol-visibility-to-hidden-for-rmw-and-rcl-packages/7981