### PR TITLE
Add an allocator to the external logging initialization.

### DIFF
--- a/rcl/include/rcl/logging_external_interface.h
+++ b/rcl/include/rcl/logging_external_interface.h
@@ -25,12 +25,14 @@
  *   logging library should use to configure itself.
  *   If no config file is provided this will be set to an empty string.
  *   Must be a NULL terminated c string.
- * \param[in] allocator The allocator to use for memory allocation.
+ * \param[in] allocator The allocator to use for memory allocation.  This is
+ *   an rcutils_allocator_t rather than an rcl_allocator_t to ensure that the
+ *   rcl_logging_* packages don't have a circular dependency back to rcl.
  * \todo TODO(clalancette) This API is marked RCL_PUBLIC, but is not built or
- *       exported from librcl.  Instead, these headers should be split into a
- *       separate package which is then depended on by both rcl and the
- *       rcl_logging_* implementations.  The duplicated headers from the
- *       implementations could then be removed.
+ *   exported from librcl.  Instead, these headers should be split into a
+ *   separate package which is then depended on by both rcl and the
+ *   rcl_logging_* implementations.  The duplicated headers from the
+ *   implementations could then be removed.
  * \return RCL_RET_OK if initialized successfully, or
  * \return RCL_RET_ERROR if an unspecified error occurs.
  */

--- a/rcl/include/rcl/logging_external_interface.h
+++ b/rcl/include/rcl/logging_external_interface.h
@@ -31,7 +31,7 @@
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
-rcl_logging_external_initialize(const char * config_file);
+rcl_logging_external_initialize(const char * config_file, rcutils_allocator_t allocator);
 
 /// Free the resources allocated for the external logging system.
 /**

--- a/rcl/include/rcl/logging_external_interface.h
+++ b/rcl/include/rcl/logging_external_interface.h
@@ -25,6 +25,12 @@
  *   logging library should use to configure itself.
  *   If no config file is provided this will be set to an empty string.
  *   Must be a NULL terminated c string.
+ * \param[in] allocator The allocator to use for memory allocation.
+ * \todo TODO(clalancette) This API is marked RCL_PUBLIC, but is not built or
+ *       exported from librcl.  Instead, these headers should be split into a
+ *       separate package which is then depended on by both rcl and the
+ *       rcl_logging_* implementations.  The duplicated headers from the
+ *       implementations could then be removed.
  * \return RCL_RET_OK if initialized successfully, or
  * \return RCL_RET_ERROR if an unspecified error occurs.
  */

--- a/rcl/src/rcl/logging.c
+++ b/rcl/src/rcl/logging.c
@@ -93,7 +93,7 @@ rcl_logging_configure(const rcl_arguments_t * global_args, const rcl_allocator_t
     }
   }
   if (g_rcl_logging_ext_lib_enabled) {
-    status = rcl_logging_external_initialize(config_file);
+    status = rcl_logging_external_initialize(config_file, g_logging_allocator);
     if (RCL_RET_OK == status) {
       rcl_logging_external_set_logger_level(NULL, default_level);
       g_rcl_logging_out_handlers[g_rcl_logging_num_out_handlers++] =


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

In order to finish the implementation of https://github.com/ros2/rcl_logging/pull/9, we're going to need to allocate some memory.  In order to comply with the way the rest of the system does it, we are going to need to pass an allocator through to `rcl_logging_external_initialize`.  This PR (and the connected one in rcl_logging) stub that out; the implementation that actually uses the allocator will come later, as it will not be an API break.