### PR TITLE
fix leak in __wait_set_clean_up

### DIFF
--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -83,11 +83,9 @@ __wait_set_is_valid(const rcl_wait_set_t * wait_set)
 static void
 __wait_set_clean_up(rcl_wait_set_t * wait_set, rcl_allocator_t allocator)
 {
-  if (wait_set->subscriptions) {
-    rcl_ret_t ret = rcl_wait_set_resize(wait_set, 0, 0, 0, 0, 0);
-    (void)ret;  // NO LINT
-    assert(RCL_RET_OK == ret);  // Defensive, shouldn't fail with size 0.
-  }
+  rcl_ret_t ret = rcl_wait_set_resize(wait_set, 0, 0, 0, 0, 0);
+  (void)ret;  // NO LINT
+  assert(RCL_RET_OK == ret);  // Defensive, shouldn't fail with size 0.
   if (wait_set->impl) {
     allocator.deallocate(wait_set->impl, allocator.state);
     wait_set->impl = NULL;


### PR DESCRIPTION
Fixes memory leak introduced in #285. Closes ros2/rclpy#302.

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=6715)](http://ci.ros2.org/job/ci_linux/6715/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=3029)](http://ci.ros2.org/job/ci_linux-aarch64/3029/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=5518)](http://ci.ros2.org/job/ci_osx/5518/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=6545)](http://ci.ros2.org/job/ci_windows/6545/)