### PR TITLE
Add new RCL_RET_UNSUPPORTED (for QoS)

### DIFF
--- a/rcl/include/rcl/types.h
+++ b/rcl/include/rcl/types.h
@@ -28,6 +28,8 @@ typedef rmw_ret_t rcl_ret_t;
 #define RCL_RET_BAD_ALLOC RMW_RET_BAD_ALLOC
 /// Invalid argument return code.
 #define RCL_RET_INVALID_ARGUMENT RMW_RET_INVALID_ARGUMENT
+/// Unsupported return code.
+#define RCL_RET_UNSUPPORTED RMW_RET_UNSUPPORTED
 
 // rcl specific ret codes start at 100
 /// rcl_init() already called return code.

--- a/rcl/src/rcl/common.c
+++ b/rcl/src/rcl/common.c
@@ -63,6 +63,8 @@ rcl_convert_rmw_ret_to_rcl_ret(rmw_ret_t rmw_ret)
       return RCL_RET_INVALID_ARGUMENT;
     case RMW_RET_BAD_ALLOC:
       return RCL_RET_BAD_ALLOC;
+    case RMW_RET_UNSUPPORTED:
+      return RCL_RET_UNSUPPORTED;
     default:
       return RCL_RET_ERROR;
   }


### PR DESCRIPTION
Add a new rcl return type for unsupported features.
Unblocks ros2/rclpy#316

Signed-off-by: Emerson Knapp <eknapp@amazon.com>