### PR TITLE
fix leak in test_service

### DIFF
--- a/rcl/test/rcl/test_service.cpp
+++ b/rcl/test/rcl/test_service.cpp
@@ -126,6 +126,8 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_service_nominal) 
   rcl_service_options_t service_options = rcl_service_get_default_options();
   ret = rcl_service_init(&service, this->node_ptr, ts, topic, &service_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ret = rcl_service_fini(&service, this->node_ptr);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
   // Check if null service is valid
   EXPECT_FALSE(rcl_service_is_valid(nullptr));
@@ -208,6 +210,7 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_service_nominal) 
     service_response.uint64_value = service_request.uint8_value + service_request.uint32_value;
     ret = rcl_send_response(&service, &header, &service_response);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+    test_msgs__srv__BasicTypes_Request__fini(&service_request);
   }
   wait_for_service_to_be_ready(&service, context_ptr, 10, 100, success);
 
@@ -220,4 +223,5 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_service_nominal) 
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   EXPECT_EQ(client_response.uint64_value, 3ULL);
   EXPECT_EQ(header.sequence_number, 1);
+  test_msgs__srv__BasicTypes_Response__fini(&client_response);
 }


### PR DESCRIPTION
Signed-off-by: Abby Xu <abbyxu@amazon.com>

memory leak detected:
```
root@ip-172-31-27-113:/root/ros2_asan_ws/build-asan/rcl/test# ./test_service__rmw_fastrtps_cpp
Running main() from /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from TestServiceFixture__rmw_fastrtps_cpp
[ RUN      ] TestServiceFixture__rmw_fastrtps_cpp.test_service_nominal
[       OK ] TestServiceFixture__rmw_fastrtps_cpp.test_service_nominal (2022 ms)
[----------] 1 test from TestServiceFixture__rmw_fastrtps_cpp (2022 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (2023 ms total)
[  PASSED  ] 1 test.

=================================================================
==10241==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 136 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6962465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff6bd166c in rcl_service_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/service.c:158
    #3 0x55555557a7e5 in TestServiceFixture__rmw_fastrtps_cpp_test_service_nominal_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_service.cpp:127
    #4 0x5555555fc19f in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555edf47 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x555555599d3b in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55555559b166 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555559bd0a in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555b6e1b in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555555fec52 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555f0210 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555b3baf in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x5555555870fe in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x555555587044 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 1 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7ffff4684f75 in rosidl_generator_c__String__assignn /root/ros2_asan_ws/src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7ffff46850af in rosidl_generator_c__String__assign /root/ros2_asan_ws/src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7ffff426532d in _BasicTypes_Response__cdr_deserialize /root/ros2_asan_ws/build-asan/test_msgs/rosidl_typesupport_fastrtps_c/test_msgs/srv/basic_types__type_support_c.cpp:709
    #4 0x7ffff4b2c982 in rmw_fastrtps_cpp::TypeSupport::deserializeROSmessage(eprosima::fastcdr::Cdr&, void*) /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/type_support_common.cpp:88
    #5 0x7ffff32a5329 in rmw_fastrtps_shared_cpp::__rmw_take_response(char const*, rmw_client_t const*, rmw_request_id_t*, void*, bool*) /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/rmw_response.cpp:61
    #6 0x7ffff4b1fe85 in rmw_take_response /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_response.cpp:32
    #7 0x7ffff6bb20e3 in rcl_take_response /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/client.c:299
    #8 0x55555557d3cb in TestServiceFixture__rmw_fastrtps_cpp_test_service_nominal_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_service.cpp:219
    #9 0x5555555fc19f in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #10 0x5555555edf47 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #11 0x555555599d3b in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #12 0x55555559b166 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #13 0x55555559bd0a in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #14 0x5555555b6e1b in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #15 0x5555555fec52 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #16 0x5555555f0210 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #17 0x5555555b3baf in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #18 0x5555555870fe in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #19 0x555555587044 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #20 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Direct leak of 1 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8f40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
    #1 0x7ffff4684f75 in rosidl_generator_c__String__assignn /root/ros2_asan_ws/src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
    #2 0x7ffff46850af in rosidl_generator_c__String__assign /root/ros2_asan_ws/src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
    #3 0x7ffff42641bd in _BasicTypes_Request__cdr_deserialize /root/ros2_asan_ws/build-asan/test_msgs/rosidl_typesupport_fastrtps_c/test_msgs/srv/basic_types__type_support_c.cpp:221
    #4 0x7ffff4b2c982 in rmw_fastrtps_cpp::TypeSupport::deserializeROSmessage(eprosima::fastcdr::Cdr&, void*) /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/type_support_common.cpp:88
    #5 0x7ffff32a1288 in rmw_fastrtps_shared_cpp::__rmw_take_request(char const*, rmw_service_t const*, rmw_request_id_t*, void*, bool*) /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/rmw_request.cpp:97
    #6 0x7ffff4b1fdea in rmw_take_request /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_request.cpp:43
    #7 0x7ffff6bd3408 in rcl_take_request /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/service.c:287
    #8 0x55555557c7d9 in TestServiceFixture__rmw_fastrtps_cpp_test_service_nominal_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_service.cpp:202
    #9 0x5555555fc19f in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #10 0x5555555edf47 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #11 0x555555599d3b in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #12 0x55555559b166 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #13 0x55555559bd0a in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #14 0x5555555b6e1b in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #15 0x5555555fec52 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #16 0x5555555f0210 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #17 0x5555555b3baf in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #18 0x5555555870fe in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #19 0x555555587044 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #20 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 104 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6efa458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x7ffff4b2311a in rmw_create_service /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_service.cpp:173
    #2 0x7ffff6bd1a51 in rcl_service_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/service.c:172
    #3 0x55555557a7e5 in TestServiceFixture__rmw_fastrtps_cpp_test_service_nominal_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_service.cpp:127
    #4 0x5555555fc19f in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555edf47 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x555555599d3b in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55555559b166 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555559bd0a in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555b6e1b in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555555fec52 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555f0210 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555b3baf in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x5555555870fe in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x555555587044 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6efa458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x7ffff4b22112 in rmw_create_service /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_service.cpp:132
    #2 0x7ffff6bd1a51 in rcl_service_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/service.c:172
    #3 0x55555557a7e5 in TestServiceFixture__rmw_fastrtps_cpp_test_service_nominal_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_service.cpp:127
    #4 0x5555555fc19f in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555edf47 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x555555599d3b in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55555559b166 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555559bd0a in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555b6e1b in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555555fec52 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555f0210 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555b3baf in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x5555555870fe in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x555555587044 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 72 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6efa458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x7ffff4b22070 in rmw_create_service /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_service.cpp:125
    #2 0x7ffff6bd1a51 in rcl_service_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/service.c:172
    #3 0x55555557a7e5 in TestServiceFixture__rmw_fastrtps_cpp_test_service_nominal_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_service.cpp:127
    #4 0x5555555fc19f in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555edf47 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x555555599d3b in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55555559b166 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555559bd0a in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555b6e1b in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555555fec52 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555f0210 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555b3baf in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x5555555870fe in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x555555587044 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 60 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff14d4bf8 in eprosima::fastcdr::FastBuffer::reserve(unsigned long) /root/ros2_asan_ws/src/eProsima/Fast-CDR/src/cpp/FastBuffer.cpp:49
    #2 0x7ffff32ca437 in rmw_fastrtps_shared_cpp::TypeSupport::deserialize(eprosima::fastrtps::rtps::SerializedPayload_t*, void*) /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_shared_cpp/src/TypeSupport_impl.cpp:86
    #3 0x7ffff20b11d9 in eprosima::fastrtps::SubscriberHistory::takeNextData(void*, eprosima::fastrtps::SampleInfo_t*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/subscriber/SubscriberHistory.cpp:446
    #4 0x7ffff20a1851 in eprosima::fastrtps::SubscriberImpl::takeNextData(void*, eprosima::fastrtps::SampleInfo_t*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/subscriber/SubscriberImpl.cpp:99
    #5 0x7ffff209d397 in eprosima::fastrtps::Subscriber::takeNextData(void*, eprosima::fastrtps::SampleInfo_t*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/subscriber/Subscriber.cpp:44
    #6 0x7ffff4b26714 in ServiceListener::onNewDataMessage(eprosima::fastrtps::Subscriber*) /root/ros2_asan_ws/install-asan/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp:81
    #7 0x7ffff20a3a8a in eprosima::fastrtps::SubscriberImpl::SubscriberReaderListener::onNewCacheChangeAdded(eprosima::fastrtps::rtps::RTPSReader*, eprosima::fastrtps::rtps::CacheChange_t const*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/subscriber/SubscriberImpl.cpp:223
    #8 0x7ffff1fc544a in eprosima::fastrtps::rtps::StatefulReader::NotifyChanges(eprosima::fastrtps::rtps::WriterProxy*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/reader/StatefulReader.cpp:570
    #9 0x7ffff1fc4e5d in eprosima::fastrtps::rtps::StatefulReader::change_received(eprosima::fastrtps::rtps::CacheChange_t*, eprosima::fastrtps::rtps::WriterProxy*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/reader/StatefulReader.cpp:545
    #10 0x7ffff1fc2578 in eprosima::fastrtps::rtps::StatefulReader::processDataMsg(eprosima::fastrtps::rtps::CacheChange_t*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/reader/StatefulReader.cpp:276
    #11 0x7ffff200c102 in eprosima::fastrtps::rtps::MessageReceiver::proc_Submsg_Data(eprosima::fastrtps::rtps::CDRMessage_t*, eprosima::fastrtps::rtps::SubmessageHeader_t*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/messages/MessageReceiver.cpp:575
    #12 0x7ffff200733c in eprosima::fastrtps::rtps::MessageReceiver::processCDRMsg(eprosima::fastrtps::rtps::Locator_t const&, eprosima::fastrtps::rtps::CDRMessage_t*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/messages/MessageReceiver.cpp:224
    #13 0x7ffff2026488 in eprosima::fastrtps::rtps::ReceiverResource::OnDataReceived(unsigned char const*, unsigned int, eprosima::fastrtps::rtps::Locator_t const&, eprosima::fastrtps::rtps::Locator_t const&) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/network/ReceiverResource.cpp:96
    #14 0x7ffff214dbed in eprosima::fastrtps::rtps::UDPTransportInterface::perform_listen_operation(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/transport/UDPTransportInterface.cpp:392
    #15 0x7ffff21594de in void std::__invoke_impl<void, void (eprosima::fastrtps::rtps::UDPTransportInterface::*)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*, eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t>(std::__invoke_memfun_deref, void (eprosima::fastrtps::rtps::UDPTransportInterface::*&&)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*&&, eprosima::fastrtps::rtps::UDPChannelResource*&&, eprosima::fastrtps::rtps::Locator_t&&) /usr/include/c++/7/bits/invoke.h:73
    #16 0x7ffff21563f8 in std::__invoke_result<void (eprosima::fastrtps::rtps::UDPTransportInterface::*)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*, eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t>::type std::__invoke<void (eprosima::fastrtps::rtps::UDPTransportInterface::*)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*, eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t>(void (eprosima::fastrtps::rtps::UDPTransportInterface::*&&)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*&&, eprosima::fastrtps::rtps::UDPChannelResource*&&, eprosima::fastrtps::rtps::Locator_t&&) /usr/include/c++/7/bits/invoke.h:95
    #17 0x7ffff216181e in decltype (__invoke((_S_declval<0ul>)(), (_S_declval<1ul>)(), (_S_declval<2ul>)(), (_S_declval<3ul>)())) std::thread::_Invoker<std::tuple<void (eprosima::fastrtps::rtps::UDPTransportInterface::*)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*, eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t> >::_M_invoke<0ul, 1ul, 2ul, 3ul>(std::_Index_tuple<0ul, 1ul, 2ul, 3ul>) /usr/include/c++/7/thread:234
    #18 0x7ffff2161750 in std::thread::_Invoker<std::tuple<void (eprosima::fastrtps::rtps::UDPTransportInterface::*)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*, eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t> >::operator()() /usr/include/c++/7/thread:243
    #19 0x7ffff21616b1 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (eprosima::fastrtps::rtps::UDPTransportInterface::*)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*, eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t> > >::_M_run() /usr/include/c++/7/thread:186
    #20 0x7ffff604157e  (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0xbd57e)

Indirect leak of 56 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6efa458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x7ffff4b21cf9 in rmw_create_service /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_service.cpp:105
    #2 0x7ffff6bd1a51 in rcl_service_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/service.c:172
    #3 0x55555557a7e5 in TestServiceFixture__rmw_fastrtps_cpp_test_service_nominal_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_service.cpp:127
    #4 0x5555555fc19f in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #5 0x5555555edf47 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #6 0x555555599d3b in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #7 0x55555559b166 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #8 0x55555559bd0a in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #9 0x5555555b6e1b in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #10 0x5555555fec52 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #11 0x5555555f0210 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #12 0x5555555b3baf in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #13 0x5555555870fe in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #14 0x555555587044 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #15 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 48 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6efa458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x7ffff4b275a3 in __gnu_cxx::new_allocator<std::_List_node<CustomServiceRequest> >::allocate(unsigned long, void const*) /usr/include/c++/7/ext/new_allocator.h:111
    #2 0x7ffff4b27476 in std::allocator_traits<std::allocator<std::_List_node<CustomServiceRequest> > >::allocate(std::allocator<std::_List_node<CustomServiceRequest> >&, unsigned long) /usr/include/c++/7/bits/alloc_traits.h:436
    #3 0x7ffff4b2728c in std::__cxx11::_List_base<CustomServiceRequest, std::allocator<CustomServiceRequest> >::_M_get_node() /usr/include/c++/7/bits/stl_list.h:383
    #4 0x7ffff4b2705e in std::_List_node<CustomServiceRequest>* std::__cxx11::list<CustomServiceRequest, std::allocator<CustomServiceRequest> >::_M_create_node<CustomServiceRequest const&>(CustomServiceRequest const&) /usr/include/c++/7/bits/stl_list.h:572
    #5 0x7ffff4b26d85 in void std::__cxx11::list<CustomServiceRequest, std::allocator<CustomServiceRequest> >::_M_insert<CustomServiceRequest const&>(std::_List_iterator<CustomServiceRequest>, CustomServiceRequest const&) /usr/include/c++/7/bits/stl_list.h:1801
    #6 0x7ffff4b26b27 in std::__cxx11::list<CustomServiceRequest, std::allocator<CustomServiceRequest> >::push_back(CustomServiceRequest const&) /usr/include/c++/7/bits/stl_list.h:1118
    #7 0x7ffff4b268bb in ServiceListener::onNewDataMessage(eprosima::fastrtps::Subscriber*) /root/ros2_asan_ws/install-asan/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp:97
    #8 0x7ffff20a3a8a in eprosima::fastrtps::SubscriberImpl::SubscriberReaderListener::onNewCacheChangeAdded(eprosima::fastrtps::rtps::RTPSReader*, eprosima::fastrtps::rtps::CacheChange_t const*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/subscriber/SubscriberImpl.cpp:223
    #9 0x7ffff1fc544a in eprosima::fastrtps::rtps::StatefulReader::NotifyChanges(eprosima::fastrtps::rtps::WriterProxy*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/reader/StatefulReader.cpp:570
    #10 0x7ffff1fc4e5d in eprosima::fastrtps::rtps::StatefulReader::change_received(eprosima::fastrtps::rtps::CacheChange_t*, eprosima::fastrtps::rtps::WriterProxy*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/reader/StatefulReader.cpp:545
    #11 0x7ffff1fc2578 in eprosima::fastrtps::rtps::StatefulReader::processDataMsg(eprosima::fastrtps::rtps::CacheChange_t*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/reader/StatefulReader.cpp:276
    #12 0x7ffff200c102 in eprosima::fastrtps::rtps::MessageReceiver::proc_Submsg_Data(eprosima::fastrtps::rtps::CDRMessage_t*, eprosima::fastrtps::rtps::SubmessageHeader_t*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/messages/MessageReceiver.cpp:575
    #13 0x7ffff200733c in eprosima::fastrtps::rtps::MessageReceiver::processCDRMsg(eprosima::fastrtps::rtps::Locator_t const&, eprosima::fastrtps::rtps::CDRMessage_t*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/messages/MessageReceiver.cpp:224
    #14 0x7ffff2026488 in eprosima::fastrtps::rtps::ReceiverResource::OnDataReceived(unsigned char const*, unsigned int, eprosima::fastrtps::rtps::Locator_t const&, eprosima::fastrtps::rtps::Locator_t const&) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/network/ReceiverResource.cpp:96
    #15 0x7ffff214dbed in eprosima::fastrtps::rtps::UDPTransportInterface::perform_listen_operation(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/transport/UDPTransportInterface.cpp:392
    #16 0x7ffff21594de in void std::__invoke_impl<void, void (eprosima::fastrtps::rtps::UDPTransportInterface::*)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*, eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t>(std::__invoke_memfun_deref, void (eprosima::fastrtps::rtps::UDPTransportInterface::*&&)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*&&, eprosima::fastrtps::rtps::UDPChannelResource*&&, eprosima::fastrtps::rtps::Locator_t&&) /usr/include/c++/7/bits/invoke.h:73
    #17 0x7ffff21563f8 in std::__invoke_result<void (eprosima::fastrtps::rtps::UDPTransportInterface::*)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*, eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t>::type std::__invoke<void (eprosima::fastrtps::rtps::UDPTransportInterface::*)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*, eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t>(void (eprosima::fastrtps::rtps::UDPTransportInterface::*&&)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*&&, eprosima::fastrtps::rtps::UDPChannelResource*&&, eprosima::fastrtps::rtps::Locator_t&&) /usr/include/c++/7/bits/invoke.h:95
    #18 0x7ffff216181e in decltype (__invoke((_S_declval<0ul>)(), (_S_declval<1ul>)(), (_S_declval<2ul>)(), (_S_declval<3ul>)())) std::thread::_Invoker<std::tuple<void (eprosima::fastrtps::rtps::UDPTransportInterface::*)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*, eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t> >::_M_invoke<0ul, 1ul, 2ul, 3ul>(std::_Index_tuple<0ul, 1ul, 2ul, 3ul>) /usr/include/c++/7/thread:234
    #19 0x7ffff2161750 in std::thread::_Invoker<std::tuple<void (eprosima::fastrtps::rtps::UDPTransportInterface::*)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*, eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t> >::operator()() /usr/include/c++/7/thread:243
    #20 0x7ffff21616b1 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (eprosima::fastrtps::rtps::UDPTransportInterface::*)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*, eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t> > >::_M_run() /usr/include/c++/7/thread:186
    #21 0x7ffff604157e  (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0xbd57e)

Indirect leak of 43 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6efa458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x55555560f3bb in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag) /usr/include/c++/7/bits/basic_string.tcc:219
    #2 0x7ffff4b2d96a in eprosima::fastrtps::TopicDataType::setName(char const*) /root/ros2_asan_ws/install-asan/fastrtps/include/fastrtps/TopicDataType.h:88
    #3 0x7ffff4b2d1d9 in rmw_fastrtps_cpp::ResponseTypeSupport::ResponseTypeSupport(service_type_support_callbacks_t const*) /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/type_support_common.cpp:132
    #4 0x7ffff4b22127 in rmw_create_service /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_service.cpp:132
    #5 0x7ffff6bd1a51 in rcl_service_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/service.c:172
    #6 0x55555557a7e5 in TestServiceFixture__rmw_fastrtps_cpp_test_service_nominal_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_service.cpp:127
    #7 0x5555555fc19f in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #8 0x5555555edf47 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #9 0x555555599d3b in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #10 0x55555559b166 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #11 0x55555559bd0a in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #12 0x5555555b6e1b in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #13 0x5555555fec52 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #14 0x5555555f0210 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #15 0x5555555b3baf in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #16 0x5555555870fe in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #17 0x555555587044 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #18 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 42 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6efa458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x55555560f3bb in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::_M_construct<char const*>(char const*, char const*, std::forward_iterator_tag) /usr/include/c++/7/bits/basic_string.tcc:219
    #2 0x7ffff4b2d96a in eprosima::fastrtps::TopicDataType::setName(char const*) /root/ros2_asan_ws/install-asan/fastrtps/include/fastrtps/TopicDataType.h:88
    #3 0x7ffff4b2cef7 in rmw_fastrtps_cpp::RequestTypeSupport::RequestTypeSupport(service_type_support_callbacks_t const*) /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/type_support_common.cpp:120
    #4 0x7ffff4b22085 in rmw_create_service /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_service.cpp:125
    #5 0x7ffff6bd1a51 in rcl_service_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/service.c:172
    #6 0x55555557a7e5 in TestServiceFixture__rmw_fastrtps_cpp_test_service_nominal_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_service.cpp:127
    #7 0x5555555fc19f in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #8 0x5555555edf47 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #9 0x555555599d3b in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #10 0x55555559b166 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #11 0x55555559bd0a in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #12 0x5555555b6e1b in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #13 0x5555555fec52 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #14 0x5555555f0210 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #15 0x5555555b3baf in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #16 0x5555555870fe in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #17 0x555555587044 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #18 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6efa458 in operator new(unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe0458)
    #1 0x7ffff4b26614 in ServiceListener::onNewDataMessage(eprosima::fastrtps::Subscriber*) /root/ros2_asan_ws/install-asan/rmw_fastrtps_shared_cpp/include/rmw_fastrtps_shared_cpp/custom_service_info.hpp:75
    #2 0x7ffff20a3a8a in eprosima::fastrtps::SubscriberImpl::SubscriberReaderListener::onNewCacheChangeAdded(eprosima::fastrtps::rtps::RTPSReader*, eprosima::fastrtps::rtps::CacheChange_t const*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/subscriber/SubscriberImpl.cpp:223
    #3 0x7ffff1fc544a in eprosima::fastrtps::rtps::StatefulReader::NotifyChanges(eprosima::fastrtps::rtps::WriterProxy*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/reader/StatefulReader.cpp:570
    #4 0x7ffff1fc4e5d in eprosima::fastrtps::rtps::StatefulReader::change_received(eprosima::fastrtps::rtps::CacheChange_t*, eprosima::fastrtps::rtps::WriterProxy*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/reader/StatefulReader.cpp:545
    #5 0x7ffff1fc2578 in eprosima::fastrtps::rtps::StatefulReader::processDataMsg(eprosima::fastrtps::rtps::CacheChange_t*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/reader/StatefulReader.cpp:276
    #6 0x7ffff200c102 in eprosima::fastrtps::rtps::MessageReceiver::proc_Submsg_Data(eprosima::fastrtps::rtps::CDRMessage_t*, eprosima::fastrtps::rtps::SubmessageHeader_t*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/messages/MessageReceiver.cpp:575
    #7 0x7ffff200733c in eprosima::fastrtps::rtps::MessageReceiver::processCDRMsg(eprosima::fastrtps::rtps::Locator_t const&, eprosima::fastrtps::rtps::CDRMessage_t*) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/messages/MessageReceiver.cpp:224
    #8 0x7ffff2026488 in eprosima::fastrtps::rtps::ReceiverResource::OnDataReceived(unsigned char const*, unsigned int, eprosima::fastrtps::rtps::Locator_t const&, eprosima::fastrtps::rtps::Locator_t const&) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/rtps/network/ReceiverResource.cpp:96
    #9 0x7ffff214dbed in eprosima::fastrtps::rtps::UDPTransportInterface::perform_listen_operation(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t) /root/ros2_asan_ws/src/eProsima/Fast-RTPS/src/cpp/transport/UDPTransportInterface.cpp:392
    #10 0x7ffff21594de in void std::__invoke_impl<void, void (eprosima::fastrtps::rtps::UDPTransportInterface::*)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*, eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t>(std::__invoke_memfun_deref, void (eprosima::fastrtps::rtps::UDPTransportInterface::*&&)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*&&, eprosima::fastrtps::rtps::UDPChannelResource*&&, eprosima::fastrtps::rtps::Locator_t&&) /usr/include/c++/7/bits/invoke.h:73
    #11 0x7ffff21563f8 in std::__invoke_result<void (eprosima::fastrtps::rtps::UDPTransportInterface::*)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*, eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t>::type std::__invoke<void (eprosima::fastrtps::rtps::UDPTransportInterface::*)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*, eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t>(void (eprosima::fastrtps::rtps::UDPTransportInterface::*&&)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*&&, eprosima::fastrtps::rtps::UDPChannelResource*&&, eprosima::fastrtps::rtps::Locator_t&&) /usr/include/c++/7/bits/invoke.h:95
    #12 0x7ffff216181e in decltype (__invoke((_S_declval<0ul>)(), (_S_declval<1ul>)(), (_S_declval<2ul>)(), (_S_declval<3ul>)())) std::thread::_Invoker<std::tuple<void (eprosima::fastrtps::rtps::UDPTransportInterface::*)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*, eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t> >::_M_invoke<0ul, 1ul, 2ul, 3ul>(std::_Index_tuple<0ul, 1ul, 2ul, 3ul>) /usr/include/c++/7/thread:234
    #13 0x7ffff2161750 in std::thread::_Invoker<std::tuple<void (eprosima::fastrtps::rtps::UDPTransportInterface::*)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*, eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t> >::operator()() /usr/include/c++/7/thread:243
    #14 0x7ffff21616b1 in std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (eprosima::fastrtps::rtps::UDPTransportInterface::*)(eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t), eprosima::fastrtps::rtps::UDPTransportInterface*, eprosima::fastrtps::rtps::UDPChannelResource*, eprosima::fastrtps::rtps::Locator_t> > >::_M_run() /usr/include/c++/7/thread:186
    #15 0x7ffff604157e  (/usr/lib/x86_64-linux-gnu/libstdc++.so.6+0xbd57e)

Indirect leak of 24 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6962465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff488de8c in rmw_allocate /root/ros2_asan_ws/src/ros2/rmw/rmw/src/allocators.c:29
    #3 0x7ffff488e1dc in rmw_service_allocate /root/ros2_asan_ws/src/ros2/rmw/rmw/src/allocators.c:119
    #4 0x7ffff4b232ac in rmw_create_service /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_service.cpp:193
    #5 0x7ffff6bd1a51 in rcl_service_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/service.c:172
    #6 0x55555557a7e5 in TestServiceFixture__rmw_fastrtps_cpp_test_service_nominal_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_service.cpp:127
    #7 0x5555555fc19f in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #8 0x5555555edf47 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #9 0x555555599d3b in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #10 0x55555559b166 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #11 0x55555559bd0a in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #12 0x5555555b6e1b in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #13 0x5555555fec52 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #14 0x5555555f0210 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #15 0x5555555b3baf in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #16 0x5555555870fe in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #17 0x555555587044 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #18 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

Indirect leak of 12 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6ef8b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
    #1 0x7ffff6962465 in __default_allocate /root/ros2_asan_ws/src/ros2/rcutils/src/allocator.c:35
    #2 0x7ffff488de8c in rmw_allocate /root/ros2_asan_ws/src/ros2/rmw/rmw/src/allocators.c:29
    #3 0x7ffff4b2338b in rmw_create_service /root/ros2_asan_ws/src/ros2/rmw_fastrtps/rmw_fastrtps_cpp/src/rmw_service.cpp:201
    #4 0x7ffff6bd1a51 in rcl_service_init /root/ros2_asan_ws/src/ros2/rcl/rcl/src/rcl/service.c:172
    #5 0x55555557a7e5 in TestServiceFixture__rmw_fastrtps_cpp_test_service_nominal_Test::TestBody() /root/ros2_asan_ws/src/ros2/rcl/rcl/test/rcl/test_service.cpp:127
    #6 0x5555555fc19f in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #7 0x5555555edf47 in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #8 0x555555599d3b in testing::Test::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2522
    #9 0x55555559b166 in testing::TestInfo::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2703
    #10 0x55555559bd0a in testing::TestCase::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2825
    #11 0x5555555b6e1b in testing::internal::UnitTestImpl::RunAllTests() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:5216
    #12 0x5555555fec52 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2447
    #13 0x5555555f0210 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:2483
    #14 0x5555555b3baf in testing::UnitTest::Run() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/./src/gtest.cc:4824
    #15 0x5555555870fe in RUN_ALL_TESTS() /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:2370
    #16 0x555555587044 in main /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc:36
    #17 0x7ffff599cb96 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x21b96)

SUMMARY: AddressSanitizer: 703 byte(s) leaked in 14 allocation(s).
```

With this PR:
```
root@ip-172-31-27-113:~/ros2_asan_ws/build-asan/rcl/test# ./test_service__rmw_fastrtps_cpp 
Running main() from /root/ros2_asan_ws/install-asan/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from TestServiceFixture__rmw_fastrtps_cpp
[ RUN      ] TestServiceFixture__rmw_fastrtps_cpp.test_service_nominal
[       OK ] TestServiceFixture__rmw_fastrtps_cpp.test_service_nominal (2023 ms)
[----------] 1 test from TestServiceFixture__rmw_fastrtps_cpp (2023 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (2024 ms total)
[  PASSED  ] 1 test.
```