### PR TITLE
rcl_action - user friendly error messages for invalid transitions

### DIFF
--- a/rcl_action/include/rcl_action/goal_handle.h
+++ b/rcl_action/include/rcl_action/goal_handle.h
@@ -29,10 +29,6 @@ extern "C"
 /// Internal rcl action goal implementation struct.
 struct rcl_action_goal_handle_impl_t;
 
-/// User friendly error messages for invalid trasntions
-extern const char * goal_state_descriptions[];
-extern const char * goal_event_descriptions[];
-
 /// Goal handle for an action.
 typedef struct rcl_action_goal_handle_t
 {

--- a/rcl_action/include/rcl_action/goal_handle.h
+++ b/rcl_action/include/rcl_action/goal_handle.h
@@ -29,6 +29,10 @@ extern "C"
 /// Internal rcl action goal implementation struct.
 struct rcl_action_goal_handle_impl_t;
 
+/// User friendly error messages for invalid trasntions
+extern const char * goal_state_descriptions[];
+extern const char * goal_event_descriptions[];
+
 /// Goal handle for an action.
 typedef struct rcl_action_goal_handle_t
 {

--- a/rcl_action/include/rcl_action/types.h
+++ b/rcl_action/include/rcl_action/types.h
@@ -93,6 +93,7 @@ typedef int8_t rcl_action_goal_state_t;
 #define GOAL_STATE_ABORTED action_msgs__msg__GoalStatus__STATUS_ABORTED
 #define GOAL_STATE_NUM_STATES 7
 
+
 /// Goal state transition events
 typedef enum rcl_action_goal_event_t
 {

--- a/rcl_action/include/rcl_action/types.h
+++ b/rcl_action/include/rcl_action/types.h
@@ -93,6 +93,10 @@ typedef int8_t rcl_action_goal_state_t;
 #define GOAL_STATE_ABORTED action_msgs__msg__GoalStatus__STATUS_ABORTED
 #define GOAL_STATE_NUM_STATES 7
 
+/// User friendly error messages for invalid trasntions
+// Description variables in types.c should be changed if enum values change
+extern const char * goal_state_descriptions[];
+extern const char * goal_event_descriptions[];
 
 /// Goal state transition events
 typedef enum rcl_action_goal_event_t

--- a/rcl_action/src/rcl_action/goal_handle.c
+++ b/rcl_action/src/rcl_action/goal_handle.c
@@ -22,6 +22,13 @@ extern "C"
 #include "rcl/rcl.h"
 #include "rcl/error_handling.h"
 
+const char * goal_state_descriptions[] =
+{"UNKNOWN", "ACCEPTED", "EXECUTING", "CANCELING", "SUCCEEDED", "CANCELED", "ABORTED"};
+
+const char * goal_event_descriptions[] =
+{"EXECUTE", "CANCEL_GOAL", "SUCCEED", "ABORT", "CANCELED", "NUM_EVENTS"};
+
+
 typedef struct rcl_action_goal_handle_impl_t
 {
   rcl_action_goal_info_t info;
@@ -89,9 +96,9 @@ rcl_action_update_goal_state(
     goal_handle->impl->state, goal_event);
   if (GOAL_STATE_UNKNOWN == new_state) {
     RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
-      "goal_handle attempted invalid transition from state %d with event %d",
-      goal_handle->impl->state,
-      goal_event);
+      "goal_handle attempted invalid transition from state %s with event %s",
+      goal_state_descriptions[goal_handle->impl->state],
+      goal_event_descriptions[goal_event]);
     return RCL_RET_ACTION_GOAL_EVENT_INVALID;
   }
   goal_handle->impl->state = new_state;

--- a/rcl_action/src/rcl_action/goal_handle.c
+++ b/rcl_action/src/rcl_action/goal_handle.c
@@ -22,13 +22,6 @@ extern "C"
 #include "rcl/rcl.h"
 #include "rcl/error_handling.h"
 
-const char * goal_state_descriptions[] =
-{"UNKNOWN", "ACCEPTED", "EXECUTING", "CANCELING", "SUCCEEDED", "CANCELED", "ABORTED"};
-
-const char * goal_event_descriptions[] =
-{"EXECUTE", "CANCEL_GOAL", "SUCCEED", "ABORT", "CANCELED", "NUM_EVENTS"};
-
-
 typedef struct rcl_action_goal_handle_impl_t
 {
   rcl_action_goal_info_t info;

--- a/rcl_action/src/rcl_action/types.c
+++ b/rcl_action/src/rcl_action/types.c
@@ -132,6 +132,13 @@ rcl_action_cancel_response_fini(rcl_action_cancel_response_t * cancel_response)
   return RCL_RET_OK;
 }
 
+/// Values should be changed if enum values chang
+const char * goal_state_descriptions[] =
+{"UNKNOWN", "ACCEPTED", "EXECUTING", "CANCELING", "SUCCEEDED", "CANCELED", "ABORTED"};
+
+const char * goal_event_descriptions[] =
+{"EXECUTE", "CANCEL_GOAL", "SUCCEED", "ABORT", "CANCELED", "NUM_EVENTS"};
+
 #ifdef __cplusplus
 }
 #endif

--- a/rcl_action/src/rcl_action/types.c
+++ b/rcl_action/src/rcl_action/types.c
@@ -132,7 +132,7 @@ rcl_action_cancel_response_fini(rcl_action_cancel_response_t * cancel_response)
   return RCL_RET_OK;
 }
 
-/// Values should be changed if enum values chang
+/// Values should be changed if enum values change
 const char * goal_state_descriptions[] =
 {"UNKNOWN", "ACCEPTED", "EXECUTING", "CANCELING", "SUCCEEDED", "CANCELED", "ABORTED"};
 


### PR DESCRIPTION
@jacobperron 
For issue: https://github.com/ros2/rmw_fastrtps/issues/277