### PR TITLE
Increase MAX_STRING_SIZE

### DIFF
--- a/rcl_yaml_param_parser/src/parser.c
+++ b/rcl_yaml_param_parser/src/parser.c
@@ -65,7 +65,7 @@ typedef struct namespace_tracker_s
   uint32_t num_parameter_ns;
 } namespace_tracker_t;
 
-#define MAX_STRING_SIZE 128U
+#define MAX_STRING_SIZE 256U
 #define PARAMS_KEY "ros__parameters"
 #define NODE_NS_SEPERATOR "/"
 #define PARAMETER_NS_SEPERATOR "."


### PR DESCRIPTION
It's too short for string length.
It occurs the error when string in field from yaml files are too long....