### PR TITLE
fix leak in test_init

### DIFF
--- a/rcl/test/rcl/test_init.cpp
+++ b/rcl/test/rcl/test_init.cpp
@@ -57,7 +57,7 @@ public:
 struct FakeTestArgv
 {
   FakeTestArgv()
-  : allocator(rcutils_get_default_allocator()), argc(2)
+  : allocator(rcl_get_default_allocator()), argc(2)
   {
     this->argv =
       static_cast<char **>(allocator.allocate(2 * sizeof(char *), allocator.state));
@@ -82,7 +82,7 @@ struct FakeTestArgv
     if (this->argv) {
       if (this->argc > 0) {
         size_t unsigned_argc = this->argc;
-        for (size_t i = 0; i < unsigned_argc; --i) {
+        for (size_t i = 0; i < unsigned_argc; ++i) {
           allocator.deallocate(this->argv[i], allocator.state);
         }
       }
@@ -90,7 +90,7 @@ struct FakeTestArgv
     allocator.deallocate(this->argv, allocator.state);
   }
 
-  rcutils_allocator_t allocator;
+  rcl_allocator_t allocator;
   int argc;
   char ** argv;
 
@@ -201,6 +201,9 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_init_and_ok_and_s
   ret = rcl_context_fini(&context);
   EXPECT_EQ(ret, RCL_RET_OK);
   context = rcl_get_zero_initialized_context();
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
+  });
 }
 
 /* Tests the rcl_get_instance_id() and rcl_ok() functions.


### PR DESCRIPTION
memory leak in test_init detected:
```
root@ip-172-31-27-113:~/ros2_asan_ws/build-asan/rcl/test# ./test_init__rmw_fastrtps_cpp 
Running main() from /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from TestRCLFixture__rmw_fastrtps_cpp
[ RUN      ] TestRCLFixture__rmw_fastrtps_cpp.test_rcl_init_and_ok_and_shutdown
[       OK ] TestRCLFixture__rmw_fastrtps_cpp.test_rcl_init_and_ok_and_shutdown (0 ms)
[ RUN      ] TestRCLFixture__rmw_fastrtps_cpp.test_rcl_get_instance_id_and_ok
[       OK ] TestRCLFixture__rmw_fastrtps_cpp.test_rcl_get_instance_id_and_ok (0 ms)
[----------] 2 tests from TestRCLFixture__rmw_fastrtps_cpp (0 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (1 ms total)
[  PASSED  ] 2 tests.

=================================================================
==670==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 104 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff66c1095 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff6bbb2ba in rcl_init_options_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init_options.c:45
    #3 0x55555557bc3a in TestRCLFixture__rmw_fastrtps_cpp_test_rcl_init_and_ok_and_shutdown_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_init.cpp:106
    #4 0x555555606c49 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555f8c29 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x5555555a54f9 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x5555555a6924 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x5555555a74c8 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555c25d9 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555556096fc in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555faef2 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555bf36d in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x5555555928bc in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x555555592802 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff5b28b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff66c1095 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff66c5eed in rcutils_format_string_limit /root/ros2_asan_ws/src/ros2/rcutils/src/format_string.c:54
    #3 0x55555558a8d5 in FakeTestArgv::FakeTestArgv() (/root/ros2_asan_ws/build-asan/rcl/test/test_init__rmw_fastrtps_cpp+0x368d5)
    #4 0x5555555806c2 in TestRCLFixture__rmw_fastrtps_cpp_test_rcl_init_and_ok_and_shutdown_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_init.cpp:188
    #5 0x555555606c49 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x5555555f8c29 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x5555555a54f9 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #8 0x5555555a6924 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x5555555a74c8 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x5555555c25d9 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x5555556096fc in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x5555555faef2 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x5555555bf36d in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x5555555928bc in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x555555592802 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7ffff5b28b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff66c1095 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff66c5eed in rcutils_format_string_limit /root/ros2_asan_ws/src/ros2/rcutils/src/format_string.c:54
    #3 0x55555558a8d5 in FakeTestArgv::FakeTestArgv() (/root/ros2_asan_ws/build-asan/rcl/test/test_init__rmw_fastrtps_cpp+0x368d5)
    #4 0x555555584fec in TestRCLFixture__rmw_fastrtps_cpp_test_rcl_get_instance_id_and_ok_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_init.cpp:228
    #5 0x555555606c49 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x5555555f8c29 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x5555555a54f9 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #8 0x5555555a6924 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x5555555a74c8 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x5555555c25d9 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x5555556096fc in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x5555555faef2 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x5555555bf36d in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x5555555928bc in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x555555592802 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7ffff5b28b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff66c1095 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff66c5eed in rcutils_format_string_limit /root/ros2_asan_ws/src/ros2/rcutils/src/format_string.c:54
    #3 0x55555558a8d5 in FakeTestArgv::FakeTestArgv() (/root/ros2_asan_ws/build-asan/rcl/test/test_init__rmw_fastrtps_cpp+0x368d5)
    #4 0x5555555865f9 in TestRCLFixture__rmw_fastrtps_cpp_test_rcl_get_instance_id_and_ok_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_init.cpp:252
    #5 0x555555606c49 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x5555555f8c29 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x5555555a54f9 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #8 0x5555555a6924 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x5555555a74c8 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x5555555c25d9 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x5555556096fc in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x5555555faef2 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x5555555bf36d in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x5555555928bc in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x555555592802 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7ffff5b28b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff66c1095 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff66c5eed in rcutils_format_string_limit /root/ros2_asan_ws/src/ros2/rcutils/src/format_string.c:54
    #3 0x55555558a8d5 in FakeTestArgv::FakeTestArgv() (/root/ros2_asan_ws/build-asan/rcl/test/test_init__rmw_fastrtps_cpp+0x368d5)
    #4 0x55555557efbd in TestRCLFixture__rmw_fastrtps_cpp_test_rcl_init_and_ok_and_shutdown_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_init.cpp:164
    #5 0x555555606c49 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x5555555f8c29 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x5555555a54f9 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #8 0x5555555a6924 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x5555555a74c8 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x5555555c25d9 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x5555556096fc in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x5555555faef2 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x5555555bf36d in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x5555555928bc in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x555555592802 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7ffff5b28b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 4 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff66c1095 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff66c5eed in rcutils_format_string_limit /root/ros2_asan_ws/src/ros2/rcutils/src/format_string.c:54
    #3 0x55555558a8d5 in FakeTestArgv::FakeTestArgv() (/root/ros2_asan_ws/build-asan/rcl/test/test_init__rmw_fastrtps_cpp+0x368d5)
    #4 0x55555557da94 in TestRCLFixture__rmw_fastrtps_cpp_test_rcl_init_and_ok_and_shutdown_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_init.cpp:139
    #5 0x555555606c49 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x5555555f8c29 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x5555555a54f9 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #8 0x5555555a6924 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x5555555a74c8 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x5555555c25d9 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x5555556096fc in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x5555555faef2 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x5555555bf36d in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x5555555928bc in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x555555592802 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7ffff5b28b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: AddressSanitizer: 124 byte(s) leaked in 6 allocation(s).
```

Now:
```
root@ip-172-31-27-113:~/ros2_asan_ws/build-asan/rcl/test# ./test_init__rmw_fastrtps_cpp 
Running main() from /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from TestRCLFixture__rmw_fastrtps_cpp
[ RUN      ] TestRCLFixture__rmw_fastrtps_cpp.test_rcl_init_and_ok_and_shutdown
[       OK ] TestRCLFixture__rmw_fastrtps_cpp.test_rcl_init_and_ok_and_shutdown (1 ms)
[ RUN      ] TestRCLFixture__rmw_fastrtps_cpp.test_rcl_get_instance_id_and_ok
[       OK ] TestRCLFixture__rmw_fastrtps_cpp.test_rcl_get_instance_id_and_ok (0 ms)
[----------] 2 tests from TestRCLFixture__rmw_fastrtps_cpp (1 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (1 ms total)
[  PASSED  ] 2 tests.
```