### PR TITLE
Fix leaks in rcl_action unit tests

### DIFF
--- a/rcl_action/CMakeLists.txt
+++ b/rcl_action/CMakeLists.txt
@@ -170,6 +170,7 @@ if(BUILD_TESTING)
       ${PROJECT_NAME}
     )
     ament_target_dependencies(test_action_server
+      "osrf_testing_tools_cpp"
       "rcl"
       "test_msgs"
     )

--- a/rcl_action/test/rcl_action/test_action_client.cpp
+++ b/rcl_action/test/rcl_action/test_action_client.cpp
@@ -52,6 +52,8 @@ protected:
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     ret = rcl_shutdown(&this->context);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+    ret = rcl_context_fini(&this->context);
+    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   }
 
   rcl_context_t context;

--- a/rcl_action/test/rcl_action/test_action_communication.cpp
+++ b/rcl_action/test/rcl_action/test_action_communication.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 #include <gtest/gtest.h>
 
+#include "osrf_testing_tools_cpp/scope_exit.hpp"
+
 #include "rcl_action/action_client.h"
 #include "rcl_action/action_server.h"
 #include "rcl_action/wait.h"
@@ -41,6 +43,9 @@ protected:
     rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
     ret = rcl_init_options_init(&init_options, allocator);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
+    });
     context = rcl_get_zero_initialized_context();
     ret = rcl_init(0, nullptr, &init_options, &context);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
@@ -119,6 +124,8 @@ protected:
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
     ret = rcl_shutdown(&context);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+    ret = rcl_context_fini(&this->context);
+    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   }
 
   void init_test_uuid0(uint8_t * uuid)

--- a/rcl_action/test/rcl_action/test_action_interaction.cpp
+++ b/rcl_action/test/rcl_action/test_action_interaction.cpp
@@ -13,6 +13,8 @@
 // limitations under the License.
 #include <gtest/gtest.h>
 
+#include "osrf_testing_tools_cpp/scope_exit.hpp"
+
 #include "rcl_action/action_client.h"
 #include "rcl_action/action_server.h"
 #include "rcl_action/wait.h"
@@ -53,6 +55,9 @@ protected:
     rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
     ret = rcl_init_options_init(&init_options, allocator);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
+    });
     context = rcl_get_zero_initialized_context();
     ret = rcl_init(0, nullptr, &init_options, &context);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
@@ -141,6 +146,8 @@ protected:
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
     ret = rcl_shutdown(&context);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+    ret = rcl_context_fini(&this->context);
+    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   }
 
   void init_test_uuid0(uint8_t * uuid)

--- a/rcl_action/test/rcl_action/test_action_server.cpp
+++ b/rcl_action/test/rcl_action/test_action_server.cpp
@@ -19,6 +19,8 @@
 
 #include "action_msgs/srv/cancel_goal.h"
 
+#include "osrf_testing_tools_cpp/scope_exit.hpp"
+
 #include "rcl_action/action_server.h"
 
 #include "rcl/error_handling.h"
@@ -137,11 +139,20 @@ TEST(TestActionServerInitFini, test_action_server_init_fini)
   ret = rcl_clock_fini(&clock);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
 
+  // Finalize init_options
+  ret = rcl_init_options_fini(&init_options);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
   // Finalize node
   ret = rcl_node_fini(&node);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
+  // Shutdown node
   ret = rcl_shutdown(&context);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  // Finalize context
+  ret = rcl_context_fini(&context);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 }
 
@@ -155,6 +166,9 @@ protected:
     rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
     ret = rcl_init_options_init(&init_options, allocator);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
+    });
     context = rcl_get_zero_initialized_context();
     ret = rcl_init(0, nullptr, &init_options, &context);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
@@ -184,6 +198,8 @@ protected:
     ret = rcl_node_fini(&this->node);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
     ret = rcl_shutdown(&context);
+    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+    ret = rcl_context_fini(&this->context);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   }
 


### PR DESCRIPTION
Fix memory leaks detected by AddressSanitizer from rcl_action unit tests.

Before the fix:
```bash
Running main() from /home/ANT.AMAZON.COM/prajaktg/ros2_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 4 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 1 test from TestActionClientBaseFixture
[ RUN      ] TestActionClientBaseFixture.test_action_client_init_fini
[       OK ] TestActionClientBaseFixture.test_action_client_init_fini (17 ms)
[----------] 1 test from TestActionClientBaseFixture (17 ms total)

[----------] 3 tests from TestActionClientFixture
[ RUN      ] TestActionClientFixture.test_action_client_is_valid
[       OK ] TestActionClientFixture.test_action_client_is_valid (13 ms)
[ RUN      ] TestActionClientFixture.test_action_client_get_action_name
[       OK ] TestActionClientFixture.test_action_client_get_action_name (10 ms)
[ RUN      ] TestActionClientFixture.test_action_client_get_options
[       OK ] TestActionClientFixture.test_action_client_get_options (10 ms)
[----------] 3 tests from TestActionClientFixture (33 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 2 test cases ran. (50 ms total)
[  PASSED  ] 4 tests.

=================================================================
==12786==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 312 byte(s) in 3 object(s) allocated from:
    ...snip...

Indirect leak of 312 byte(s) in 3 object(s) allocated from:
    ...snip...

SUMMARY: AddressSanitizer: 1184 byte(s) leaked in 12 allocation(s).
```

After the fix:
```bash
Running main() from /home/ANT.AMAZON.COM/prajaktg/ros2_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 4 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 1 test from TestActionClientBaseFixture
[ RUN      ] TestActionClientBaseFixture.test_action_client_init_fini
[       OK ] TestActionClientBaseFixture.test_action_client_init_fini (18 ms)
[----------] 1 test from TestActionClientBaseFixture (18 ms total)

[----------] 3 tests from TestActionClientFixture
[ RUN      ] TestActionClientFixture.test_action_client_is_valid
[       OK ] TestActionClientFixture.test_action_client_is_valid (11 ms)
[ RUN      ] TestActionClientFixture.test_action_client_get_action_name
[       OK ] TestActionClientFixture.test_action_client_get_action_name (12 ms)
[ RUN      ] TestActionClientFixture.test_action_client_get_options
[       OK ] TestActionClientFixture.test_action_client_get_options (10 ms)
[----------] 3 tests from TestActionClientFixture (34 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 2 test cases ran. (52 ms total)
[  PASSED  ] 4 tests.
```

All tests pass after the fixes:
```bash
Running tests...
Test project /home/ANT.AMAZON.COM/prajaktg/ros2_ws/build-asan/rcl_action
      Start  1: test_action_client
 1/15 Test  #1: test_action_client ............................   Passed    0.18 sec
      Start  2: test_action_communication__rmw_fastrtps_cpp
 2/15 Test  #2: test_action_communication__rmw_fastrtps_cpp ...   Passed    0.41 sec
      Start  3: test_action_interaction__rmw_fastrtps_cpp
 3/15 Test  #3: test_action_interaction__rmw_fastrtps_cpp .....   Passed    0.18 sec
      Start  4: test_graph__rmw_fastrtps_cpp
 4/15 Test  #4: test_graph__rmw_fastrtps_cpp ..................   Passed    3.31 sec
      Start  5: test_action_server
 5/15 Test  #5: test_action_server ............................   Passed   10.33 sec
      Start  6: test_goal_handle
 6/15 Test  #6: test_goal_handle ..............................   Passed    0.13 sec
      Start  7: test_goal_state_machine
 7/15 Test  #7: test_goal_state_machine .......................   Passed    0.13 sec
      Start  8: test_types
 8/15 Test  #8: test_types ....................................   Passed    0.13 sec
      Start  9: test_names
 9/15 Test  #9: test_names ....................................   Passed    0.12 sec
      Start 10: copyright
10/15 Test #10: copyright .....................................   Passed    0.30 sec
      Start 11: cppcheck
11/15 Test #11: cppcheck ......................................   Passed    0.66 sec
      Start 12: cpplint
12/15 Test #12: cpplint .......................................   Passed    1.76 sec
      Start 13: lint_cmake
13/15 Test #13: lint_cmake ....................................   Passed    0.29 sec
      Start 14: uncrustify
14/15 Test #14: uncrustify ....................................   Passed    1.01 sec
      Start 15: xmllint
15/15 Test #15: xmllint .......................................   Passed    0.40 sec

100% tests passed, 0 tests failed out of 15
```

Signed-off-by: Prajakta Gokhale <prajaktg@amazon.com>