### PR TITLE
Revert "Changes the default 3rd party logger from rcl_logging_noop to…

### DIFF
--- a/rcl/cmake/get_default_rcl_logging_implementation.cmake
+++ b/rcl/cmake/get_default_rcl_logging_implementation.cmake
@@ -24,13 +24,13 @@
 macro(get_default_rcl_logging_implementation var)
 
   # if logging implementation already specified or RCL_LOGGING_IMPLEMENTATION environment variable
-  # is set then use that, otherwise default to using rcl_logging_log4cxx
+  # is set then use that, otherwise default to using rcl_logging_noop
   if(NOT "${RCL_LOGGING_IMPLEMENTATION}" STREQUAL "")
     set(_logging_implementation "${RCL_LOGGING_IMPLEMENTATION}")
   elseif(NOT "$ENV{RCL_LOGGING_IMPLEMENTATION}" STREQUAL "")
     set(_logging_implementation "$ENV{RCL_LOGGING_IMPLEMENTATION}")
   else()
-    set(_logging_implementation rcl_logging_log4cxx)
+    set(_logging_implementation rcl_logging_noop)
   endif()
 
   # persist implementation decision in cache

--- a/rcl/package.xml
+++ b/rcl/package.xml
@@ -28,7 +28,6 @@
   <exec_depend>rcutils</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
-  <depend>rcl_logging_log4cxx</depend> <!-- the default logging impl -->
   <depend>rmw_implementation</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>

--- a/rcl/package.xml
+++ b/rcl/package.xml
@@ -28,6 +28,7 @@
   <exec_depend>rcutils</exec_depend>
   <exec_depend>rosidl_default_runtime</exec_depend>
 
+  <depend>rcl_logging_noop</depend> <!-- the default logging impl -->
   <depend>rmw_implementation</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>


### PR DESCRIPTION
… rcl_logging_log4cxx (#425)"

This reverts commit ac8ee907405748684d1184ca4fd6257313f20a5c.

As discussed at length in https://github.com/ros2/build_cop/issues/189 and https://github.com/ros2/build_cop/issues/188, there are enough problems in the rcl_logging_log4cxx backend that we should switch back to noop for now and then revisit the issue immediately after dashing.  