### PR TITLE
Use size_t printf format for size_t variable

### DIFF
--- a/rcl/src/rcl/lexer_lookahead.c
+++ b/rcl/src/rcl/lexer_lookahead.c
@@ -219,12 +219,12 @@ rcl_lexer_lookahead2_expect(
   if (type != lexeme) {
     if (RCL_LEXEME_NONE == lexeme || RCL_LEXEME_EOF == lexeme) {
       RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
-        "Expected lexeme type (%d) not found, search ended at index %lu",
+        "Expected lexeme type (%d) not found, search ended at index %zu",
         type, buffer->impl->text_idx);
       return RCL_RET_WRONG_LEXEME;
     }
     RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
-      "Expected lexeme type %d, got %d at index %lu", type, lexeme,
+      "Expected lexeme type %d, got %d at index %zu", type, lexeme,
       buffer->impl->text_idx);
     return RCL_RET_WRONG_LEXEME;
   }


### PR DESCRIPTION
Related to https://github.com/ros2/ros2/issues/721

Fixes these warnings https://ci.ros2.org/view/All/job/test_ci_linux-armhf/8/warnings23Result/package.1954841715/

Signed-off-by: Emerson Knapp <eknapp@amazon.com>