### PR TITLE
Implement get_actual_qos() for subscriptions

### DIFF
--- a/rcl/include/rcl/subscription.h
+++ b/rcl/include/rcl/subscription.h
@@ -445,6 +445,32 @@ rcl_subscription_get_publisher_count(
   const rcl_subscription_t * subscription,
   size_t * publisher_count);
 
+/// Get the actual qos settings of the subscription.
+/**
+ * Used to get the actual qos settings of the subscription.
+ * The actual configuration applied when using RMW_*_SYSTEM_DEFAULT
+ * can only be resolved after the creation of the subscription, and it
+ * depends on the underlying rmw implementation.
+ * If the underlying setting in use can't be represented in ROS terms,
+ * it will be set to RMW_*_UNKNOWN.
+ * The returned struct is only valid as long as the rcl_subscription_t is valid.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | Yes
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] subscription pointer to the rcl subscription
+ * \return qos struct if successful, otherwise `NULL`
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+const rmw_qos_profile_t *
+rcl_subscription_get_actual_qos(const rcl_subscription_t * subscription);
+
 #ifdef __cplusplus
 }
 #endif

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -167,6 +167,17 @@ rcl_subscription_init(
     RCL_SET_ERROR_MSG(rmw_get_error_string().str);
     goto fail;
   }
+  // get actual qos, and store it
+  rmw_ret = rmw_subscription_get_actual_qos(
+    subscription->impl->rmw_handle,
+    &subscription->impl->actual_qos);
+  if (RMW_RET_OK != rmw_ret) {
+    RCL_SET_ERROR_MSG(rmw_get_error_string().str);
+    ret = RCL_RET_ERROR;
+    goto fail;
+  }
+  subscription->impl->actual_qos.avoid_ros_namespace_conventions =
+    options->qos.avoid_ros_namespace_conventions;
   // options
   subscription->impl->options = *options;
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Subscription initialized");
@@ -357,6 +368,15 @@ rcl_subscription_get_publisher_count(
     return rcl_convert_rmw_ret_to_rcl_ret(ret);
   }
   return RCL_RET_OK;
+}
+
+const rmw_qos_profile_t *
+rcl_subscription_get_actual_qos(const rcl_subscription_t * subscription)
+{
+  if (!rcl_subscription_is_valid(subscription)) {
+    return NULL;
+  }
+  return &subscription->impl->actual_qos;
 }
 
 #ifdef __cplusplus

--- a/rcl/src/rcl/subscription_impl.h
+++ b/rcl/src/rcl/subscription_impl.h
@@ -22,6 +22,7 @@
 typedef struct rcl_subscription_impl_t
 {
   rcl_subscription_options_t options;
+  rmw_qos_profile_t actual_qos;
   rmw_subscription_t * rmw_handle;
 } rcl_subscription_impl_t;
 

--- a/rcl/test/rcl/test_get_actual_qos.cpp
+++ b/rcl/test/rcl/test_get_actual_qos.cpp
@@ -67,7 +67,7 @@ std::ostream & operator<<(
   return out;
 }
 
-class TEST_FIXTURE_P_RMW(TestGetActualQoS)
+class TEST_FIXTURE_P_RMW (TestGetActualQoS)
   : public ::testing::TestWithParam<TestParameters>
 {
 public:
@@ -115,7 +115,7 @@ protected:
 };
 
 
-class TEST_FIXTURE_P_RMW(TestPublisherGetActualQoS)
+class TEST_FIXTURE_P_RMW (TestPublisherGetActualQoS)
   : public TEST_FIXTURE_P_RMW(TestGetActualQoS) {};
 
 TEST_P_RMW(TestPublisherGetActualQoS, test_publisher_get_qos_settings) {
@@ -159,7 +159,7 @@ TEST_P_RMW(TestPublisherGetActualQoS, test_publisher_get_qos_settings) {
 }
 
 
-class TEST_FIXTURE_P_RMW(TestSubscriptionGetActualQoS)
+class TEST_FIXTURE_P_RMW (TestSubscriptionGetActualQoS)
   : public TEST_FIXTURE_P_RMW(TestGetActualQoS) {};
 
 TEST_P_RMW(TestSubscriptionGetActualQoS, test_subscription_get_qos_settings) {

--- a/rcl/test/rcl/test_get_actual_qos.cpp
+++ b/rcl/test/rcl/test_get_actual_qos.cpp
@@ -234,10 +234,7 @@ TEST_P_RMW(TestSubscriptionGetActualQoS, test_subscription_get_qos_settings)
   EXPECT_GE(
     qos->deadline,
     parameters.qos_expected.deadline);
-  // lifespan is not a concept in subscriptions
-  // EXPECT_GE(
-  //   qos->lifespan,
-  //   parameters.qos_expected.lifespan);
+  // note: lifespan is not a concept in subscriptions
   EXPECT_EQ(
     qos->liveliness,
     parameters.qos_expected.liveliness);
@@ -358,7 +355,6 @@ expected_system_default_subscription_qos_profile()
   profile.depth = 1;
   profile.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
   profile.deadline.sec = 2147483647;
-  profile.lifespan.sec = 2147483647;
   profile.liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
   profile.liveliness_lease_duration.sec = 2147483647;
   return profile;
@@ -372,7 +368,6 @@ expected_system_default_subscription_qos_profile_for_fastrtps()
   profile.reliability = RMW_QOS_POLICY_RELIABILITY_BEST_EFFORT;
   profile.durability = RMW_QOS_POLICY_DURABILITY_VOLATILE;
   profile.deadline.sec = 2147483647;
-  profile.lifespan.sec = 2147483647;
   profile.liveliness = RMW_QOS_POLICY_LIVELINESS_AUTOMATIC;
   profile.liveliness_lease_duration.sec = 2147483647;
   return profile;


### PR DESCRIPTION
Currently, publishers have the get_actual_qos() feature/function. It would make sense for subscriptions to have them, too.