### PR TITLE
fix leak in test_client

### DIFF
--- a/rcl/test/rcl/test_client.cpp
+++ b/rcl/test/rcl/test_client.cpp
@@ -58,6 +58,9 @@ public:
     delete this->node_ptr;
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     ret = rcl_shutdown(this->context_ptr);
+    EXPECT_EQ(ret, RCL_RET_OK);
+    ret = rcl_context_fini(this->context_ptr);
+    EXPECT_EQ(ret, RCL_RET_OK);
     delete this->context_ptr;
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   }
@@ -98,6 +101,7 @@ TEST_F(TestClientFixture, test_client_nominal) {
   ret = rcl_send_request(&client, &req, &sequence_number);
   EXPECT_EQ(sequence_number, 1);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  test_msgs__srv__BasicTypes_Request__fini(&req);
 }
 
 
@@ -138,6 +142,8 @@ TEST_F(TestClientFixture, test_client_init_fini) {
   ret = rcl_client_init(&client, this->node_ptr, ts, topic_name, &default_client_options);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   EXPECT_TRUE(rcl_client_is_valid(&client));
+  ret = rcl_client_fini(&client, this->node_ptr);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   rcl_reset_error();
 
   // Try passing an invalid (uninitialized) node in init.


### PR DESCRIPTION
memory leak detected in test_client:
```
root@ip-172-31-27-113:~/ros2_asan_ws/build-asan/rcl/test# ./test_client__rmw_fastrtps_cpp
Running main() from /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from TestClientFixture
[ RUN      ] TestClientFixture.test_client_nominal
[       OK ] TestClientFixture.test_client_nominal (15 ms)
[ RUN      ] TestClientFixture.test_client_init_fini
[       OK ] TestClientFixture.test_client_init_fini (8 ms)
[----------] 2 tests from TestClientFixture (23 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (23 ms total)
[  PASSED  ] 2 tests.

=================================================================
==31508==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 208 byte(s) in 2 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6962465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff6ba543d in rcl_parse_arguments /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/arguments.c:209
    #3 0x7ffff6bb9ccc in rcl_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init.c:114
    #4 0x55555557d3bf in TestClientFixture::SetUp() (/root/ros2_asan_ws/build-asan/rcl/test/test_client__rmw_fastrtps_cpp+0x293bf)
    #5 0x5555555f5cf3 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x5555555e7a9b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x5555555937d9 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2517
    #8 0x555555594cba in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x55555559585e in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x5555555b096f in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x5555555f87a6 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x5555555e9d64 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x5555555ad703 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x555555580c52 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x555555580b98 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 176 byte(s) in 2 object(s) allocated from:
    #0 0x7ffff6ef8d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7ffff69624d6 in __default_zero_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:56
    #2 0x7ffff6bb95d9 in rcl_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init.c:78
    #3 0x55555557d3bf in TestClientFixture::SetUp() (/root/ros2_asan_ws/build-asan/rcl/test/test_client__rmw_fastrtps_cpp+0x293bf)
    #4 0x5555555f5cf3 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555e7a9b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x5555555937d9 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2517
    #7 0x555555594cba in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555559585e in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555b096f in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555555f87a6 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555e9d64 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555ad703 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x555555580c52 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x555555580b98 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 144 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6962465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff6baffb7 in rcl_client_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/client.c:160
    #3 0x555555579346 in TestClientFixture_test_client_init_fini_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_client.cpp:138
    #4 0x5555555f5cf3 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555e7a9b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55555559388f in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x555555594cba in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555559585e in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555b096f in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555555f87a6 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555e9d64 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555ad703 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x555555580c52 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x555555580b98 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 1 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff4684b44 in rosidl_generator_c__String__init /root/ros2_asan_ws/src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:28
    #2 0x7ffff65408ca in test_msgs__srv__BasicTypes_Request__init /root/ros2_asan_ws/build-asan/test_msgs/rosidl_generator_c/test_msgs/srv/basic_types__functions.c:35
    #3 0x555555577762 in TestClientFixture_test_client_nominal_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_client.cpp:92
    #4 0x5555555f5cf3 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555e7a9b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55555559388f in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x555555594cba in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555559585e in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555b096f in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555555f87a6 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555e9d64 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555ad703 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x555555580c52 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x555555580b98 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 208 byte(s) in 2 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6962465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff6bbb2ba in rcl_init_options_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init_options.c:45
    #3 0x7ffff6bbb916 in rcl_init_options_copy /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init_options.c:73
    #4 0x7ffff6bb9729 in rcl_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init.c:86
    #5 0x55555557d3bf in TestClientFixture::SetUp() (/root/ros2_asan_ws/build-asan/rcl/test/test_client__rmw_fastrtps_cpp+0x293bf)
    #6 0x5555555f5cf3 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #7 0x5555555e7a9b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #8 0x5555555937d9 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2517
    #9 0x555555594cba in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #10 0x55555559585e in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #11 0x5555555b096f in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #12 0x5555555f87a6 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #13 0x5555555e9d64 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #14 0x5555555ad703 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #15 0x555555580c52 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #16 0x555555580b98 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #17 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 152 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6efa458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x7ffff4b093b5 in rmw_create_client /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_client.cpp:163
    #2 0x7ffff6bb00bb in rcl_client_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/client.c:167
    #3 0x555555579346 in TestClientFixture_test_client_init_fini_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_client.cpp:138
    #4 0x5555555f5cf3 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555e7a9b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55555559388f in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x555555594cba in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555559585e in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555b096f in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555555f87a6 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555e9d64 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555ad703 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x555555580c52 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x555555580b98 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 96 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6efa458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x7ffff4b07f7e in rmw_create_client /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_client.cpp:93
    #2 0x7ffff6bb00bb in rcl_client_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/client.c:167
    #3 0x555555579346 in TestClientFixture_test_client_init_fini_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_client.cpp:138
    #4 0x5555555f5cf3 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555e7a9b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55555559388f in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x555555594cba in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555559585e in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555b096f in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555555f87a6 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555e9d64 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555ad703 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x555555580c52 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x555555580b98 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6efa458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x7ffff4b0830b in rmw_create_client /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_client.cpp:115
    #2 0x7ffff6bb00bb in rcl_client_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/client.c:167
    #3 0x555555579346 in TestClientFixture_test_client_init_fini_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_client.cpp:138
    #4 0x5555555f5cf3 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555e7a9b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55555559388f in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x555555594cba in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555559585e in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555b096f in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555555f87a6 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555e9d64 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555ad703 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x555555580c52 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x555555580b98 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6efa458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x7ffff4b083ad in rmw_create_client /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_client.cpp:122
    #2 0x7ffff6bb00bb in rcl_client_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/client.c:167
    #3 0x555555579346 in TestClientFixture_test_client_init_fini_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_client.cpp:138
    #4 0x5555555f5cf3 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555e7a9b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55555559388f in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x555555594cba in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555559585e in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555b096f in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555555f87a6 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555e9d64 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555ad703 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x555555580c52 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x555555580b98 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 64 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6efa458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x7ffff4b094cb in rmw_create_client /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_client.cpp:176
    #2 0x7ffff6bb00bb in rcl_client_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/client.c:167
    #3 0x555555579346 in TestClientFixture_test_client_init_fini_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_client.cpp:138
    #4 0x5555555f5cf3 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555e7a9b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55555559388f in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x555555594cba in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555559585e in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555b096f in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555555f87a6 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555e9d64 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555ad703 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x555555580c52 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x555555580b98 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 43 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6efa458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x555555608f0f in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag) /usr/include/c++/7/bits/basic_string.tcc:219
    #2 0x7ffff4b2d96a in eprosima::fastrtps::TopicDataType::setName(char const*) /root/ros2_asan_ws/install-asan/fastrtps/include/fastrtps/TopicDataType.h:88
    #3 0x7ffff4b2d1d9 in rmw_fastrtps_cpp::ResponseTypeSupport::ResponseTypeSupport(service_type_support_callbacks_t const*) /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/type_support_common.cpp:132
    #4 0x7ffff4b083c2 in rmw_create_client /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_client.cpp:122
    #5 0x7ffff6bb00bb in rcl_client_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/client.c:167
    #6 0x555555579346 in TestClientFixture_test_client_init_fini_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_client.cpp:138
    #7 0x5555555f5cf3 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #8 0x5555555e7a9b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #9 0x55555559388f in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #10 0x555555594cba in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #11 0x55555559585e in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #12 0x5555555b096f in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #13 0x5555555f87a6 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #14 0x5555555e9d64 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #15 0x5555555ad703 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #16 0x555555580c52 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #17 0x555555580b98 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #18 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 42 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6efa458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x555555608f0f in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag) /usr/include/c++/7/bits/basic_string.tcc:219
    #2 0x7ffff4b2d96a in eprosima::fastrtps::TopicDataType::setName(char const*) /root/ros2_asan_ws/install-asan/fastrtps/include/fastrtps/TopicDataType.h:88
    #3 0x7ffff4b2cef7 in rmw_fastrtps_cpp::RequestTypeSupport::RequestTypeSupport(service_type_support_callbacks_t const*) /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/type_support_common.cpp:120
    #4 0x7ffff4b08320 in rmw_create_client /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_client.cpp:115
    #5 0x7ffff6bb00bb in rcl_client_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/client.c:167
    #6 0x555555579346 in TestClientFixture_test_client_init_fini_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_client.cpp:138
    #7 0x5555555f5cf3 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #8 0x5555555e7a9b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #9 0x55555559388f in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #10 0x555555594cba in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #11 0x55555559585e in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #12 0x5555555b096f in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #13 0x5555555f87a6 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #14 0x5555555e9d64 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #15 0x5555555ad703 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #16 0x555555580c52 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #17 0x555555580b98 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #18 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6962465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff488de8c in rmw_allocate /root/ros2_asan_ws/src/ros2/rmw/rmw/src/allocators.c:29
    #3 0x7ffff488e1b1 in rmw_client_allocate /root/ros2_asan_ws/src/ros2/rmw/rmw/src/allocators.c:105
    #4 0x7ffff4b095f3 in rmw_create_client /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_client.cpp:186
    #5 0x7ffff6bb00bb in rcl_client_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/client.c:167
    #6 0x555555579346 in TestClientFixture_test_client_init_fini_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_client.cpp:138
    #7 0x5555555f5cf3 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #8 0x5555555e7a9b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #9 0x55555559388f in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #10 0x555555594cba in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #11 0x55555559585e in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #12 0x5555555b096f in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #13 0x5555555f87a6 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #14 0x5555555e9d64 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #15 0x5555555ad703 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #16 0x555555580c52 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #17 0x555555580b98 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #18 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 9 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6962465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff488de8c in rmw_allocate /root/ros2_asan_ws/src/ros2/rmw/rmw/src/allocators.c:29
    #3 0x7ffff4b096d2 in rmw_create_client /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_client.cpp:195
    #4 0x7ffff6bb00bb in rcl_client_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/client.c:167
    #5 0x555555579346 in TestClientFixture_test_client_init_fini_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_client.cpp:138
    #6 0x5555555f5cf3 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #7 0x5555555e7a9b in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #8 0x55555559388f in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #9 0x555555594cba in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #10 0x55555559585e in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #11 0x5555555b096f in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #12 0x5555555f87a6 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #13 0x5555555e9d64 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #14 0x5555555ad703 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #15 0x555555580c52 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #16 0x555555580b98 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #17 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: AddressSanitizer: 1311 byte(s) leaked in 17 allocation(s).
```

with this PR:
```
root@ip-172-31-27-113:~/ros2_asan_ws/build-asan/rcl/test# ./test_client__rmw_fastrtps_cpp
Running main() from /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from TestClientFixture
[ RUN      ] TestClientFixture.test_client_nominal
[       OK ] TestClientFixture.test_client_nominal (15 ms)
[ RUN      ] TestClientFixture.test_client_init_fini
[       OK ] TestClientFixture.test_client_init_fini (8 ms)
[----------] 2 tests from TestClientFixture (23 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (23 ms total)
[  PASSED  ] 2 tests.
```