### PR TITLE
fix leak in test_guard_condition

### DIFF
--- a/rcl/test/rcl/test_guard_condition.cpp
+++ b/rcl/test/rcl/test_guard_condition.cpp
@@ -149,6 +149,7 @@ TEST_F(
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
     ASSERT_EQ(RCL_RET_OK, rcl_shutdown(&context));
+    ASSERT_EQ(RCL_RET_OK, rcl_context_fini(&context));
   });
   // Try invalid arguments.
   ret = rcl_guard_condition_init(nullptr, &context, default_options);


### PR DESCRIPTION
Signed-off-by: Abby Xu <abbyxu@amazon.com>

memory leak detected:
```
root@ip-172-31-27-113:~/ros2_asan_ws/build-asan/rcl/test# ./test_guard_condition__rmw_fastrtps_cpp
Running main() from /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from TestGuardConditionFixture__rmw_fastrtps_cpp
[ RUN      ] TestGuardConditionFixture__rmw_fastrtps_cpp.test_rcl_guard_condition_accessors
[       OK ] TestGuardConditionFixture__rmw_fastrtps_cpp.test_rcl_guard_condition_accessors (1 ms)
[ RUN      ] TestGuardConditionFixture__rmw_fastrtps_cpp.test_rcl_guard_condition_life_cycle
[       OK ] TestGuardConditionFixture__rmw_fastrtps_cpp.test_rcl_guard_condition_life_cycle (0 ms)
[----------] 2 tests from TestGuardConditionFixture__rmw_fastrtps_cpp (1 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (1 ms total)
[  PASSED  ] 2 tests.

=================================================================
==6877==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 104 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff66bf465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff6ba543d in rcl_parse_arguments /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/arguments.c:209
    #3 0x7ffff6bb9ccc in rcl_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init.c:114
    #4 0x55555558044e in TestGuardConditionFixture__rmw_fastrtps_cpp_test_rcl_guard_condition_life_cycle_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_guard_condition.cpp:148
    #5 0x55555560448b in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #6 0x5555555f64a1 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #7 0x5555555a2da7 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #8 0x5555555a41d2 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #9 0x5555555a4d76 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #10 0x5555555bfe87 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #11 0x555555606f3e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #12 0x5555555f876a in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #13 0x5555555bcc1b in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #14 0x55555559016a in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #15 0x5555555900b0 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #16 0x7ffff5b26b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 88 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8d38 in __interceptor_calloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xded38)
    #1 0x7ffff66bf4d6 in __default_zero_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:56
    #2 0x7ffff6bb95d9 in rcl_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init.c:78
    #3 0x55555558044e in TestGuardConditionFixture__rmw_fastrtps_cpp_test_rcl_guard_condition_life_cycle_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_guard_condition.cpp:148
    #4 0x55555560448b in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555f64a1 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x5555555a2da7 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x5555555a41d2 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x5555555a4d76 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555bfe87 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x555555606f3e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555f876a in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555bcc1b in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x55555559016a in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x5555555900b0 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff5b26b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 104 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff66bf465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff6bbb2ba in rcl_init_options_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init_options.c:45
    #3 0x7ffff6bbb916 in rcl_init_options_copy /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init_options.c:73
    #4 0x7ffff6bb9729 in rcl_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/init.c:86
    #5 0x55555558044e in TestGuardConditionFixture__rmw_fastrtps_cpp_test_rcl_guard_condition_life_cycle_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_guard_condition.cpp:148
    #6 0x55555560448b in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #7 0x5555555f64a1 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #8 0x5555555a2da7 in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #9 0x5555555a41d2 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #10 0x5555555a4d76 in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #11 0x5555555bfe87 in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #12 0x555555606f3e in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #13 0x5555555f876a in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #14 0x5555555bcc1b in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #15 0x55555559016a in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #16 0x5555555900b0 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #17 0x7ffff5b26b96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: AddressSanitizer: 296 byte(s) leaked in 3 allocation(s).
```

with this PR:
```
root@ip-172-31-27-113:/root/ros2_asan_ws/build-asan/rcl/test# ./test_guard_condition__rmw_fastrtps_cpp 
Running main() from /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 2 tests from 1 test case.
[----------] Global test environment set-up.
[----------] 2 tests from TestGuardConditionFixture__rmw_fastrtps_cpp
[ RUN      ] TestGuardConditionFixture__rmw_fastrtps_cpp.test_rcl_guard_condition_accessors
[       OK ] TestGuardConditionFixture__rmw_fastrtps_cpp.test_rcl_guard_condition_accessors (0 ms)
[ RUN      ] TestGuardConditionFixture__rmw_fastrtps_cpp.test_rcl_guard_condition_life_cycle
[       OK ] TestGuardConditionFixture__rmw_fastrtps_cpp.test_rcl_guard_condition_life_cycle (0 ms)
[----------] 2 tests from TestGuardConditionFixture__rmw_fastrtps_cpp (0 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 1 test case ran. (0 ms total)
[  PASSED  ] 2 tests.
```