### PR TITLE
Split test_token to avoid compiler note

### DIFF
--- a/rcl/test/rcl/test_lexer.cpp
+++ b/rcl/test/rcl/test_lexer.cpp
@@ -49,14 +49,17 @@ public:
     EXPECT_STREQ(expected_text, actual_text.c_str()); \
   } while (false)
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token)
+TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_different_endings)
 {
   // Things get recognized as tokens whether input ends or non token characters come after them
   EXPECT_LEX(RCL_LEXEME_TOKEN, "foo", "foo");
   EXPECT_LEX(RCL_LEXEME_TOKEN, "foo", "foo:");
   EXPECT_LEX(RCL_LEXEME_TOKEN, "foo_", "foo_");
   EXPECT_LEX(RCL_LEXEME_TOKEN, "foo_", "foo_:");
+}
 
+TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_start_char)
+{
   // Check full range for starting character
   EXPECT_LEX(RCL_LEXEME_TOKEN, "a", "a");
   EXPECT_LEX(RCL_LEXEME_TOKEN, "b", "b");
@@ -111,13 +114,19 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token)
   EXPECT_LEX(RCL_LEXEME_TOKEN, "Y", "Y");
   EXPECT_LEX(RCL_LEXEME_TOKEN, "Z", "Z");
   EXPECT_LEX(RCL_LEXEME_TOKEN, "_", "_");
+}
 
+TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_adjacent_ascii)
+{
   // Check banned characters adjacent to allowed ones in ASCII
   EXPECT_LEX(RCL_LEXEME_NONE, "@", "@");
   EXPECT_LEX(RCL_LEXEME_NONE, "[", "[");
   EXPECT_LEX(RCL_LEXEME_NONE, "`", "`");
   EXPECT_LEX(RCL_LEXEME_NONE, "{", "{");
+}
 
+TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_cannot_start_with_digits)
+{
   // Tokens cannot start with digits
   EXPECT_LEX(RCL_LEXEME_NONE, "0", "0");
   EXPECT_LEX(RCL_LEXEME_NONE, "1", "1");
@@ -129,7 +138,10 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token)
   EXPECT_LEX(RCL_LEXEME_NONE, "7", "7");
   EXPECT_LEX(RCL_LEXEME_NONE, "8", "8");
   EXPECT_LEX(RCL_LEXEME_NONE, "9", "9");
+}
 
+TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_underscores)
+{
   // Tokens may contain underscores
   EXPECT_LEX(RCL_LEXEME_TOKEN, "_abcd", "_abcd");
   EXPECT_LEX(RCL_LEXEME_TOKEN, "abcd_", "abcd_");
@@ -142,7 +154,10 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token)
   EXPECT_LEX(RCL_LEXEME_TOKEN, "A_", "A__bcd");
   EXPECT_LEX(RCL_LEXEME_NONE, "__a", "__a");
   EXPECT_LEX(RCL_LEXEME_NONE, "__A", "__A");
+}
 
+TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_contain_digits)
+{
   // Tokens may contain digits
   EXPECT_LEX(RCL_LEXEME_TOKEN, "_0_", "_0_");
   EXPECT_LEX(RCL_LEXEME_TOKEN, "_1_", "_1_");
@@ -164,7 +179,10 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token)
   EXPECT_LEX(RCL_LEXEME_TOKEN, "a7a", "a7a");
   EXPECT_LEX(RCL_LEXEME_TOKEN, "a8a", "a8a");
   EXPECT_LEX(RCL_LEXEME_TOKEN, "a9a", "a9a");
+}
 
+TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_end_with_digits)
+{
   // Tokens may end with digits
   EXPECT_LEX(RCL_LEXEME_TOKEN, "_0", "_0");
   EXPECT_LEX(RCL_LEXEME_TOKEN, "_1", "_1");
@@ -186,7 +204,10 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token)
   EXPECT_LEX(RCL_LEXEME_TOKEN, "a7", "a7");
   EXPECT_LEX(RCL_LEXEME_TOKEN, "a8", "a8");
   EXPECT_LEX(RCL_LEXEME_TOKEN, "a9", "a9");
+}
 
+TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_close_to_url_scheme)
+{
   // Things that almost look like a url scheme but are actually tokens
   EXPECT_LEX(RCL_LEXEME_TOKEN, "ro", "ro");
   EXPECT_LEX(RCL_LEXEME_TOKEN, "ros", "ros");
@@ -210,7 +231,10 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token)
   EXPECT_LEX(RCL_LEXEME_TOKEN, "rostopic", "rostopic:=");
   EXPECT_LEX(RCL_LEXEME_TOKEN, "rostopic", "rostopic:/");
   EXPECT_LEX(RCL_LEXEME_TOKEN, "rostopic", "rostopic:/a");
+}
 
+TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_upper_case)
+{
   // Tokens may contain uppercase characters
   EXPECT_LEX(RCL_LEXEME_TOKEN, "ABC", "ABC");
   EXPECT_LEX(RCL_LEXEME_TOKEN, "_DEF", "_DEF");


### PR DESCRIPTION
This fixes a compiler note first reported by @mikaelarguedas https://github.com/ros2/rcl/pull/227#issuecomment-387258967

The note pretty much just says the function is really big. This PR splits it into multiple tests.

```
In file included from /home/sloretz/ws/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:58:0,
                 from /home/sloretz/ws/ros2/src/ros2/rcl/rcl/test/rcl/test_lexer.cpp:15:
/home/sloretz/ws/ros2/src/ros2/rcl/rcl/test/rcl/test_lexer.cpp: In member function ‘virtual void TestLexerFixture__rmw_fastrtps_cpp_test_token_Test::TestBody()’:
/home/sloretz/ws/ros2/src/ros2/rcl/rcl/test/rcl/test_lexer.cpp:52:18: note: variable tracking size limit exceeded with -fvar-tracking-assignments, retrying without
 TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token)
                  ^
/home/sloretz/ws/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/internal/gtest-internal.h:1259:3: note: in definition of macro ‘GTEST_TEST_CLASS_NAME_’
   test_case_name##_##test_name##_Test
   ^~~~~~~~~~~~~~
/home/sloretz/ws/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2223:3: note: in expansion of macro ‘GTEST_TEST_’
   GTEST_TEST_(test_fixture, test_name, test_fixture, \
   ^~~~~~~~~~~
/home/sloretz/ws/ros2/src/ros2/rcl/rcl/test/rcl/test_lexer.cpp:52:1: note: in expansion of macro ‘TEST_F’
 TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token)
 ^~~~~~
/home/sloretz/ws/ros2/src/ros2/rcl/rcl/test/rcl/test_lexer.cpp:23:34: note: in expansion of macro ‘CLASSNAME_’
 # define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
                                  ^~~~~~~~~~
/home/sloretz/ws/ros2/src/ros2/rcl/rcl/test/rcl/test_lexer.cpp:52:8: note: in expansion of macro ‘CLASSNAME’
 TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token)
        ^~~~~~~~~
In file included from /home/sloretz/ws/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:58:0,
                 from /home/sloretz/ws/ros2/src/ros2/rcl/rcl/test/rcl/test_lexer.cpp:15:
/home/sloretz/ws/ros2/src/ros2/rcl/rcl/test/rcl/test_lexer.cpp: In member function ‘virtual void TestLexerFixture__rmw_fastrtps_dynamic_cpp_test_token_Test::TestBody()’:
/home/sloretz/ws/ros2/src/ros2/rcl/rcl/test/rcl/test_lexer.cpp:52:18: note: variable tracking size limit exceeded with -fvar-tracking-assignments, retrying without
 TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token)
                  ^
/home/sloretz/ws/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/internal/gtest-internal.h:1259:3: note: in definition of macro ‘GTEST_TEST_CLASS_NAME_’
   test_case_name##_##test_name##_Test
   ^~~~~~~~~~~~~~
/home/sloretz/ws/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2223:3: note: in expansion of macro ‘GTEST_TEST_’
   GTEST_TEST_(test_fixture, test_name, test_fixture, \
   ^~~~~~~~~~~
/home/sloretz/ws/ros2/src/ros2/rcl/rcl/test/rcl/test_lexer.cpp:52:1: note: in expansion of macro ‘TEST_F’
 TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token)
 ^~~~~~
/home/sloretz/ws/ros2/src/ros2/rcl/rcl/test/rcl/test_lexer.cpp:23:34: note: in expansion of macro ‘CLASSNAME_’
 # define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
                                  ^~~~~~~~~~
/home/sloretz/ws/ros2/src/ros2/rcl/rcl/test/rcl/test_lexer.cpp:52:8: note: in expansion of macro ‘CLASSNAME’
 TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token)
        ^~~~~~~~~
```

CI (only rcl)

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6289)](http://ci.ros2.org/job/ci_linux/6289/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2709)](http://ci.ros2.org/job/ci_linux-aarch64/2709/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5169)](http://ci.ros2.org/job/ci_osx/5169/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=6128)](http://ci.ros2.org/job/ci_windows/6128/)