### PR TITLE
fix leak in test_expand_topic_name

### DIFF
--- a/rcl/test/rcl/test_expand_topic_name.cpp
+++ b/rcl/test/rcl/test_expand_topic_name.cpp
@@ -44,7 +44,11 @@ TEST(test_expand_topic_name, normal) {
     ret = rcl_expand_topic_name(topic, node, ns, &subs, allocator, &expanded_topic);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     EXPECT_STREQ(expected.c_str(), expanded_topic);
+    allocator.deallocate(expanded_topic, allocator.state);
   }
+
+  ret = rcutils_string_map_fini(&subs);
+  ASSERT_EQ(RCL_RET_OK, ret);
 }
 
 TEST(test_expand_topic_name, invalid_arguments) {
@@ -116,6 +120,9 @@ TEST(test_expand_topic_name, invalid_arguments) {
     EXPECT_EQ(RCL_RET_NODE_INVALID_NAMESPACE, ret);
     rcl_reset_error();
   }
+
+  ret = rcutils_string_map_fini(&subs);
+  ASSERT_EQ(RCL_RET_OK, ret);
 }
 
 TEST(test_expand_topic_name, various_valid_topics) {
@@ -174,7 +181,11 @@ TEST(test_expand_topic_name, various_valid_topics) {
       ss.str() <<
       ", it failed with '" << ret << "': " << rcl_get_error_string().str;
     EXPECT_STREQ(expected.c_str(), expanded_topic) << ss.str() << " strings did not match.\n";
+    allocator.deallocate(expanded_topic, allocator.state);
   }
+
+  ret = rcutils_string_map_fini(&subs);
+  ASSERT_EQ(RCL_RET_OK, ret);
 }
 
 TEST(test_expand_topic_name, unknown_substitution) {
@@ -195,7 +206,11 @@ TEST(test_expand_topic_name, unknown_substitution) {
     EXPECT_EQ(RCL_RET_UNKNOWN_SUBSTITUTION, ret);
     rcl_reset_error();
     EXPECT_EQ(NULL, expanded_topic);
+    allocator.deallocate(expanded_topic, allocator.state);
   }
+
+  ret = rcutils_string_map_fini(&subs);
+  ASSERT_EQ(RCL_RET_OK, ret);
 }
 
 TEST(test_expand_topic_name, custom_substitution) {
@@ -218,5 +233,9 @@ TEST(test_expand_topic_name, custom_substitution) {
     ret = rcl_expand_topic_name(topic, node, ns, &subs, allocator, &expanded_topic);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     EXPECT_STREQ("/my_ns/pong", expanded_topic);
+    allocator.deallocate(expanded_topic, allocator.state);
   }
+
+  ret = rcutils_string_map_fini(&subs);
+  ASSERT_EQ(RCL_RET_OK, ret);
 }


### PR DESCRIPTION
Signed-off-by: Abby Xu <abbyxu@amazon.com>

memory leak detected:
```
root@ip-172-31-27-113:~/ros2_asan_ws/build-asan/rcl/test# ./test_expand_topic_name
Running main() from /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 5 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 5 tests from test_expand_topic_name
[ RUN      ] test_expand_topic_name.normal
[       OK ] test_expand_topic_name.normal (0 ms)
[ RUN      ] test_expand_topic_name.invalid_arguments
[       OK ] test_expand_topic_name.invalid_arguments (0 ms)
[ RUN      ] test_expand_topic_name.various_valid_topics
[       OK ] test_expand_topic_name.various_valid_topics (0 ms)
[ RUN      ] test_expand_topic_name.unknown_substitution
[       OK ] test_expand_topic_name.unknown_substitution (0 ms)
[ RUN      ] test_expand_topic_name.custom_substitution
[       OK ] test_expand_topic_name.custom_substitution (0 ms)
[----------] 5 tests from test_expand_topic_name (0 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test case ran. (1 ms total)
[  PASSED  ] 5 tests.

=================================================================
==18823==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6743465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff6756902 in rcutils_string_map_init /root/ros2_asan_ws/src/ros2/rcutils/src/string_map.c:62
    #3 0x5555555819de in test_expand_topic_name_unknown_substitution_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_expand_topic_name.cpp:184
    #4 0x5555555fdae1 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555efba5 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55555559c1d1 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55555559d5fc in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555559e1a0 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555b92b1 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x555555600594 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555f1e6e in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555b6045 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x555555589594 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x5555555894da in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff5dc9b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6743465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff6756902 in rcutils_string_map_init /root/ros2_asan_ws/src/ros2/rcutils/src/string_map.c:62
    #3 0x555555578fea in test_expand_topic_name_invalid_arguments_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_expand_topic_name.cpp:54
    #4 0x5555555fdae1 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555efba5 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55555559c1d1 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55555559d5fc in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555559e1a0 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555b92b1 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x555555600594 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555f1e6e in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555b6045 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x555555589594 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x5555555894da in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff5dc9b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6743465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff6756902 in rcutils_string_map_init /root/ros2_asan_ws/src/ros2/rcutils/src/string_map.c:62
    #3 0x555555582911 in test_expand_topic_name_custom_substitution_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_expand_topic_name.cpp:205
    #4 0x5555555fdae1 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555efba5 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55555559c1d1 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55555559d5fc in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555559e1a0 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555b92b1 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x555555600594 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555f1e6e in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555b6045 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x555555589594 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x5555555894da in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff5dc9b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6743465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff6756902 in rcutils_string_map_init /root/ros2_asan_ws/src/ros2/rcutils/src/string_map.c:62
    #3 0x5555555779f3 in test_expand_topic_name_normal_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_expand_topic_name.cpp:32
    #4 0x5555555fdae1 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555efba5 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55555559c1d1 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55555559d5fc in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555559e1a0 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555b92b1 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x555555600594 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555f1e6e in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555b6045 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x555555589594 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x5555555894da in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff5dc9b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6743465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff6756902 in rcutils_string_map_init /root/ros2_asan_ws/src/ros2/rcutils/src/string_map.c:62
    #3 0x55555557bc1c in test_expand_topic_name_various_valid_topics_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_expand_topic_name.cpp:125
    #4 0x5555555fdae1 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555efba5 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x55555559c1d1 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55555559d5fc in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555559e1a0 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555b92b1 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x555555600594 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555f1e6e in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555b6045 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x555555589594 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x5555555894da in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff5dc9b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 71 byte(s) in 5 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6743465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff67482bd in rcutils_format_string_limit /root/ros2_asan_ws/src/ros2/rcutils/src/format_string.c:54
    #3 0x7ffff6bb63cd in rcl_expand_topic_name /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/expand_topic_name.c:212
    #4 0x55555557f422 in test_expand_topic_name_various_valid_topics_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_expand_topic_name.cpp:167
    #5 0x5555555fdae1 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x5555555efba5 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x55555559c1d1 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #8 0x55555559d5fc in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x55555559e1a0 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x5555555b92b1 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x555555600594 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x5555555f1e6e in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x5555555b6045 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x555555589594 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x5555555894da in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7ffff5dc9b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 58 byte(s) in 5 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6743465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff6753a28 in rcutils_repl_str /root/ros2_asan_ws/src/ros2/rcutils/src/repl_str.c:106
    #3 0x7ffff6bb6152 in rcl_expand_topic_name /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/expand_topic_name.c:191
    #4 0x55555557f422 in test_expand_topic_name_various_valid_topics_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_expand_topic_name.cpp:167
    #5 0x5555555fdae1 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x5555555efba5 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x55555559c1d1 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #8 0x55555559d5fc in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x55555559e1a0 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x5555555b92b1 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x555555600594 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x5555555f1e6e in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x5555555b6045 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x555555589594 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x5555555894da in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7ffff5dc9b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 58 byte(s) in 4 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6743465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff67482bd in rcutils_format_string_limit /root/ros2_asan_ws/src/ros2/rcutils/src/format_string.c:54
    #3 0x7ffff6bb5c4f in rcl_expand_topic_name /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/expand_topic_name.c:125
    #4 0x55555557f422 in test_expand_topic_name_various_valid_topics_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_expand_topic_name.cpp:167
    #5 0x5555555fdae1 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x5555555efba5 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x55555559c1d1 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #8 0x55555559d5fc in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x55555559e1a0 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x5555555b92b1 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x555555600594 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x5555555f1e6e in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x5555555b6045 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x555555589594 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x5555555894da in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7ffff5dc9b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 23 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6743465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff67482bd in rcutils_format_string_limit /root/ros2_asan_ws/src/ros2/rcutils/src/format_string.c:54
    #3 0x7ffff6bb63cd in rcl_expand_topic_name /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/expand_topic_name.c:212
    #4 0x55555557822a in test_expand_topic_name_normal_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_expand_topic_name.cpp:44
    #5 0x5555555fdae1 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x5555555efba5 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x55555559c1d1 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #8 0x55555559d5fc in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x55555559e1a0 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x5555555b92b1 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x555555600594 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x5555555f1e6e in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x5555555b6045 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x555555589594 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x5555555894da in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7ffff5dc9b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 21 byte(s) in 3 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6743465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff6755c08 in rcutils_strndup /root/ros2_asan_ws/src/ros2/rcutils/src/strdup.c:42
    #3 0x7ffff6755b87 in rcutils_strdup /root/ros2_asan_ws/src/ros2/rcutils/src/strdup.c:33
    #4 0x7ffff6bb5b45 in rcl_expand_topic_name /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/expand_topic_name.c:111
    #5 0x55555557f422 in test_expand_topic_name_various_valid_topics_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_expand_topic_name.cpp:167
    #6 0x5555555fdae1 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #7 0x5555555efba5 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #8 0x55555559c1d1 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #9 0x55555559d5fc in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #10 0x55555559e1a0 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #11 0x5555555b92b1 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #12 0x555555600594 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #13 0x5555555f1e6e in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #14 0x5555555b6045 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #15 0x555555589594 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #16 0x5555555894da in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #17 0x7ffff5dc9b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 12 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6743465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff67482bd in rcutils_format_string_limit /root/ros2_asan_ws/src/ros2/rcutils/src/format_string.c:54
    #3 0x7ffff6bb63cd in rcl_expand_topic_name /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/expand_topic_name.c:212
    #4 0x5555555830e4 in test_expand_topic_name_custom_substitution_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_expand_topic_name.cpp:218
    #5 0x5555555fdae1 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x5555555efba5 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x55555559c1d1 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #8 0x55555559d5fc in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x55555559e1a0 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x5555555b92b1 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x555555600594 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x5555555f1e6e in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x5555555b6045 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x555555589594 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x5555555894da in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7ffff5dc9b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7ffff67434ad in __default_reallocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:49
    #2 0x7ffff6757655 in rcutils_string_map_reserve /root/ros2_asan_ws/src/ros2/rcutils/src/string_map.c:176
    #3 0x7ffff6757fc8 in rcutils_string_map_set /root/ros2_asan_ws/src/ros2/rcutils/src/string_map.c:238
    #4 0x555555582da7 in test_expand_topic_name_custom_substitution_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_expand_topic_name.cpp:210
    #5 0x5555555fdae1 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x5555555efba5 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x55555559c1d1 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #8 0x55555559d5fc in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x55555559e1a0 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x5555555b92b1 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x555555600594 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x5555555f1e6e in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x5555555b6045 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x555555589594 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x5555555894da in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7ffff5dc9b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7ffff67434ad in __default_reallocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:49
    #2 0x7ffff675757b in rcutils_string_map_reserve /root/ros2_asan_ws/src/ros2/rcutils/src/string_map.c:167
    #3 0x7ffff6757fc8 in rcutils_string_map_set /root/ros2_asan_ws/src/ros2/rcutils/src/string_map.c:238
    #4 0x555555582da7 in test_expand_topic_name_custom_substitution_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_expand_topic_name.cpp:210
    #5 0x5555555fdae1 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x5555555efba5 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x55555559c1d1 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #8 0x55555559d5fc in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x55555559e1a0 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x5555555b92b1 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x555555600594 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x5555555f1e6e in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x5555555b6045 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x555555589594 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x5555555894da in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7ffff5dc9b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 5 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6743465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff6755c08 in rcutils_strndup /root/ros2_asan_ws/src/ros2/rcutils/src/strdup.c:42
    #3 0x7ffff6755b87 in rcutils_strdup /root/ros2_asan_ws/src/ros2/rcutils/src/strdup.c:33
    #4 0x7ffff6758a30 in rcutils_string_map_set_no_resize /root/ros2_asan_ws/src/ros2/rcutils/src/string_map.c:309
    #5 0x7ffff6757fed in rcutils_string_map_set /root/ros2_asan_ws/src/ros2/rcutils/src/string_map.c:244
    #6 0x555555582da7 in test_expand_topic_name_custom_substitution_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_expand_topic_name.cpp:210
    #7 0x5555555fdae1 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #8 0x5555555efba5 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #9 0x55555559c1d1 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #10 0x55555559d5fc in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #11 0x55555559e1a0 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #12 0x5555555b92b1 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #13 0x555555600594 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #14 0x5555555f1e6e in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #15 0x5555555b6045 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #16 0x555555589594 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #17 0x5555555894da in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #18 0x7ffff5dc9b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 5 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6743465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff6755c08 in rcutils_strndup /root/ros2_asan_ws/src/ros2/rcutils/src/strdup.c:42
    #3 0x7ffff6755b87 in rcutils_strdup /root/ros2_asan_ws/src/ros2/rcutils/src/strdup.c:33
    #4 0x7ffff67588a9 in rcutils_string_map_set_no_resize /root/ros2_asan_ws/src/ros2/rcutils/src/string_map.c:300
    #5 0x7ffff6757fed in rcutils_string_map_set /root/ros2_asan_ws/src/ros2/rcutils/src/string_map.c:244
    #6 0x555555582da7 in test_expand_topic_name_custom_substitution_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_expand_topic_name.cpp:210
    #7 0x5555555fdae1 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #8 0x5555555efba5 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #9 0x55555559c1d1 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #10 0x55555559d5fc in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #11 0x55555559e1a0 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #12 0x5555555b92b1 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #13 0x555555600594 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #14 0x5555555f1e6e in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #15 0x5555555b6045 in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #16 0x555555589594 in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #17 0x5555555894da in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #18 0x7ffff5dc9b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: AddressSanitizer: 629 byte(s) leaked in 28 allocation(s).
```

with this PR:
```
root@ip-172-31-27-113:/root/ros2_asan_ws/build-asan/rcl/test# ./test_expand_topic_name 
Running main() from /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 5 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 5 tests from test_expand_topic_name
[ RUN      ] test_expand_topic_name.normal
[       OK ] test_expand_topic_name.normal (0 ms)
[ RUN      ] test_expand_topic_name.invalid_arguments
[       OK ] test_expand_topic_name.invalid_arguments (0 ms)
[ RUN      ] test_expand_topic_name.various_valid_topics
[       OK ] test_expand_topic_name.various_valid_topics (0 ms)
[ RUN      ] test_expand_topic_name.unknown_substitution
[       OK ] test_expand_topic_name.unknown_substitution (0 ms)
[ RUN      ] test_expand_topic_name.custom_substitution
[       OK ] test_expand_topic_name.custom_substitution (0 ms)
[----------] 5 tests from test_expand_topic_name (0 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 1 test case ran. (1 ms total)
[  PASSED  ] 5 tests.
```