### PR TITLE
Changes the default 3rd party logger from rcl_logging_noop to rcl_logging_log4cxx

### DIFF
--- a/rcl/cmake/get_default_rcl_logging_implementation.cmake
+++ b/rcl/cmake/get_default_rcl_logging_implementation.cmake
@@ -24,13 +24,13 @@
 macro(get_default_rcl_logging_implementation var)
 
   # if logging implementation already specified or RCL_LOGGING_IMPLEMENTATION environment variable
-  # is set then use that, otherwise default to using rcl_logging_noop
+  # is set then use that, otherwise default to using rcl_logging_log4cxx
   if(NOT "${RCL_LOGGING_IMPLEMENTATION}" STREQUAL "")
     set(_logging_implementation "${RCL_LOGGING_IMPLEMENTATION}")
   elseif(NOT "$ENV{RCL_LOGGING_IMPLEMENTATION}" STREQUAL "")
     set(_logging_implementation "$ENV{RCL_LOGGING_IMPLEMENTATION}")
   else()
-    set(_logging_implementation rcl_logging_noop)
+    set(_logging_implementation rcl_logging_log4cxx)
   endif()
 
   # persist implementation decision in cache


### PR DESCRIPTION
When we initially did the logging work we had shipped it using the rcl_logging_noop implementation by default because we were having issues getting rcl_logging_log4cxx fully built on Windows and Mac. This allowed the logging changes to make it in for Crystal, but meant that file based logging still wasn't enable. 

Now that rcl_logging_log4cxx has been building, switching the default logger over will enable logs to start being generated by ROS nodes and will enable advanced logging configuration via a log4cxx config file. 

Without this change, anyone who wants the file based logging would have to rebuild from source with the environment variable set to change from the default logger to explicitly use log4cxx. 

Connects to https://github.com/ros2/rcl_logging/pull/7
Related to https://github.com/ros2/rcl_logging/pull/7