### PR TITLE
Fix leak in rcl context fini

### DIFF
--- a/rcl/src/rcl/context.c
+++ b/rcl/src/rcl/context.c
@@ -157,6 +157,7 @@ __cleanup_context(rcl_context_t * context)
       }
       allocator.deallocate(context->impl->argv, allocator.state);
     }
+    allocator.deallocate(context->impl, allocator.state);
   }  // if (NULL != context->impl)
 
   // zero-initialize the context


### PR DESCRIPTION
tests in `test_node` revealed memory leaks:

```
root@ip-172-31-27-113:~/ros2_asan_ws/build-asan/rcl/test# ./test_node__rmw_fastrtps_cpp 
Running main() from /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 5 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 5 tests from TestNodeFixture__rmw_fastrtps_cpp
[ RUN      ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_accessors
[       OK ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_accessors (19 ms)
[ RUN      ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_life_cycle
[       OK ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_life_cycle (15 ms)
[ RUN      ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_name_restrictions
[       OK ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_name_restrictions (5 ms)
[ RUN      ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_namespace_restrictions
[       OK ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_namespace_restrictions (19 ms)
[ RUN      ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_names
[       OK ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_names (25 ms)
[----------] 5 tests from TestNodeFixture__rmw_fastrtps_cpp (83 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test case ran. (83 ms total)
[  PASSED  ] 5 tests.

=================================================================
==12172==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7ffff64c3df6 in __default_zero_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:56
    #2 0x7ffff6bba58f in rcl_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init.c:78
    #3 0x5555555ca557 in TestNodeFixture__rmw_fastrtps_cpp_test_rcl_node_accessors_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_node.cpp:129
    #4 0x5555556ccde7 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555556bf9fb in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55555566d26b in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55555566e696 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555566f23a in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x55555568a34b in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555556cf88c in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555556c1bcc in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555556870df in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x55555565a62f in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x55555565a575 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff5930b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7ffff64c3df6 in __default_zero_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:56
    #2 0x7ffff6bba58f in rcl_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init.c:78
    #3 0x5555555d6270 in TestNodeFixture__rmw_fastrtps_cpp_test_rcl_node_life_cycle_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_node.cpp:348
    #4 0x5555556ccde7 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555556bf9fb in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55555566d26b in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55555566e696 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555566f23a in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x55555568a34b in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555556cf88c in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555556c1bcc in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555556870df in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x55555565a62f in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x55555565a575 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff5930b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7ffff64c3df6 in __default_zero_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:56
    #2 0x7ffff6bba58f in rcl_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init.c:78
    #3 0x5555555dd73c in TestNodeFixture__rmw_fastrtps_cpp_test_rcl_node_name_restrictions_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_node.cpp:445
    #4 0x5555556ccde7 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555556bf9fb in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55555566d26b in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55555566e696 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555566f23a in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x55555568a34b in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555556cf88c in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555556c1bcc in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555556870df in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x55555565a62f in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x55555565a575 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff5930b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7ffff64c3df6 in __default_zero_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:56
    #2 0x7ffff6bba58f in rcl_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init.c:78
    #3 0x5555555e1fb8 in TestNodeFixture__rmw_fastrtps_cpp_test_rcl_node_namespace_restrictions_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_node.cpp:511
    #4 0x5555556ccde7 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555556bf9fb in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55555566d26b in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55555566e696 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555566f23a in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x55555568a34b in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555556cf88c in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555556c1bcc in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555556870df in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x55555565a62f in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x55555565a575 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff5930b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7ffff64c3df6 in __default_zero_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:56
    #2 0x7ffff6bba58f in rcl_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init.c:78
    #3 0x5555555e8bc2 in TestNodeFixture__rmw_fastrtps_cpp_test_rcl_node_names_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_node.cpp:615
    #4 0x5555556ccde7 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555556bf9fb in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55555566d26b in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55555566e696 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555566f23a in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x55555568a34b in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555556cf88c in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555556c1bcc in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555556870df in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x55555565a62f in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x55555565a575 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff5930b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7ffff64c3df6 in __default_zero_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:56
    #2 0x7ffff6bba58f in rcl_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init.c:78
    #3 0x5555555c95cd in TestNodeFixture__rmw_fastrtps_cpp_test_rcl_node_accessors_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_node.cpp:97
    #4 0x5555556ccde7 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555556bf9fb in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55555566d26b in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55555566e696 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555566f23a in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x55555568a34b in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555556cf88c in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555556c1bcc in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555556870df in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x55555565a62f in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x55555565a575 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff5930b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: AddressSanitizer: 528 byte(s) leaked in 6 allocation(s).
```

Addressed the leak and got:
```
root@ip-172-31-27-113:~/ros2_asan_ws/build-asan/rcl/test# ./test_node__rmw_fastrtps_cpp 
Running main() from /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 5 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 5 tests from TestNodeFixture__rmw_fastrtps_cpp
[ RUN      ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_accessors
[       OK ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_accessors (19 ms)
[ RUN      ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_life_cycle
[       OK ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_life_cycle (14 ms)
[ RUN      ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_name_restrictions
[       OK ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_name_restrictions (5 ms)
[ RUN      ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_namespace_restrictions
[       OK ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_namespace_restrictions (19 ms)
[ RUN      ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_names
[       OK ] TestNodeFixture__rmw_fastrtps_cpp.test_rcl_node_names (24 ms)
[----------] 5 tests from TestNodeFixture__rmw_fastrtps_cpp (82 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test case ran. (82 ms total)
[  PASSED  ] 5 tests.
```