### PR TITLE
add explicit dependency on rcl_logging_log4cxx

### DIFF
--- a/rcl/package.xml
+++ b/rcl/package.xml
@@ -28,6 +28,7 @@
   <exec_depend>rcutils</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
+  <depend>rcl_logging_log4cxx</depend> <!-- the default logging impl -->
   <depend>rmw_implementation</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>


### PR DESCRIPTION
Makes it possible for the devel / PR jobs to pass, e.g. http://build.ros2.org/view/Ddev/job/Ddev__rcl__ubuntu_bionic_amd64/21/