### PR TITLE
Fix leaks in test_wait.cpp

### DIFF
--- a/rcl/test/rcl/test_wait.cpp
+++ b/rcl/test/rcl/test_wait.cpp
@@ -111,35 +111,42 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), negative_timeout) {
   rcl_ret_t ret =
     rcl_wait_set_init(&wait_set, 0, 1, 1, 0, 0, 0, context_ptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    ret = rcl_wait_set_fini(&wait_set);
+    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  });
 
   // Add a dummy guard condition to avoid an error
   rcl_guard_condition_t guard_cond = rcl_get_zero_initialized_guard_condition();
   ret = rcl_guard_condition_init(
     &guard_cond, this->context_ptr, rcl_guard_condition_get_default_options());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    ret = rcl_guard_condition_fini(&guard_cond);
+    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  });
   ret = rcl_wait_set_add_guard_condition(&wait_set, &guard_cond, NULL);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
   rcl_clock_t clock;
   rcl_allocator_t allocator = rcl_get_default_allocator();
   ret = rcl_clock_init(RCL_STEADY_TIME, &clock, &allocator);
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    ret = rcl_clock_fini(&clock);
+    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  });
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
   rcl_timer_t timer = rcl_get_zero_initialized_timer();
   ret = rcl_timer_init(
     &timer, &clock, this->context_ptr, RCL_MS_TO_NS(10), nullptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  ret = rcl_wait_set_add_timer(&wait_set, &timer, NULL);
-  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-    rcl_ret_t ret = rcl_guard_condition_fini(&guard_cond);
-    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    ret = rcl_wait_set_fini(&wait_set);
-    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     ret = rcl_timer_fini(&timer);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
+  ret = rcl_wait_set_add_timer(&wait_set, &timer, NULL);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
   int64_t timeout = -1;
   std::chrono::steady_clock::time_point before_sc = std::chrono::steady_clock::now();
@@ -158,21 +165,22 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), zero_timeout) {
   rcl_ret_t ret =
     rcl_wait_set_init(&wait_set, 0, 1, 1, 0, 0, 0, context_ptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    ret = rcl_wait_set_fini(&wait_set);
+    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  });
 
   // Add a dummy guard condition to avoid an error
   rcl_guard_condition_t guard_cond = rcl_get_zero_initialized_guard_condition();
   ret = rcl_guard_condition_init(
     &guard_cond, this->context_ptr, rcl_guard_condition_get_default_options());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  ret = rcl_wait_set_add_guard_condition(&wait_set, &guard_cond, NULL);
-  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-    rcl_ret_t ret = rcl_guard_condition_fini(&guard_cond);
-    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    ret = rcl_wait_set_fini(&wait_set);
+    ret = rcl_guard_condition_fini(&guard_cond);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
+  ret = rcl_wait_set_add_guard_condition(&wait_set, &guard_cond, NULL);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
   // Time spent during wait should be negligible.
   int64_t timeout = 0;
@@ -191,22 +199,23 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), zero_timeout_triggered
   rcl_ret_t ret =
     rcl_wait_set_init(&wait_set, 0, 1, 0, 0, 0, 0, context_ptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    ret = rcl_wait_set_fini(&wait_set);
+    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  });
 
   rcl_guard_condition_t guard_cond = rcl_get_zero_initialized_guard_condition();
   ret = rcl_guard_condition_init(
     &guard_cond, this->context_ptr, rcl_guard_condition_get_default_options());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    ret = rcl_guard_condition_fini(&guard_cond);
+    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  });
   ret = rcl_wait_set_add_guard_condition(&wait_set, &guard_cond, NULL);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   ret = rcl_trigger_guard_condition(&guard_cond);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-    rcl_ret_t ret = rcl_guard_condition_fini(&guard_cond);
-    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    ret = rcl_wait_set_fini(&wait_set);
-    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  });
 
 // Time spent during wait should be negligible.
   int64_t timeout = 0;
@@ -225,18 +234,30 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), canceled_timer) {
   rcl_ret_t ret =
     rcl_wait_set_init(&wait_set, 0, 1, 1, 0, 0, 0, context_ptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    ret = rcl_wait_set_fini(&wait_set);
+    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  });
 
   // Add a dummy guard condition to avoid an error
   rcl_guard_condition_t guard_cond = rcl_get_zero_initialized_guard_condition();
   ret = rcl_guard_condition_init(
     &guard_cond, this->context_ptr, rcl_guard_condition_get_default_options());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    ret = rcl_guard_condition_fini(&guard_cond);
+    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  });
   ret = rcl_wait_set_add_guard_condition(&wait_set, &guard_cond, NULL);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
   rcl_clock_t clock;
   rcl_allocator_t allocator = rcl_get_default_allocator();
   ret = rcl_clock_init(RCL_STEADY_TIME, &clock, &allocator);
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    ret = rcl_clock_fini(&clock);
+    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  });
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
   rcl_timer_t canceled_timer = rcl_get_zero_initialized_timer();
@@ -244,19 +265,14 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), canceled_timer) {
     &canceled_timer, &clock, this->context_ptr,
     RCL_MS_TO_NS(1), nullptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    ret = rcl_timer_fini(&canceled_timer);
+    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  });
   ret = rcl_timer_cancel(&canceled_timer);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   ret = rcl_wait_set_add_timer(&wait_set, &canceled_timer, NULL);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-    rcl_ret_t ret = rcl_guard_condition_fini(&guard_cond);
-    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    ret = rcl_wait_set_fini(&wait_set);
-    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    ret = rcl_timer_fini(&canceled_timer);
-    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  });
 
   int64_t timeout = RCL_MS_TO_NS(10);
   std::chrono::steady_clock::time_point before_sc = std::chrono::steady_clock::now();
@@ -267,9 +283,6 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), canceled_timer) {
   // Check time
   int64_t diff = std::chrono::duration_cast<std::chrono::nanoseconds>(after_sc - before_sc).count();
   EXPECT_LE(diff, RCL_MS_TO_NS(10) + TOLERANCE);
-
-  ret = rcl_clock_fini(&clock);
-  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 }
 
 // Test rcl_wait_set_t with excess capacity works.
@@ -278,6 +291,10 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), excess_capacity) {
   rcl_ret_t ret =
     rcl_wait_set_init(&wait_set, 42, 42, 42, 42, 42, 0, context_ptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    ret = rcl_wait_set_fini(&wait_set);
+    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  });
 
   int64_t timeout = 1;
   ret = rcl_wait(&wait_set, timeout);
@@ -358,11 +375,13 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), multi_wait_set_threade
     ret = rcl_guard_condition_init(
       &test_set.guard_condition, this->context_ptr, rcl_guard_condition_get_default_options());
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+    // guard_condition must live longer than this loop. Call fini from function-level exit-scope.
     // setup the wait set
     test_set.wait_set = rcl_get_zero_initialized_wait_set();
     ret = rcl_wait_set_init(
       &test_set.wait_set, 0, 1, 0, 0, 0, 0, context_ptr, rcl_get_default_allocator());
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+    // wait_set must live longer than this loop. Call fini from function-level exit-scope.
     ret = rcl_wait_set_add_guard_condition(&test_set.wait_set, &test_set.guard_condition, NULL);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     test_set.thread_id = 0;
@@ -421,19 +440,20 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), guard_condition) {
   rcl_ret_t ret =
     rcl_wait_set_init(&wait_set, 0, 1, 0, 0, 0, 0, context_ptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    ret = rcl_wait_set_fini(&wait_set);
+    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  });
   rcl_guard_condition_t guard_cond = rcl_get_zero_initialized_guard_condition();
   ret = rcl_guard_condition_init(
     &guard_cond, this->context_ptr, rcl_guard_condition_get_default_options());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  ret = rcl_wait_set_add_guard_condition(&wait_set, &guard_cond, NULL);
-  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
-    rcl_ret_t ret = rcl_wait_set_fini(&wait_set);
-    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     ret = rcl_guard_condition_fini(&guard_cond);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
+  ret = rcl_wait_set_add_guard_condition(&wait_set, &guard_cond, NULL);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
   std::promise<rcl_ret_t> p;
 
@@ -469,6 +489,10 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), add_with_index) {
   rcl_ret_t ret = rcl_wait_set_init(
     &wait_set, 0, kNumEntities, 0, 0, 0, 0, context_ptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    ret = rcl_wait_set_fini(&wait_set);
+    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  });
 
   // Initialize to invalid value
   size_t guard_condition_index = 42u;
@@ -479,6 +503,10 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), add_with_index) {
     ret = rcl_guard_condition_init(
       &guard_conditions[i], this->context_ptr, rcl_guard_condition_get_default_options());
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      ret = rcl_guard_condition_fini(&guard_conditions[i]);
+      EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+    });
     ret = rcl_wait_set_add_guard_condition(
       &wait_set, &guard_conditions[i], &guard_condition_index);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;


### PR DESCRIPTION
- Ensured appropriate 'fini' functions are called for any allocations made during tests. 
- Where possible, 'fini' is called from an 'OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT' that immediately follows where the object is initialized.
- Ensured all instances of 'fini' follow a consistent pattern within the file.

Before this fix
```
Testing started at 1:16 PM ...
/home/cevans/ros2/src/ros2/rcl/rcl/cmake-build-debug/test/test_wait__rmw_fastrtps_cpp --gtest_filter=* --gtest_color=no
Running main() from /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc

=================================================================
Direct leak of 184 byte(s) in 1 object(s) allocated from:
    #0 0x7f9f12272b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7f9f119c0095 in __default_allocate /home/cevans/ros2/src/ros2/rcutils/src/allocator.c:35
    #2 0x7f9f11f5d596 in rcl_wait_set_init /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/wait.c:134
    #3 0x55a93e404398 in WaitSetTestFixture__rmw_fastrtps_cpp_add_with_index_Test::TestBody() /home/cevans/ros2/src/ros2/rcl/rcl/test/rcl/test_wait.cpp:469
    #4 0x55a93e43fc17 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x55a93e4393ba in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55a93e417115 in testing::Test::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55a93e417aaa in testing::TestInfo::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55a93e418153 in testing::TestCase::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x55a93e4231f1 in testing::internal::UnitTestImpl::RunAllTests() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x55a93e440e1e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x55a93e43a250 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x55a93e421c7d in testing::UnitTest::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x55a93e40f03f in RUN_ALL_TESTS() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x55a93e40efce in main /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7f9f10e27b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 184 byte(s) in 1 object(s) allocated from:
    #0 0x7f9f12272b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7f9f119c0095 in __default_allocate /home/cevans/ros2/src/ros2/rcutils/src/allocator.c:35
    #2 0x7f9f11f5d596 in rcl_wait_set_init /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/wait.c:134
    #3 0x55a93e40141f in WaitSetTestFixture__rmw_fastrtps_cpp_excess_capacity_Test::TestBody() /home/cevans/ros2/src/ros2/rcl/rcl/test/rcl/test_wait.cpp:279
    #4 0x55a93e43fc17 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x55a93e4393ba in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55a93e417115 in testing::Test::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55a93e417aaa in testing::TestInfo::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55a93e418153 in testing::TestCase::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x55a93e4231f1 in testing::internal::UnitTestImpl::RunAllTests() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x55a93e440e1e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x55a93e43a250 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x55a93e421c7d in testing::UnitTest::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x55a93e40f03f in RUN_ALL_TESTS() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x55a93e40efce in main /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7f9f10e27b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 168 byte(s) in 3 object(s) allocated from:
    #0 0x7f9f12272b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7f9f119c0095 in __default_allocate /home/cevans/ros2/src/ros2/rcutils/src/allocator.c:35
    #2 0x7f9f11f32e20 in __rcl_guard_condition_init_from_rmw_impl /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/guard_condition.c:73
    #3 0x7f9f11f3333e in rcl_guard_condition_init /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/guard_condition.c:107
    #4 0x55a93e404550 in WaitSetTestFixture__rmw_fastrtps_cpp_add_with_index_Test::TestBody() /home/cevans/ros2/src/ros2/rcl/rcl/test/rcl/test_wait.cpp:479
    #5 0x55a93e43fc17 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x55a93e4393ba in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x55a93e417115 in testing::Test::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #8 0x55a93e417aaa in testing::TestInfo::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x55a93e418153 in testing::TestCase::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x55a93e4231f1 in testing::internal::UnitTestImpl::RunAllTests() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x55a93e440e1e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x55a93e43a250 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x55a93e421c7d in testing::UnitTest::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x55a93e40f03f in RUN_ALL_TESTS() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x55a93e40efce in main /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7f9f10e27b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f9f12272f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7f9f119c00dd in __default_reallocate /home/cevans/ros2/src/ros2/rcutils/src/allocator.c:49
    #2 0x7f9f11f5fbc8 in rcl_wait_set_resize /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/wait.c:392
    #3 0x7f9f11f5dab2 in rcl_wait_set_init /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/wait.c:167
    #4 0x55a93e404398 in WaitSetTestFixture__rmw_fastrtps_cpp_add_with_index_Test::TestBody() /home/cevans/ros2/src/ros2/rcl/rcl/test/rcl/test_wait.cpp:469
    #5 0x55a93e43fc17 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x55a93e4393ba in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x55a93e417115 in testing::Test::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #8 0x55a93e417aaa in testing::TestInfo::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x55a93e418153 in testing::TestCase::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x55a93e4231f1 in testing::internal::UnitTestImpl::RunAllTests() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x55a93e440e1e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x55a93e43a250 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x55a93e421c7d in testing::UnitTest::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x55a93e40f03f in RUN_ALL_TESTS() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x55a93e40efce in main /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7f9f10e27b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 672 byte(s) in 1 object(s) allocated from:
    #0 0x7f9f12272f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7f9f119c00dd in __default_reallocate /home/cevans/ros2/src/ros2/rcutils/src/allocator.c:49
    #2 0x7f9f11f5ff2a in rcl_wait_set_resize /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/wait.c:406
    #3 0x7f9f11f5dab2 in rcl_wait_set_init /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/wait.c:167
    #4 0x55a93e40141f in WaitSetTestFixture__rmw_fastrtps_cpp_excess_capacity_Test::TestBody() /home/cevans/ros2/src/ros2/rcl/rcl/test/rcl/test_wait.cpp:279
    #5 0x55a93e43fc17 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x55a93e4393ba in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x55a93e417115 in testing::Test::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #8 0x55a93e417aaa in testing::TestInfo::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x55a93e418153 in testing::TestCase::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x55a93e4231f1 in testing::internal::UnitTestImpl::RunAllTests() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x55a93e440e1e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x55a93e43a250 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x55a93e421c7d in testing::UnitTest::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x55a93e40f03f in RUN_ALL_TESTS() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x55a93e40efce in main /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7f9f10e27b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 336 byte(s) in 1 object(s) allocated from:
    #0 0x7f9f12272f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7f9f119c00dd in __default_reallocate /home/cevans/ros2/src/ros2/rcutils/src/allocator.c:49
    #2 0x7f9f11f5f7db in rcl_wait_set_resize /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/wait.c:384
    #3 0x7f9f11f5dab2 in rcl_wait_set_init /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/wait.c:167
    #4 0x55a93e40141f in WaitSetTestFixture__rmw_fastrtps_cpp_excess_capacity_Test::TestBody() /home/cevans/ros2/src/ros2/rcl/rcl/test/rcl/test_wait.cpp:279
    #5 0x55a93e43fc17 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x55a93e4393ba in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x55a93e417115 in testing::Test::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #8 0x55a93e417aaa in testing::TestInfo::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x55a93e418153 in testing::TestCase::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x55a93e4231f1 in testing::internal::UnitTestImpl::RunAllTests() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x55a93e440e1e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x55a93e43a250 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x55a93e421c7d in testing::UnitTest::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x55a93e40f03f in RUN_ALL_TESTS() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x55a93e40efce in main /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7f9f10e27b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 336 byte(s) in 1 object(s) allocated from:
    #0 0x7f9f12272f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7f9f119c00dd in __default_reallocate /home/cevans/ros2/src/ros2/rcutils/src/allocator.c:49
    #2 0x7f9f11f611ba in rcl_wait_set_resize /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/wait.c:431
    #3 0x7f9f11f5dab2 in rcl_wait_set_init /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/wait.c:167
    #4 0x55a93e40141f in WaitSetTestFixture__rmw_fastrtps_cpp_excess_capacity_Test::TestBody() /home/cevans/ros2/src/ros2/rcl/rcl/test/rcl/test_wait.cpp:279
    #5 0x55a93e43fc17 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x55a93e4393ba in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x55a93e417115 in testing::Test::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #8 0x55a93e417aaa in testing::TestInfo::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x55a93e418153 in testing::TestCase::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x55a93e4231f1 in testing::internal::UnitTestImpl::RunAllTests() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x55a93e440e1e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x55a93e43a250 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x55a93e421c7d in testing::UnitTest::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x55a93e40f03f in RUN_ALL_TESTS() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x55a93e40efce in main /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7f9f10e27b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 336 byte(s) in 1 object(s) allocated from:
    #0 0x7f9f12272f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7f9f119c00dd in __default_reallocate /home/cevans/ros2/src/ros2/rcutils/src/allocator.c:49
    #2 0x7f9f11f60ae3 in rcl_wait_set_resize /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/wait.c:425
    #3 0x7f9f11f5dab2 in rcl_wait_set_init /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/wait.c:167
    #4 0x55a93e40141f in WaitSetTestFixture__rmw_fastrtps_cpp_excess_capacity_Test::TestBody() /home/cevans/ros2/src/ros2/rcl/rcl/test/rcl/test_wait.cpp:279
    #5 0x55a93e43fc17 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x55a93e4393ba in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x55a93e417115 in testing::Test::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #8 0x55a93e417aaa in testing::TestInfo::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x55a93e418153 in testing::TestCase::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x55a93e4231f1 in testing::internal::UnitTestImpl::RunAllTests() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x55a93e440e1e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x55a93e43a250 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x55a93e421c7d in testing::UnitTest::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x55a93e40f03f in RUN_ALL_TESTS() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x55a93e40efce in main /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7f9f10e27b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 192 byte(s) in 3 object(s) allocated from:
    #0 0x7f9f12274458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x7f9f0f2709f5 in rmw_fastrtps_shared_cpp::__rmw_create_guard_condition(char const*) /home/cevans/ros2/src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/rmw_guard_condition.cpp:29
    #2 0x7f9f11c6a9ed in rmw_create_guard_condition /home/cevans/ros2/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_guard_condition.cpp:36
    #3 0x7f9f11f32faa in __rcl_guard_condition_init_from_rmw_impl /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/guard_condition.c:86
    #4 0x7f9f11f3333e in rcl_guard_condition_init /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/guard_condition.c:107
    #5 0x55a93e404550 in WaitSetTestFixture__rmw_fastrtps_cpp_add_with_index_Test::TestBody() /home/cevans/ros2/src/ros2/rcl/rcl/test/rcl/test_wait.cpp:479
    #6 0x55a93e43fc17 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #7 0x55a93e4393ba in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #8 0x55a93e417115 in testing::Test::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #9 0x55a93e417aaa in testing::TestInfo::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #10 0x55a93e418153 in testing::TestCase::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #11 0x55a93e4231f1 in testing::internal::UnitTestImpl::RunAllTests() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #12 0x55a93e440e1e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #13 0x55a93e43a250 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #14 0x55a93e421c7d in testing::UnitTest::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #15 0x55a93e40f03f in RUN_ALL_TESTS() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #16 0x55a93e40efce in main /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #17 0x7f9f10e27b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0x7f9f12272b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7f9f119c0095 in __default_allocate /home/cevans/ros2/src/ros2/rcutils/src/allocator.c:35
    #2 0x7f9f0fe0be8c in rmw_allocate /home/cevans/ros2/src/ros2/rmw/rmw/src/allocators.c:29
    #3 0x7f9f0f2dffaa in rmw_fastrtps_shared_cpp::__rmw_create_wait_set(char const*, rmw_context_t*, unsigned long) /home/cevans/ros2/src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/rmw_wait_set.cpp:47
    #4 0x7f9f11c7d4a4 in rmw_create_wait_set /home/cevans/ros2/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_wait_set.cpp:29
    #5 0x7f9f11f5d8d6 in rcl_wait_set_init /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/wait.c:157
    #6 0x55a93e404398 in WaitSetTestFixture__rmw_fastrtps_cpp_add_with_index_Test::TestBody() /home/cevans/ros2/src/ros2/rcl/rcl/test/rcl/test_wait.cpp:469
    #7 0x55a93e43fc17 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #8 0x55a93e4393ba in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #9 0x55a93e417115 in testing::Test::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #10 0x55a93e417aaa in testing::TestInfo::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #11 0x55a93e418153 in testing::TestCase::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #12 0x55a93e4231f1 in testing::internal::UnitTestImpl::RunAllTests() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #13 0x55a93e440e1e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #14 0x55a93e43a250 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #15 0x55a93e421c7d in testing::UnitTest::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #16 0x55a93e40f03f in RUN_ALL_TESTS() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #17 0x55a93e40efce in main /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #18 0x7f9f10e27b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0x7f9f12272b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7f9f119c0095 in __default_allocate /home/cevans/ros2/src/ros2/rcutils/src/allocator.c:35
    #2 0x7f9f0fe0be8c in rmw_allocate /home/cevans/ros2/src/ros2/rmw/rmw/src/allocators.c:29
    #3 0x7f9f0f2dffaa in rmw_fastrtps_shared_cpp::__rmw_create_wait_set(char const*, rmw_context_t*, unsigned long) /home/cevans/ros2/src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/rmw_wait_set.cpp:47
    #4 0x7f9f11c7d4a4 in rmw_create_wait_set /home/cevans/ros2/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_wait_set.cpp:29
    #5 0x7f9f11f5d8d6 in rcl_wait_set_init /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/wait.c:157
    #6 0x55a93e40141f in WaitSetTestFixture__rmw_fastrtps_cpp_excess_capacity_Test::TestBody() /home/cevans/ros2/src/ros2/rcl/rcl/test/rcl/test_wait.cpp:279
    #7 0x55a93e43fc17 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #8 0x55a93e4393ba in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #9 0x55a93e417115 in testing::Test::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #10 0x55a93e417aaa in testing::TestInfo::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #11 0x55a93e418153 in testing::TestCase::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #12 0x55a93e4231f1 in testing::internal::UnitTestImpl::RunAllTests() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #13 0x55a93e440e1e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #14 0x55a93e43a250 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #15 0x55a93e421c7d in testing::UnitTest::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #16 0x55a93e40f03f in RUN_ALL_TESTS() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #17 0x55a93e40efce in main /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #18 0x7f9f10e27b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 72 byte(s) in 3 object(s) allocated from:
    #0 0x7f9f12274458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x7f9f0f2709bb in rmw_fastrtps_shared_cpp::__rmw_create_guard_condition(char const*) /home/cevans/ros2/src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/rmw_guard_condition.cpp:27
    #2 0x7f9f11c6a9ed in rmw_create_guard_condition /home/cevans/ros2/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_guard_condition.cpp:36
    #3 0x7f9f11f32faa in __rcl_guard_condition_init_from_rmw_impl /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/guard_condition.c:86
    #4 0x7f9f11f3333e in rcl_guard_condition_init /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/guard_condition.c:107
    #5 0x55a93e404550 in WaitSetTestFixture__rmw_fastrtps_cpp_add_with_index_Test::TestBody() /home/cevans/ros2/src/ros2/rcl/rcl/test/rcl/test_wait.cpp:479
    #6 0x55a93e43fc17 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #7 0x55a93e4393ba in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #8 0x55a93e417115 in testing::Test::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #9 0x55a93e417aaa in testing::TestInfo::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #10 0x55a93e418153 in testing::TestCase::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #11 0x55a93e4231f1 in testing::internal::UnitTestImpl::RunAllTests() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #12 0x55a93e440e1e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #13 0x55a93e43a250 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #14 0x55a93e421c7d in testing::UnitTest::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #15 0x55a93e40f03f in RUN_ALL_TESTS() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #16 0x55a93e40efce in main /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #17 0x7f9f10e27b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f9f12272f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7f9f119c00dd in __default_reallocate /home/cevans/ros2/src/ros2/rcutils/src/allocator.c:49
    #2 0x7f9f11f5ff2a in rcl_wait_set_resize /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/wait.c:406
    #3 0x7f9f11f5dab2 in rcl_wait_set_init /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/wait.c:167
    #4 0x55a93e404398 in WaitSetTestFixture__rmw_fastrtps_cpp_add_with_index_Test::TestBody() /home/cevans/ros2/src/ros2/rcl/rcl/test/rcl/test_wait.cpp:469
    #5 0x55a93e43fc17 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x55a93e4393ba in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x55a93e417115 in testing::Test::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #8 0x55a93e417aaa in testing::TestInfo::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x55a93e418153 in testing::TestCase::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x55a93e4231f1 in testing::internal::UnitTestImpl::RunAllTests() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x55a93e440e1e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x55a93e43a250 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x55a93e421c7d in testing::UnitTest::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x55a93e40f03f in RUN_ALL_TESTS() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x55a93e40efce in main /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7f9f10e27b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f9f12272b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7f9f119c0095 in __default_allocate /home/cevans/ros2/src/ros2/rcutils/src/allocator.c:35
    #2 0x7f9f0fe0be8c in rmw_allocate /home/cevans/ros2/src/ros2/rmw/rmw/src/allocators.c:29
    #3 0x7f9f0fe0c207 in rmw_wait_set_allocate /home/cevans/ros2/src/ros2/rmw/rmw/src/allocators.c:133
    #4 0x7f9f0f2dff32 in rmw_fastrtps_shared_cpp::__rmw_create_wait_set(char const*, rmw_context_t*, unsigned long) /home/cevans/ros2/src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/rmw_wait_set.cpp:38
    #5 0x7f9f11c7d4a4 in rmw_create_wait_set /home/cevans/ros2/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_wait_set.cpp:29
    #6 0x7f9f11f5d8d6 in rcl_wait_set_init /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/wait.c:157
    #7 0x55a93e404398 in WaitSetTestFixture__rmw_fastrtps_cpp_add_with_index_Test::TestBody() /home/cevans/ros2/src/ros2/rcl/rcl/test/rcl/test_wait.cpp:469
    #8 0x55a93e43fc17 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #9 0x55a93e4393ba in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #10 0x55a93e417115 in testing::Test::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #11 0x55a93e417aaa in testing::TestInfo::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #12 0x55a93e418153 in testing::TestCase::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #13 0x55a93e4231f1 in testing::internal::UnitTestImpl::RunAllTests() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #14 0x55a93e440e1e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #15 0x55a93e43a250 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #16 0x55a93e421c7d in testing::UnitTest::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #17 0x55a93e40f03f in RUN_ALL_TESTS() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #18 0x55a93e40efce in main /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #19 0x7f9f10e27b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7f9f12272b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7f9f119c0095 in __default_allocate /home/cevans/ros2/src/ros2/rcutils/src/allocator.c:35
    #2 0x7f9f0fe0be8c in rmw_allocate /home/cevans/ros2/src/ros2/rmw/rmw/src/allocators.c:29
    #3 0x7f9f0fe0c207 in rmw_wait_set_allocate /home/cevans/ros2/src/ros2/rmw/rmw/src/allocators.c:133
    #4 0x7f9f0f2dff32 in rmw_fastrtps_shared_cpp::__rmw_create_wait_set(char const*, rmw_context_t*, unsigned long) /home/cevans/ros2/src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/rmw_wait_set.cpp:38
    #5 0x7f9f11c7d4a4 in rmw_create_wait_set /home/cevans/ros2/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_wait_set.cpp:29
    #6 0x7f9f11f5d8d6 in rcl_wait_set_init /home/cevans/ros2/src/ros2/rcl/rcl/src/rcl/wait.c:157
    #7 0x55a93e40141f in WaitSetTestFixture__rmw_fastrtps_cpp_excess_capacity_Test::TestBody() /home/cevans/ros2/src/ros2/rcl/rcl/test/rcl/test_wait.cpp:279
    #8 0x55a93e43fc17 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #9 0x55a93e4393ba in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #10 0x55a93e417115 in testing::Test::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #11 0x55a93e417aaa in testing::TestInfo::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #12 0x55a93e418153 in testing::TestCase::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #13 0x55a93e4231f1 in testing::internal::UnitTestImpl::RunAllTests() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #14 0x55a93e440e1e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #15 0x55a93e43a250 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #16 0x55a93e421c7d in testing::UnitTest::Run() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #17 0x55a93e40f03f in RUN_ALL_TESTS() /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #18 0x55a93e40efce in main /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #19 0x7f9f10e27b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: AddressSanitizer: 4432 byte(s) leaked in 26 allocation(s).
Process finished with exit code 1
```
After applying this fix:
```
Testing started at 1:15 PM ...
/home/cevans/ros2/src/ros2/rcl/rcl/cmake-build-debug/test/test_wait__rmw_fastrtps_cpp --gtest_filter=* --gtest_color=no
Running main() from /home/cevans/ros2/install/gtest_vendor/src/gtest_vendor/src/gtest_main.cc

Process finished with exit code 0
```