### PR TITLE
fix leak in test_context

### DIFF
--- a/rcl/test/rcl/test_context.cpp
+++ b/rcl/test/rcl/test_context.cpp
@@ -111,4 +111,7 @@ TEST_F(CLASSNAME(TestContextFixture, RMW_IMPLEMENTATION), nominal) {
   });
   EXPECT_NE(rmw_context_ptr, nullptr) << rcl_get_error_string().str;
   rcl_reset_error();
+
+  ret = rcl_init_options_fini(&init_options);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 }


### PR DESCRIPTION
memory leak detected in test_context:
```
root@ip-172-31-27-113:~/ros2_asan_ws/build-asan/rcl/test# ./test_context__rmw_fastrtps_cpp
Running main() from /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from TestContextFixture__rmw_fastrtps_cpp
[ RUN      ] TestContextFixture__rmw_fastrtps_cpp.nominal
[       OK ] TestContextFixture__rmw_fastrtps_cpp.nominal (1 ms)
[----------] 1 test from TestContextFixture__rmw_fastrtps_cpp (1 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (1 ms total)
[  PASSED  ] 1 test.

=================================================================
==1826==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 104 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff66c1095 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff6bbb2ba in rcl_init_options_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init_options.c:45
    #3 0x55555557bf48 in TestContextFixture__rmw_fastrtps_cpp_nominal_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_context.cpp:44
    #4 0x555555600935 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555f29d5 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55555559f40b in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x5555555a0836 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x5555555a13da in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555bc4eb in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555556033e8 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555f4c9e in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555b927f in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x55555558c7ce in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x55555558c714 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff5b28b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: AddressSanitizer: 104 byte(s) leaked in 1 allocation(s).
```

Now:
```
root@ip-172-31-27-113:~/ros2_asan_ws/build-asan/rcl/test# ./test_context__rmw_fastrtps_cpp 
Running main() from /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from TestContextFixture__rmw_fastrtps_cpp
[ RUN      ] TestContextFixture__rmw_fastrtps_cpp.nominal
[       OK ] TestContextFixture__rmw_fastrtps_cpp.nominal (1 ms)
[----------] 1 test from TestContextFixture__rmw_fastrtps_cpp (1 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (1 ms total)
[  PASSED  ] 1 test.
```