### PR TITLE
fix heap buffer overflow in test_security_directory

### DIFF
--- a/rcl/test/rcl/test_security_directory.cpp
+++ b/rcl/test/rcl/test_security_directory.cpp
@@ -15,6 +15,7 @@
 #include <gtest/gtest.h>
 
 #include <string>
+#include <algorithm>
 #include "rcl/security_directory.h"
 #include "rcutils/filesystem.h"
 
@@ -109,7 +110,8 @@ TEST_F(TestGetSecureRoot, successScenarios) {
       TEST_SECURITY_DIRECTORY_RESOURCES_DIR_NAME, allocator);
   std::string putenv_input = ROS_SECURITY_ROOT_DIRECTORY_VAR_NAME "=";
   putenv_input += base_lookup_dir_fqn;
-  memcpy(g_envstring, putenv_input.c_str(), sizeof(g_envstring) - 1);
+  memcpy(g_envstring, putenv_input.c_str(),
+    std::min(putenv_input.length(), sizeof(g_envstring) - 1));
   putenv_wrapper(g_envstring);
   /* --------------------------
    * Namespace  : Root


### PR DESCRIPTION
Test shows:
```
root@ip-172-31-27-113:~/ros2_asan_ws/build-asan/rcl/test# ./test_security_directory 
Running main() from /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 3 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 3 tests from TestGetSecureRoot
[ RUN      ] TestGetSecureRoot.failureScenarios

>>> [rcutils|error_handling.c:106] rcutils_set_error_state()
This error state is being overwritten:

  'SECURITY ERROR: directory /root/ros2_asan_ws/build-asan/rcl/test/resources/some_other_namespace/dummy_node does not exist. Lookup strategy: MATCH_EXACT, at /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/security_directory.c:252'

with this new error message:

  'SECURITY ERROR: directory /root/ros2_asan_ws/build-asan/rcl/test/resources/test_security_directory/not_dummy_node does not exist. Lookup strategy: MATCH_EXACT, at /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/security_directory.c:252'

rcutils_reset_error() should be called after error handling to avoid this.
<<<
[       OK ] TestGetSecureRoot.failureScenarios (0 ms)
[ RUN      ] TestGetSecureRoot.successScenarios

>>> [rcutils|error_handling.c:106] rcutils_set_error_state()
This error state is being overwritten:

  'SECURITY ERROR: directory /root/ros2_asan_ws/build-asan/rcl/test/resources/test_security_directory/not_dummy_node does not exist. Lookup strategy: MATCH_EXACT, at /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/security_directory.c:252'

with this new error message:

  'SECURITY ERROR: directory /root/ros2_asan_ws/build-asan/rcl/test/resources/test_security_directory/dummy_node_and_some_suffix_added does not exist. Lookup strategy: MATCH_EXACT, at /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/security_directory.c:252'

rcutils_reset_error() should be called after error handling to avoid this.
<<<
=================================================================
==10537==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60b000000365 at pc 0x7f2e4c049733 bp 0x7fff12158b70 sp 0x7fff12158318
READ of size 511 at 0x60b000000365 thread T0
    #0 0x7f2e4c049732  (/usr/lib/x86_64-linux-gnu/libasan.so.4+0x79732)
    #1 0x563717a0ea58 in TestGetSecureRoot_successScenarios_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_security_directory.cpp:112
    #2 0x563717a878a9 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #3 0x563717a79593 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #4 0x563717a252bb in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #5 0x563717a266e6 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #6 0x563717a2728a in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #7 0x563717a4239b in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #8 0x563717a8a35c in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #9 0x563717a7b85c in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #10 0x563717a3f12f in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #11 0x563717a1267e in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #12 0x563717a125c4 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #13 0x7f2e4af89b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)
    #14 0x563717a0d259 in _start (/root/ros2_asan_ws/build-asan/rcl/test/test_security_directory+0x17259)

0x60b000000365 is located 0 bytes to the right of 101-byte region [0x60b000000300,0x60b000000365)
allocated by thread T0 here:
    #0 0x7f2e4c0b0458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x7f2e4b8b4cfa in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_mutate(unsigned long, unsigned long, char const*, unsigned long) (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0x124cfa)

SUMMARY: AddressSanitizer: heap-buffer-overflow (/usr/lib/x86_64-linux-gnu/libasan.so.4+0x79732) 
Shadow bytes around the buggy address:
  0x0c167fff8010: fd fd fd fd fd fa fa fa fa fa fa fa fa fa fd fd
  0x0c167fff8020: fd fd fd fd fd fd fd fd fd fd fd fa fa fa fa fa
  0x0c167fff8030: fa fa fa fa fd fd fd fd fd fd fd fd fd fd fd fd
  0x0c167fff8040: fd fd fa fa fa fa fa fa fa fa 00 00 00 00 00 00
  0x0c167fff8050: 00 00 00 00 00 00 00 00 fa fa fa fa fa fa fa fa
=>0x0c167fff8060: 00 00 00 00 00 00 00 00 00 00 00 00[05]fa fa fa
  0x0c167fff8070: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c167fff8080: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c167fff8090: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c167fff80a0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x0c167fff80b0: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==10537==ABORTING
```
After fixing with the code change in this PR, tests ran and passed. 

(memory leaks detected and fix is in: #420 