### PR TITLE
Fix rosout handler visibility

### DIFF
--- a/rcl/src/rcl/logging_rosout.c
+++ b/rcl/src/rcl/logging_rosout.c
@@ -14,6 +14,7 @@
 
 #include "rcl/allocator.h"
 #include "rcl/error_handling.h"
+#include "rcl/logging_rosout.h"
 #include "rcl/node.h"
 #include "rcl/publisher.h"
 #include "rcl/time.h"


### PR DESCRIPTION
The `rcl/logging_rosout.c` file is not including its header `rcl/logging_rosout.h`.

For some reasons it still builds, but this has the side-effect of neglecting the visibility macros explicitly declared in the header file.

This PR partially address https://github.com/ros2/rcl/issues/476