### PR TITLE
Migrate to '--ros-args ... [--]'-based ROS args extraction

### DIFF
--- a/rcl/include/rcl/arguments.h
+++ b/rcl/include/rcl/arguments.h
@@ -100,7 +100,7 @@ rcl_parse_arguments(
   rcl_allocator_t allocator,
   rcl_arguments_t * args_output);
 
-/// Return the number of arguments that were not successfully parsed.
+/// Return the number of arguments that were not ROS specific arguments.
 /**
  * <hr>
  * Attribute          | Adherence
@@ -120,10 +120,10 @@ int
 rcl_arguments_get_count_unparsed(
   const rcl_arguments_t * args);
 
-/// Return a list of indexes that weren't successfully parsed.
+/// Return a list of indices to non ROS specific arguments.
 /**
- * Some arguments may not have been successfully parsed, or were not intended as ROS arguments.
- * This function populates an array of indexes to these arguments in the original argv array.
+ * Non ROS specific arguments may have been provided i.e. arguments outside a '--ros-args' scope.
+ * This function populates an array of indices to these arguments in the original argv array.
  * Since the first argument is always assumed to be a process name, the list will always contain
  * the index 0.
  *
@@ -152,6 +152,58 @@ rcl_arguments_get_unparsed(
   const rcl_arguments_t * args,
   rcl_allocator_t allocator,
   int ** output_unparsed_indices);
+
+/// Return the number of ROS specific arguments that were not successfully parsed.
+/**
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | Yes
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] args An arguments structure that has been parsed.
+ * \return number of unparsed ROS specific arguments, or
+ * \return -1 if args is `NULL` or zero initialized.
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+int
+rcl_arguments_get_count_unparsed_ros(
+  const rcl_arguments_t * args);
+
+/// Return a list of indices to ROS specific arguments that weren't successfully parsed.
+/**
+ * Some ROS specific arguments may not have been successfully parsed, or were not intended to be
+ * parsed by rcl.
+ * This function populates an array of indices to these arguments in the original argv array.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | Yes
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] args An arguments structure that has been parsed.
+ * \param[in] allocator A valid allocator.
+ * \param[out] output_unparsed_indices An allocated array of indices into the original argv array.
+ *   This array must be deallocated by the caller using the given allocator.
+ *   If there are no unparsed ROS specific arguments then the output will be set to NULL.
+ * \return `RCL_RET_OK` if everything goes correctly, or
+ * \return `RCL_RET_INVALID_ARGUMENT` if any function arguments are invalid, or
+ * \return `RCL_RET_BAD_ALLOC` if allocating memory failed, or
+ * \return `RCL_RET_ERROR` if an unspecified error occurs.
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_arguments_get_unparsed_ros(
+  const rcl_arguments_t * args,
+  rcl_allocator_t allocator,
+  int ** output_unparsed_ros_indices);
 
 /// Return the number of parameter yaml files given in the arguments.
 /**

--- a/rcl/include/rcl/arguments.h
+++ b/rcl/include/rcl/arguments.h
@@ -34,6 +34,9 @@ typedef struct rcl_arguments_t
   struct rcl_arguments_impl_t * impl;
 } rcl_arguments_t;
 
+#define RCL_ROS_ARGS_FLAG "--ros-args"
+#define RCL_ROS_ARGS_EXPLICIT_END_TOKEN "--"
+
 #define RCL_LOG_LEVEL_ARG_RULE "__log_level:="
 #define RCL_EXTERNAL_LOG_CONFIG_ARG_RULE "__log_config_file:="
 #define RCL_LOG_DISABLE_STDOUT_ARG_RULE "__log_disable_stdout:="

--- a/rcl/include/rcl/arguments.h
+++ b/rcl/include/rcl/arguments.h
@@ -173,7 +173,7 @@ int
 rcl_arguments_get_count_unparsed_ros(
   const rcl_arguments_t * args);
 
-/// Return a list of indices to ROS specific arguments that weren't successfully parsed.
+/// Return a list of indices to ROS specific arguments that were not successfully parsed.
 /**
  * Some ROS specific arguments may not have been successfully parsed, or were not intended to be
  * parsed by rcl.

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -254,15 +254,10 @@ rcl_parse_arguments(
   }
 
   bool parsing_ros_args = false;
-  const size_t ros_args_flag_len = strlen(RCL_ROS_ARGS_FLAG);
-  const size_t ros_args_explicit_end_token_len = strlen(RCL_ROS_ARGS_EXPLICIT_END_TOKEN);
   for (int i = 0; i < argc; ++i) {
     if (parsing_ros_args) {
       // Check for ROS specific arguments explicit end token
-      if (
-        strncmp(RCL_ROS_ARGS_EXPLICIT_END_TOKEN, argv[i], ros_args_explicit_end_token_len) == 0 &&
-        argv[i][ros_args_explicit_end_token_len] == '\0')
-      {
+      if (strcmp(RCL_ROS_ARGS_EXPLICIT_END_TOKEN, argv[i]) == 0) {
         parsing_ros_args = false;
         continue;
       }
@@ -357,7 +352,7 @@ rcl_parse_arguments(
       ++(args_impl->num_unparsed_ros_args);
     } else {
       // Check for ROS specific arguments flags
-      if (strncmp(RCL_ROS_ARGS_FLAG, argv[i], ros_args_flag_len) == 0) {
+      if (strcmp(RCL_ROS_ARGS_FLAG, argv[i]) == 0) {
         parsing_ros_args = true;
         continue;
       }

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -468,6 +468,41 @@ rcl_arguments_get_unparsed(
   return RCL_RET_OK;
 }
 
+int
+rcl_arguments_get_count_unparsed_ros(
+  const rcl_arguments_t * args)
+{
+  if (NULL == args || NULL == args->impl) {
+    return -1;
+  }
+  return args->impl->num_unparsed_ros_args;
+}
+
+rcl_ret_t
+rcl_arguments_get_unparsed_ros(
+  const rcl_arguments_t * args,
+  rcl_allocator_t allocator,
+  int ** output_unparsed_ros_indices)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(args, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(args->impl, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(output_unparsed_ros_indices, RCL_RET_INVALID_ARGUMENT);
+
+  *output_unparsed_ros_indices = NULL;
+  if (args->impl->num_unparsed_ros_args) {
+    *output_unparsed_ros_indices = allocator.allocate(
+      sizeof(int) * args->impl->num_unparsed_ros_args, allocator.state);
+    if (NULL == *output_unparsed_ros_indices) {
+      return RCL_RET_BAD_ALLOC;
+    }
+    for (int i = 0; i < args->impl->num_unparsed_ros_args; ++i) {
+      (*output_unparsed_ros_indices)[i] = args->impl->unparsed_ros_args[i];
+    }
+  }
+  return RCL_RET_OK;
+}
+
 rcl_arguments_t
 rcl_get_zero_initialized_arguments(void)
 {

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -256,6 +256,11 @@ rcl_parse_arguments(
   bool parsing_ros_args = false;
   for (int i = 0; i < argc; ++i) {
     if (parsing_ros_args) {
+      // Ignore ROS specific arguments flags
+      if (strcmp(RCL_ROS_ARGS_FLAG, argv[i]) == 0) {
+        continue;
+      }
+
       // Check for ROS specific arguments explicit end token
       if (strcmp(RCL_ROS_ARGS_EXPLICIT_END_TOKEN, argv[i]) == 0) {
         parsing_ros_args = false;

--- a/rcl/src/rcl/arguments_impl.h
+++ b/rcl/src/rcl/arguments_impl.h
@@ -31,7 +31,7 @@ typedef struct rcl_arguments_impl_t
   /// Length of unparsed_ros_args.
   int num_unparsed_ros_args;
 
-  /// Array of indices to not ROS specific arguments.
+  /// Array of indices to non-ROS arguments.
   int * unparsed_args;
   /// Length of unparsed_args.
   int num_unparsed_args;

--- a/rcl/src/rcl/arguments_impl.h
+++ b/rcl/src/rcl/arguments_impl.h
@@ -26,7 +26,12 @@ extern "C"
 /// \internal
 typedef struct rcl_arguments_impl_t
 {
-  /// Array of indices that were not valid ROS arguments.
+  /// Array of indices to unknown ROS specific arguments.
+  int * unparsed_ros_args;
+  /// Length of unparsed_ros_args.
+  int num_unparsed_ros_args;
+
+  /// Array of indices to not ROS specific arguments.
   int * unparsed_args;
   /// Length of unparsed_args.
   int num_unparsed_args;

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -49,6 +49,7 @@ public:
     if (actual_num_unparsed > 0) { \
       rcl_ret_t ret = rcl_arguments_get_unparsed(&parsed_args, alloc, &actual_unparsed); \
       ASSERT_EQ(RCL_RET_OK, ret); \
+      ASSERT_TRUE(NULL != actual_unparsed); \
     } \
     std::stringstream expected; \
     expected << "["; \
@@ -65,7 +66,7 @@ public:
     if (NULL != actual_unparsed) { \
       alloc.deallocate(actual_unparsed, alloc.state); \
     } \
-    EXPECT_STREQ(expected.str().c_str(), actual.str().c_str()); \
+    EXPECT_EQ(expected.str(), actual.str()); \
   } while (0)
 
 #define EXPECT_UNPARSED_ROS(parsed_args, ...) \
@@ -78,25 +79,25 @@ public:
     if (actual_num_unparsed_ros > 0) { \
       rcl_ret_t ret = rcl_arguments_get_unparsed_ros(&parsed_args, alloc, &actual_unparsed_ros); \
       ASSERT_EQ(RCL_RET_OK, ret); \
+      ASSERT_TRUE(NULL != actual_unparsed_ros); \
     } \
     std::stringstream expected; \
     expected << "["; \
     for (int e = 0; e < expect_num_unparsed_ros; ++e) { \
-      expected << expect_unparsed_ros[e] << ", ";       \
+      expected << expect_unparsed_ros[e] << ", "; \
     } \
     expected << "]"; \
     std::stringstream actual; \
     actual << "["; \
     for (int a = 0; a < actual_num_unparsed_ros; ++a) { \
-      actual << actual_unparsed_ros[a] << ", ";         \
+      actual << actual_unparsed_ros[a] << ", "; \
     } \
     actual << "]"; \
-    if (NULL != actual_unparsed_ros) {                \
+    if (NULL != actual_unparsed_ros) { \
       alloc.deallocate(actual_unparsed_ros, alloc.state); \
     } \
-    EXPECT_STREQ(expected.str().c_str(), actual.str().c_str()); \
+    EXPECT_EQ(expected.str(), actual.str()); \
   } while (0)
-
 
 bool
 is_valid_ros_arg(const char * arg)
@@ -206,7 +207,9 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_one_remap) {
 }
 
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_mix_valid_invalid_rules) {
-  const char * argv[] = {"process_name", "--ros-args", "/foo/bar:=", "bar:=/fiz/buz", "}bar:=fiz", "--", "run"};
+  const char * argv[] = {
+    "process_name", "--ros-args", "/foo/bar:=", "bar:=/fiz/buz", "}bar:=fiz", "--", "run"
+  };
   int argc = sizeof(argv) / sizeof(const char *);
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
   rcl_ret_t ret;

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -178,7 +178,6 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_no_args) {
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
 }
 
-
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_null_args) {
   int argc = 1;
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
@@ -252,7 +251,6 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_one_remap_w_tra
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
 }
 
-
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_mix_valid_invalid_rules) {
   const char * argv[] = {
     "process_name", "--ros-args", "/foo/bar:=", "bar:=/fiz/buz", "}bar:=fiz", "--", "arg"
@@ -312,7 +310,6 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_copy_no_ros_arg
   EXPECT_EQ(0, rcl_arguments_get_count_unparsed_ros(&copied_args));
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&copied_args));
 }
-
 
 // Similar to the default allocator, but returns NULL when size is zero.
 // This is useful for emulating systems where `malloc(0)` return NULL.

--- a/rcl/test/rcl/test_remap.cpp
+++ b/rcl/test/rcl/test_remap.cpp
@@ -42,7 +42,7 @@ public:
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), global_namespace_replacement) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "__ns:=/foo/bar");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "__ns:=/foo/bar");
 
   char * output = NULL;
   ret = rcl_remap_node_namespace(
@@ -57,7 +57,11 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), nodename_prefix_namespac
   rcl_arguments_t global_arguments;
   SCOPE_ARGS(
     global_arguments,
-    "process_name", "Node1:__ns:=/foo/bar", "Node2:__ns:=/this_one", "Node3:__ns:=/bar/foo");
+    "process_name",
+    "--ros-args",
+    "Node1:__ns:=/foo/bar",
+    "Node2:__ns:=/this_one",
+    "Node3:__ns:=/bar/foo");
 
   {
     char * output = NULL;
@@ -100,9 +104,9 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), no_namespace_replacement
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), local_namespace_replacement_before_global) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "__ns:=/global_args");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "__ns:=/global_args");
   rcl_arguments_t local_arguments;
-  SCOPE_ARGS(local_arguments, "process_name", "__ns:=/local_args");
+  SCOPE_ARGS(local_arguments, "process_name", "--ros-args", "__ns:=/local_args");
 
   char * output = NULL;
   ret = rcl_remap_node_namespace(
@@ -128,7 +132,12 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), other_rules_before_names
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
   SCOPE_ARGS(
-    global_arguments, "process_name", "/foobar:=/foo/bar", "__ns:=/namespace", "__node:=new_name");
+    global_arguments,
+    "process_name",
+    "--ros-args",
+    "/foobar:=/foo/bar",
+    "__ns:=/namespace",
+    "__node:=new_name");
 
   rcl_allocator_t allocator = rcl_get_default_allocator();
   char * output = NULL;
@@ -141,7 +150,7 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), other_rules_before_names
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), global_topic_name_replacement) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "/bar/foo:=/foo/bar");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "/bar/foo:=/foo/bar");
 
   {
     char * output = NULL;
@@ -163,7 +172,7 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), global_topic_name_replac
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), relative_topic_name_remap) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "foo:=bar");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "foo:=bar");
 
   char * output = NULL;
   ret = rcl_remap_topic_name(
@@ -178,7 +187,11 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), nodename_prefix_topic_re
   rcl_arguments_t global_arguments;
   SCOPE_ARGS(
     global_arguments,
-    "process_name", "Node1:/foo:=/foo/bar", "Node2:/foo:=/this_one", "Node3:/foo:=/bar/foo");
+    "process_name",
+    "--ros-args",
+    "Node1:/foo:=/foo/bar",
+    "Node2:/foo:=/this_one",
+    "Node3:/foo:=/bar/foo");
 
   {
     char * output = NULL;
@@ -233,9 +246,9 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), no_topic_name_replacemen
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), local_topic_replacement_before_global) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "/bar/foo:=/foo/global_args");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "/bar/foo:=/foo/global_args");
   rcl_arguments_t local_arguments;
-  SCOPE_ARGS(local_arguments, "process_name", "/bar/foo:=/foo/local_args");
+  SCOPE_ARGS(local_arguments, "process_name", "--ros-args", "/bar/foo:=/foo/local_args");
 
   char * output = NULL;
   ret = rcl_remap_topic_name(
@@ -250,7 +263,11 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), other_rules_before_topic
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
   SCOPE_ARGS(
-    global_arguments, "process_name", "__ns:=/namespace", "__node:=remap_name",
+    global_arguments,
+    "process_name",
+    "--ros-args",
+    "__ns:=/namespace",
+    "__node:=remap_name",
     "/foobar:=/foo/bar");
 
   rcl_allocator_t allocator = rcl_get_default_allocator();
@@ -265,7 +282,7 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), other_rules_before_topic
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), global_service_name_replacement) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "/bar/foo:=/foo/bar");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "/bar/foo:=/foo/bar");
 
   {
     char * output = NULL;
@@ -287,7 +304,7 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), global_service_name_repl
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), relative_service_name_remap) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "foo:=bar");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "foo:=bar");
 
   char * output = NULL;
   ret = rcl_remap_service_name(
@@ -302,7 +319,11 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), nodename_prefix_service_
   rcl_arguments_t global_arguments;
   SCOPE_ARGS(
     global_arguments,
-    "process_name", "Node1:/foo:=/foo/bar", "Node2:/foo:=/this_one", "Node3:/foo:=/bar/foo");
+    "process_name",
+    "--ros-args",
+    "Node1:/foo:=/foo/bar",
+    "Node2:/foo:=/this_one",
+    "Node3:/foo:=/bar/foo");
 
   {
     char * output = NULL;
@@ -358,9 +379,9 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), no_service_name_replacem
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), local_service_replacement_before_global) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "/bar/foo:=/foo/global_args");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "/bar/foo:=/foo/global_args");
   rcl_arguments_t local_arguments;
-  SCOPE_ARGS(local_arguments, "process_name", "/bar/foo:=/foo/local_args");
+  SCOPE_ARGS(local_arguments, "process_name", "--ros-args", "/bar/foo:=/foo/local_args");
 
   char * output = NULL;
   ret = rcl_remap_service_name(
@@ -375,7 +396,11 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), other_rules_before_servi
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
   SCOPE_ARGS(
-    global_arguments, "process_name", "__ns:=/namespace", "__node:=remap_name",
+    global_arguments,
+    "process_name",
+    "--ros-args",
+    "__ns:=/namespace",
+    "__node:=remap_name",
     "/foobar:=/foo/bar");
 
   rcl_allocator_t allocator = rcl_get_default_allocator();
@@ -390,7 +415,7 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), other_rules_before_servi
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), global_nodename_replacement) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "__node:=globalname");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "__node:=globalname");
 
   rcl_allocator_t allocator = rcl_get_default_allocator();
   char * output = NULL;
@@ -415,9 +440,9 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), no_nodename_replacement)
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), local_nodename_replacement_before_global) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "__node:=global_name");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "__node:=global_name");
   rcl_arguments_t local_arguments;
-  SCOPE_ARGS(local_arguments, "process_name", "__node:=local_name");
+  SCOPE_ARGS(local_arguments, "process_name", "--ros-args", "__node:=local_name");
 
   char * output = NULL;
   ret = rcl_remap_node_name(
@@ -442,7 +467,12 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), no_use_global_nodename_r
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), use_first_nodename_rule) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "__node:=firstname", "__node:=secondname");
+  SCOPE_ARGS(
+    global_arguments,
+    "process_name",
+    "--ros-args",
+    "__node:=firstname",
+    "__node:=secondname");
 
   rcl_allocator_t allocator = rcl_get_default_allocator();
   char * output = NULL;
@@ -456,7 +486,12 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), other_rules_before_noden
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
   SCOPE_ARGS(
-    global_arguments, "process_name", "/foobar:=/foo", "__ns:=/namespace", "__node:=remap_name");
+    global_arguments,
+    "process_name",
+    "--ros-args",
+    "/foobar:=/foo",
+    "__ns:=/namespace",
+    "__node:=remap_name");
 
   rcl_allocator_t allocator = rcl_get_default_allocator();
   char * output = NULL;
@@ -469,7 +504,7 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), other_rules_before_noden
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), url_scheme_rosservice) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "rosservice://foo:=bar");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "rosservice://foo:=bar");
 
   char * output = NULL;
   ret = rcl_remap_service_name(
@@ -487,7 +522,7 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), url_scheme_rosservice) {
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), url_scheme_rostopic) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "rostopic://foo:=bar");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "rostopic://foo:=bar");
 
   char * output = NULL;
   ret = rcl_remap_topic_name(

--- a/rcl/test/rcl/test_remap_integration.cpp
+++ b/rcl/test/rcl/test_remap_integration.cpp
@@ -46,7 +46,12 @@ TEST_F(CLASSNAME(TestRemapIntegrationFixture, RMW_IMPLEMENTATION), remap_using_g
   int argc;
   char ** argv;
   SCOPE_GLOBAL_ARGS(
-    argc, argv, "process_name", "__node:=new_name", "__ns:=/new_ns", "/foo/bar:=/bar/foo");
+    argc, argv,
+    "process_name",
+    "--ros-args",
+    "__node:=new_name",
+    "__ns:=/new_ns",
+    "/foo/bar:=/bar/foo");
 
   rcl_node_t node = rcl_get_zero_initialized_node();
   rcl_node_options_t default_options = rcl_node_get_default_options();
@@ -112,7 +117,12 @@ TEST_F(CLASSNAME(TestRemapIntegrationFixture, RMW_IMPLEMENTATION), ignore_global
   int argc;
   char ** argv;
   SCOPE_GLOBAL_ARGS(
-    argc, argv, "process_name", "__node:=new_name", "__ns:=/new_ns", "/foo/bar:=/bar/foo");
+    argc, argv,
+    "process_name",
+    "--ros-args",
+    "__node:=new_name",
+    "__ns:=/new_ns",
+    "/foo/bar:=/bar/foo");
   rcl_arguments_t local_arguments;
   SCOPE_ARGS(local_arguments, "local_process_name");
 
@@ -180,11 +190,20 @@ TEST_F(CLASSNAME(TestRemapIntegrationFixture, RMW_IMPLEMENTATION), local_rules_b
   int argc;
   char ** argv;
   SCOPE_GLOBAL_ARGS(
-    argc, argv, "process_name", "__node:=global_name", "__ns:=/global_ns", "/foo/bar:=/bar/global");
+    argc, argv,
+    "process_name",
+    "--ros-args",
+    "__node:=global_name",
+    "__ns:=/global_ns",
+    "/foo/bar:=/bar/global");
   rcl_arguments_t local_arguments;
   SCOPE_ARGS(
     local_arguments,
-    "process_name", "__node:=local_name", "__ns:=/local_ns", "/foo/bar:=/bar/local");
+    "process_name",
+    "--ros-args",
+    "__node:=local_name",
+    "__ns:=/local_ns",
+    "/foo/bar:=/bar/local");
 
   rcl_node_t node = rcl_get_zero_initialized_node();
   rcl_node_options_t options = rcl_node_get_default_options();
@@ -248,7 +267,7 @@ TEST_F(CLASSNAME(TestRemapIntegrationFixture, RMW_IMPLEMENTATION), local_rules_b
 TEST_F(CLASSNAME(TestRemapIntegrationFixture, RMW_IMPLEMENTATION), remap_relative_topic) {
   int argc;
   char ** argv;
-  SCOPE_GLOBAL_ARGS(argc, argv, "process_name", "/foo/bar:=remap/global");
+  SCOPE_GLOBAL_ARGS(argc, argv, "process_name", "--ros-args", "/foo/bar:=remap/global");
 
   rcl_node_t node = rcl_get_zero_initialized_node();
   rcl_node_options_t default_options = rcl_node_get_default_options();
@@ -303,7 +322,7 @@ TEST_F(CLASSNAME(TestRemapIntegrationFixture, RMW_IMPLEMENTATION), remap_using_n
   int argc;
   char ** argv;
   SCOPE_GLOBAL_ARGS(
-    argc, argv, "process_name", "original_name:__ns:=/new_ns");
+    argc, argv, "process_name", "--ros-args", "original_name:__ns:=/new_ns");
 
   rcl_node_t node = rcl_get_zero_initialized_node();
   rcl_node_options_t default_options = rcl_node_get_default_options();


### PR DESCRIPTION
Precisely what the title says. This pull request enforces all ROS specific arguments to be scoped in a `--ros-args ... [--]` pair as described in https://github.com/ros2/design/pull/245. 

Tests are still TBD.