### PR TITLE
Add function rcl_names_and_types_init

### DIFF
--- a/rcl/include/rcl/graph.h
+++ b/rcl/include/rcl/graph.h
@@ -296,7 +296,7 @@ rcl_get_service_names_and_types(
 /**
  * This function initializes the string array for the names and allocates space
  * for all the string arrays for the types according to the given size, but
- * it does not initialize the string array for each setup of types.
+ * it does not initialize the string array for each set of types.
  * However, the string arrays for each set of types is zero initialized.
  *
  * <hr>
@@ -311,7 +311,7 @@ rcl_get_service_names_and_types(
  * \param[in] size the number of names and sets of types to be stored
  * \param[in] allocator to be used to allocate and deallocate memory
  * \returns `RCL_RET_OK` on success, or
- * \returns `RCL_RET_INVALID_ARGUMENT` if `names_and_types` is `NULL`, or
+ * \returns `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
  * \returns `RCL_BAD_ALLOC` if memory allocation fails, or
  * \returns `RCL_RET_ERROR` when an unspecified error occurs.
  */

--- a/rcl/include/rcl/graph.h
+++ b/rcl/include/rcl/graph.h
@@ -292,6 +292,37 @@ rcl_get_service_names_and_types(
   rcl_allocator_t * allocator,
   rcl_names_and_types_t * service_names_and_types);
 
+/// Initialize a rcl_names_and_types_t object.
+/**
+ * This function initializes the string array for the names and allocates space
+ * for all the string arrays for the types according to the given size, but
+ * it does not initialize the string array for each setup of types.
+ * However, the string arrays for each set of types is zero initialized.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[inout] names_and_types object to be initialized
+ * \param[in] size the number of names and sets of types to be stored
+ * \param[in] allocator to be used to allocate and deallocate memory
+ * \returns `RCL_RET_OK` on success, or
+ * \returns `RCL_RET_INVALID_ARGUMENT` if `names_and_types` is `NULL`, or
+ * \returns `RCL_BAD_ALLOC` if memory allocation fails, or
+ * \returns `RCL_RET_ERROR` when an unspecified error occurs.
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_names_and_types_init(
+  rcl_names_and_types_t * names_and_types,
+  size_t size,
+  rcl_allocator_t * allocator);
+
 /// Finalize a rcl_names_and_types_t object.
 /**
  * The object is populated when given to one of the rcl_get_*_names_and_types()

--- a/rcl/src/rcl/graph.c
+++ b/rcl/src/rcl/graph.c
@@ -194,6 +194,17 @@ rcl_get_service_names_and_types(
 }
 
 rcl_ret_t
+rcl_names_and_types_init(
+  rcl_names_and_types_t * names_and_types,
+  size_t size,
+  rcl_allocator_t * allocator)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(names_and_types, RCL_RET_INVALID_ARGUMENT);
+  rmw_ret_t rmw_ret = rmw_names_and_types_init(names_and_types, size, allocator);
+  return rcl_convert_rmw_ret_to_rcl_ret(rmw_ret);
+}
+
+rcl_ret_t
 rcl_names_and_types_fini(rcl_names_and_types_t * topic_names_and_types)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(topic_names_and_types, RCL_RET_INVALID_ARGUMENT);

--- a/rcl/test/rcl/test_graph.cpp
+++ b/rcl/test/rcl/test_graph.cpp
@@ -170,6 +170,41 @@ TEST_F(
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 }
 
+/* Test the rcl_names_and_types_init function.
+ */
+TEST_F(
+  CLASSNAME(TestGraphFixture, RMW_IMPLEMENTATION),
+  test_rcl_names_and_types_init
+) {
+  rcl_ret_t ret;
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  rcl_names_and_types_t nat = rcl_get_zero_initialized_names_and_types();
+  // invalid names and types
+  ret = rcl_names_and_types_init(nullptr, 10, &allocator);
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
+  // invalid allocator
+  ret = rcl_names_and_types_init(&nat, 10, nullptr);
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
+  // zero size
+  ret = rcl_names_and_types_init(&nat, 0, &allocator);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  EXPECT_EQ(nat.names.size, 0u);
+  ret = rcl_names_and_types_fini(&nat);
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  // non-zero size
+  size_t num_names = 10u;
+  ret = rcl_names_and_types_init(&nat, num_names, &allocator);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  EXPECT_EQ(nat.names.size, num_names);
+  for (size_t i = 0; i < num_names; i++) {
+    EXPECT_EQ(nat.types[i].size, 0u);
+  }
+  ret = rcl_names_and_types_fini(&nat);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+}
+
 /* Test the rcl_count_publishers function.
  *
  * This does not test content the response.


### PR DESCRIPTION
This wraps the rmw function just like the finalize function.

---

I plan to use this function in the action graph API ([for example](https://github.com/ros2/rcl/blob/ba83518bf381139938d7341a1120890cf2594a94/rcl_action/src/rcl_action/graph.c#L88)).

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6447)](http://ci.ros2.org/job/ci_linux/6447/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=2819)](http://ci.ros2.org/job/ci_linux-aarch64/2819/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5294)](http://ci.ros2.org/job/ci_osx/5294/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=6268)](http://ci.ros2.org/job/ci_windows/6268/)