### PR TITLE
Fix argument passed to logging macros

### DIFF
--- a/rcl/src/rcl/init.c
+++ b/rcl/src/rcl/init.c
@@ -60,7 +60,7 @@ rcl_init(
 
   RCUTILS_LOG_DEBUG_NAMED(
     ROS_PACKAGE_NAME,
-    "Initializing ROS client library, for context at address: %p", context);
+    "Initializing ROS client library, for context at address: %p", (void *) context);
 
   // test expectation that given context is zero initialized
   if (NULL != context->impl) {
@@ -161,7 +161,7 @@ rcl_shutdown(rcl_context_t * context)
 {
   RCUTILS_LOG_DEBUG_NAMED(
     ROS_PACKAGE_NAME,
-    "Shutting down ROS client library, for context at address: %p", context);
+    "Shutting down ROS client library, for context at address: %p", (void *) context);
   RCL_CHECK_ARGUMENT_FOR_NULL(context, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_FOR_NULL_WITH_MSG(
     context->impl, "context is zero-initialized", return RCL_RET_INVALID_ARGUMENT);

--- a/rcl/test/rcl/test_graph.cpp
+++ b/rcl/test/rcl/test_graph.cpp
@@ -709,7 +709,7 @@ void expect_topics_types(
   if (expect) {
     EXPECT_EQ(num_topics, nat.names.size);
   } else {
-    RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Expected topics %d, actual topics %d", num_topics,
+    RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Expected topics %zu, actual topics %zu", num_topics,
       nat.names.size);
   }
   ret = rcl_names_and_types_fini(&nat);


### PR DESCRIPTION
This commit fixes two problems with the logging
statements:
- %p requires a void * object to be passed
- %d expects an integer. For size_t objects, %zu should be used

Signed-off-by: Thomas Moulard <tmoulard@amazon.com>