### PR TITLE
fix leak in node.c

### DIFF
--- a/rcl/include/rcl/security_directory.h
+++ b/rcl/include/rcl/security_directory.h
@@ -53,7 +53,7 @@ extern "C"
  * \returns machine specific (absolute) node secure root path or NULL on failure
  */
 RCL_PUBLIC
-const char * rcl_get_secure_root(
+char * rcl_get_secure_root(
   const char * node_name,
   const char * node_namespace,
   const rcl_allocator_t * allocator

--- a/rcl/include/rcl/security_directory.h
+++ b/rcl/include/rcl/security_directory.h
@@ -51,6 +51,7 @@ extern "C"
  * \param[in] node_namespace validated, absolute namespace (starting with "/")
  * \param[in] allocator the allocator to use for allocation
  * \returns machine specific (absolute) node secure root path or NULL on failure
+ *          returned pointer must be deallocated by the caller of this function
  */
 RCL_PUBLIC
 char * rcl_get_secure_root(

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -126,6 +126,7 @@ rcl_node_init(
   rcl_ret_t ret;
   rcl_ret_t fail_ret = RCL_RET_ERROR;
   char * remapped_node_name = NULL;
+  char * node_secure_root = NULL;
 
   // Check options and allocator first, so allocator can be used for errors.
   RCL_CHECK_ARGUMENT_FOR_NULL(options, RCL_RET_INVALID_ARGUMENT);
@@ -306,7 +307,7 @@ rcl_node_init(
     node_security_options.enforce_security = RMW_SECURITY_ENFORCEMENT_PERMISSIVE;
   } else {  // if use_security
     // File discovery magic here
-    const char * node_secure_root = rcl_get_secure_root(name, local_namespace_, allocator);
+    node_secure_root = rcl_get_secure_root(name, local_namespace_, allocator);
     if (node_secure_root) {
       RCUTILS_LOG_INFO_NAMED(ROS_PACKAGE_NAME, "Found security directory: %s", node_secure_root);
       node_security_options.security_root_path = node_secure_root;
@@ -408,6 +409,7 @@ cleanup:
   if (NULL != remapped_node_name) {
     allocator->deallocate(remapped_node_name, allocator->state);
   }
+  allocator->deallocate(node_secure_root, allocator->state);
   return ret;
 }
 

--- a/rcl/src/rcl/security_directory.c
+++ b/rcl/src/rcl/security_directory.c
@@ -173,7 +173,7 @@ char * prefix_match_lookup(
   return node_secure_root;
 }
 
-const char * rcl_get_secure_root(
+char * rcl_get_secure_root(
   const char * node_name,
   const char * node_namespace,
   const rcl_allocator_t * allocator)


### PR DESCRIPTION
Caller of `rcl_get_secure_root` should be responsible for deallocating memory. In `node.c`, `node_secure_root` is only needed for `rmw_create_node`. Code change in this PR frees the memory allocated for storing `node_secure_root` after `rmw_create_node` or in `cleanup`.

using fastRTPS as the DDS vendor when running `test_node` tests, I got the following:
```
root@ip-172-31-27-113:~/ros2_asan_ws/build-asan/rcl/test# ./test_node__rmw_fastrtps_cpp 
Running main() from /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 5 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 5 tests from TestNodeFixture__rmw_fastrtps_cpp
[ RUN      ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_accessors
[       OK ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_accessors (19 ms)
[ RUN      ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_life_cycle
[       OK ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_life_cycle (16 ms)
[ RUN      ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_name_restrictions
[       OK ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_name_restrictions (5 ms)
[ RUN      ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_namespace_restrictions
[       OK ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_namespace_restrictions (21 ms)
[ RUN      ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_names
[       OK ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_names (26 ms)
[----------] 5 tests from TestNodeFixture__rmw_fastrtps_cpp (87 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test case ran. (87 ms total)
[  PASSED  ] 5 tests.

=================================================================
==17555==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0x7f7043993d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7f7042e7bc26 in __default_zero_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:56
    #2 0x7f70436587f0 in rcl_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init.c:78
    #3 0x55f925f01ae7 in TestNodeFixture__rmw_fastrtps_cpp_test_rcl_node_accessors_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_node.cpp:129
    #4 0x55f926004377 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x55f925ff6f8b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55f925fa47fb in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55f925fa5c26 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55f925fa67ca in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x55f925fc18db in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x55f926006e1c in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x55f925ff915c in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x55f925fbe66f in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x55f925f91bbf in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x55f925f91b05 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7f70422e3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0x7f7043993d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7f7042e7bc26 in __default_zero_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:56
    #2 0x7f70436587f0 in rcl_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init.c:78
    #3 0x55f925f0d800 in TestNodeFixture__rmw_fastrtps_cpp_test_rcl_node_life_cycle_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_node.cpp:348
    #4 0x55f926004377 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x55f925ff6f8b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55f925fa47fb in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55f925fa5c26 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55f925fa67ca in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x55f925fc18db in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x55f926006e1c in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x55f925ff915c in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x55f925fbe66f in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x55f925f91bbf in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x55f925f91b05 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7f70422e3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0x7f7043993d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7f7042e7bc26 in __default_zero_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:56
    #2 0x7f70436587f0 in rcl_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init.c:78
    #3 0x55f925f14ccc in TestNodeFixture__rmw_fastrtps_cpp_test_rcl_node_name_restrictions_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_node.cpp:445
    #4 0x55f926004377 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x55f925ff6f8b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55f925fa47fb in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55f925fa5c26 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55f925fa67ca in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x55f925fc18db in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x55f926006e1c in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x55f925ff915c in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x55f925fbe66f in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x55f925f91bbf in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x55f925f91b05 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7f70422e3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0x7f7043993d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7f7042e7bc26 in __default_zero_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:56
    #2 0x7f70436587f0 in rcl_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init.c:78
    #3 0x55f925f19548 in TestNodeFixture__rmw_fastrtps_cpp_test_rcl_node_namespace_restrictions_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_node.cpp:511
    #4 0x55f926004377 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x55f925ff6f8b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55f925fa47fb in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55f925fa5c26 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55f925fa67ca in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x55f925fc18db in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x55f926006e1c in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x55f925ff915c in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x55f925fbe66f in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x55f925f91bbf in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x55f925f91b05 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7f70422e3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0x7f7043993d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7f7042e7bc26 in __default_zero_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:56
    #2 0x7f70436587f0 in rcl_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init.c:78
    #3 0x55f925f20152 in TestNodeFixture__rmw_fastrtps_cpp_test_rcl_node_names_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_node.cpp:615
    #4 0x55f926004377 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x55f925ff6f8b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55f925fa47fb in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55f925fa5c26 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55f925fa67ca in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x55f925fc18db in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x55f926006e1c in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x55f925ff915c in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x55f925fbe66f in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x55f925f91bbf in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x55f925f91b05 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7f70422e3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0x7f7043993d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7f7042e7bc26 in __default_zero_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:56
    #2 0x7f70436587f0 in rcl_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init.c:78
    #3 0x55f925f00b5d in TestNodeFixture__rmw_fastrtps_cpp_test_rcl_node_accessors_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_node.cpp:97
    #4 0x55f926004377 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x55f925ff6f8b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55f925fa47fb in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55f925fa5c26 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55f925fa67ca in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x55f925fc18db in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x55f926006e1c in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x55f925ff915c in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x55f925fbe66f in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x55f925f91bbf in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x55f925f91b05 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7f70422e3b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: AddressSanitizer: 528 byte(s) leaked in 6 allocation(s).
```