### PR TITLE
rosout init and fini marked as RCL_PUBLIC

### DIFF
--- a/rcl/include/rcl/logging_rosout.h
+++ b/rcl/include/rcl/logging_rosout.h
@@ -45,7 +45,7 @@ extern "C"
  * \return `RCL_RET_BAD_ALLOC` if allocating memory failed, or
  * \return `RCL_RET_ERROR` if an unspecified error occurs.
  */
-RCL_LOCAL
+RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
 rcl_logging_rosout_init(
@@ -67,7 +67,7 @@ rcl_logging_rosout_init(
  * \return `RCL_RET_OK` if the rcl_logging_rosout feature was successfully unitialized, or
  * \return `RCL_RET_ERROR` if an unspecified error occurs.
  */
-RCL_LOCAL
+RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
 rcl_logging_rosout_fini();


### PR DESCRIPTION
The functions for setting logger handlers are accessible from the `rcl` library, together with `rcl_logging_rosout_output_handler` (a bug in the visibility setting is addressed in https://github.com/ros2/rcl/pull/478).

However, the `rcl_logging_rosout_output_handler` is not usable from outside this library without access to the `init` and `fini` functions.

This PR addresses https://github.com/ros2/rcl/issues/476