### PR TITLE
fix leak in test_get_actual_qos

### DIFF
--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -124,7 +124,7 @@ function(test_target_function)
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME}
-    AMENT_DEPENDENCIES ${rmw_implementation} "test_msgs"
+    AMENT_DEPENDENCIES ${rmw_implementation} "test_msgs" "osrf_testing_tools_cpp"
   )
 
   rcl_add_custom_gtest(test_init${target_suffix}

--- a/rcl/test/rcl/test_get_actual_qos.cpp
+++ b/rcl/test/rcl/test_get_actual_qos.cpp
@@ -21,6 +21,7 @@
 #include "rcl/rcl.h"
 #include "rcl/publisher.h"
 
+#include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcutils/logging_macros.h"
 #include "rcutils/macros.h"
 
@@ -82,6 +83,9 @@ public:
     *this->context_ptr = rcl_get_zero_initialized_context();
     ret = rcl_init(0, nullptr, &init_options, this->context_ptr);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
+    });
     this->node_ptr = new rcl_node_t;
     *this->node_ptr = rcl_get_zero_initialized_node();
     const char * name = "test_get_actual_qos_node";


### PR DESCRIPTION
Signed-off-by: Abby Xu <abbyxu@amazon.com>

Memory leak detected:
```
root@ip-172-31-27-113:/root/ros2_asan_ws/build-asan/rcl/test# ./test_get_actual_qos__rmw_fastrtps_cpp 
Running main() from /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 3 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 3 tests from TestWithDifferentQoSSettings/TestGetActualQoS__rmw_fastrtps_cpp
[ RUN      ] TestWithDifferentQoSSettings/TestGetActualQoS__rmw_fastrtps_cpp.test_publisher_get_qos_settings/publisher_default_qos
[       OK ] TestWithDifferentQoSSettings/TestGetActualQoS__rmw_fastrtps_cpp.test_publisher_get_qos_settings/publisher_default_qos (15 ms)
[ RUN      ] TestWithDifferentQoSSettings/TestGetActualQoS__rmw_fastrtps_cpp.test_publisher_get_qos_settings/publisher_non_default_qos
[       OK ] TestWithDifferentQoSSettings/TestGetActualQoS__rmw_fastrtps_cpp.test_publisher_get_qos_settings/publisher_non_default_qos (8 ms)
[ RUN      ] TestWithDifferentQoSSettings/TestGetActualQoS__rmw_fastrtps_cpp.test_publisher_get_qos_settings/publisher_system_default_qos
[       OK ] TestWithDifferentQoSSettings/TestGetActualQoS__rmw_fastrtps_cpp.test_publisher_get_qos_settings/publisher_system_default_qos (8 ms)
[----------] 3 tests from TestWithDifferentQoSSettings/TestGetActualQoS__rmw_fastrtps_cpp (31 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test case ran. (31 ms total)
[  PASSED  ] 3 tests.

=================================================================
==28306==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 312 byte(s) in 3 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6962465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff6bbb2ba in rcl_init_options_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init_options.c:45
    #3 0x55555557d062 in TestGetActualQoS__rmw_fastrtps_cpp::SetUp() (/root/ros2_asan_ws/build-asan/rcl/test/test_get_actual_qos__rmw_fastrtps_cpp+0x29062)
    #4 0x555555608d2b in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555fb221 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x5555555a8191 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2517
    #7 0x5555555a9672 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x5555555aa216 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555c5327 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x55555560b7de in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555fd4ea in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555c20bb in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x55555559560b in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x555555595551 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff5bc1b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: AddressSanitizer: 312 byte(s) leaked in 3 allocation(s).
```

With this PR:
```
root@ip-172-31-27-113:/root/ros2_asan_ws/build-asan/rcl/test# ./test_get_actual_qos__rmw_fastrtps_cpp 
Running main() from /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 3 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 3 tests from TestWithDifferentQoSSettings/TestGetActualQoS__rmw_fastrtps_cpp
[ RUN      ] TestWithDifferentQoSSettings/TestGetActualQoS__rmw_fastrtps_cpp.test_publisher_get_qos_settings/publisher_default_qos
[       OK ] TestWithDifferentQoSSettings/TestGetActualQoS__rmw_fastrtps_cpp.test_publisher_get_qos_settings/publisher_default_qos (15 ms)
[ RUN      ] TestWithDifferentQoSSettings/TestGetActualQoS__rmw_fastrtps_cpp.test_publisher_get_qos_settings/publisher_non_default_qos
[       OK ] TestWithDifferentQoSSettings/TestGetActualQoS__rmw_fastrtps_cpp.test_publisher_get_qos_settings/publisher_non_default_qos (8 ms)
[ RUN      ] TestWithDifferentQoSSettings/TestGetActualQoS__rmw_fastrtps_cpp.test_publisher_get_qos_settings/publisher_system_default_qos
[       OK ] TestWithDifferentQoSSettings/TestGetActualQoS__rmw_fastrtps_cpp.test_publisher_get_qos_settings/publisher_system_default_qos (8 ms)
[----------] 3 tests from TestWithDifferentQoSSettings/TestGetActualQoS__rmw_fastrtps_cpp (31 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test case ran. (31 ms total)
[  PASSED  ] 3 tests.
```