### PR TITLE
Enforce -r/--remap flags.

### DIFF
--- a/rcl/include/rcl/arguments.h
+++ b/rcl/include/rcl/arguments.h
@@ -57,26 +57,38 @@ rcl_get_zero_initialized_arguments(void);
 
 /// Parse command line arguments into a structure usable by code.
 /**
- * If an argument does not appear to be a valid ROS argument then it is skipped
- * and parsing continues with the next argument in `argv`.
- *
  * \sa rcl_get_zero_initialized_arguments()
- * \sa rcl_arguments_get_count_unparsed()
- * \sa rcl_arguments_get_unparsed()
  *
+ * ROS arguments are expected to be scoped by a leading `--ros-args` flag and a trailing double
+ * dash token `--` which may be elided if no non-ROS arguments follow after the last `--ros-args`.
+ *
+ * Remap rule parsing is supported via `-r/--remap` flags e.g. `--remap from:=to` or `-r from:=to`.
  * Successfully parsed remap rules are stored in the order they were given in `argv`.
  * If given arguments `{"__ns:=/foo", "__ns:=/bar"}` then the namespace used by nodes in this
  * process will be `/foo` and not `/bar`.
+ *
+ * \sa rcl_remap_topic_name()
+ * \sa rcl_remap_service_name()
+ * \sa rcl_remap_node_name()
+ * \sa rcl_remap_node_namespace()
+ *
+ * Parameter override rule parsing is supported via `-p/--param` flags e.g. `--param name:=value`
+ * or `-p name:=value`.
  *
  * The default log level will be parsed as `__log_level:=level`, where `level` is a name
  * representing one of the log levels in the `RCUTILS_LOG_SEVERITY` enum, e.g. `info`, `debug`,
  * `warn`, not case sensitive.
  * If multiple of these rules are found, the last one parsed will be used.
  *
- * \sa rcl_remap_topic_name()
- * \sa rcl_remap_service_name()
- * \sa rcl_remap_node_name()
- * \sa rcl_remap_node_namespace()
+ * If an argument does not appear to be a known ROS argument, then it is skipped and left unparsed.
+ *
+ * \sa rcl_arguments_get_count_unparsed_ros()
+ * \sa rcl_arguments_get_unparsed_ros()
+ *
+ * All arguments found outside a `--ros-args ... --` scope are skipped and left unparsed.
+ *
+ * \sa rcl_arguments_get_count_unparsed()
+ * \sa rcl_arguments_get_unparsed()
  *
  * <hr>
  * Attribute          | Adherence

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -364,18 +364,6 @@ rcl_parse_arguments(
         rcl_get_error_string().str);
       rcl_reset_error();
 
-      // Attempt to parse argument as remap rule
-      rcl_remap_t * rule = &(args_impl->remap_rules[args_impl->num_remap_rules]);
-      *rule = rcl_get_zero_initialized_remap();
-      if (RCL_RET_OK == _rcl_parse_remap_rule(argv[i], allocator, rule)) {
-        ++(args_impl->num_remap_rules);
-        continue;
-      }
-      RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
-        "Couldn't parse arg %d (%s) as remap rule. Error: %s", i, argv[i],
-        rcl_get_error_string().str);
-      rcl_reset_error();
-
       // Attempt to parse argument as log level configuration
       int log_level;
       if (RCL_RET_OK == _rcl_parse_log_level_rule(argv[i], allocator, &log_level)) {

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -104,11 +104,11 @@ public:
   } while (0)
 
 bool
-are_valid_ros_args(int argc, std::vector<const char *> argv)
+are_known_ros_args(std::vector<const char *> argv)
 {
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
   rcl_ret_t ret = rcl_parse_arguments(
-    argc, argv.data(), rcl_get_default_allocator(), &parsed_args);
+    argv.size(), argv.data(), rcl_get_default_allocator(), &parsed_args);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   bool is_valid = (
     0 == rcl_arguments_get_count_unparsed(&parsed_args) &&
@@ -117,74 +117,80 @@ are_valid_ros_args(int argc, std::vector<const char *> argv)
   return is_valid;
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), check_valid_vs_invalid_args) {
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-r", "__node:=node_name"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-r", "old_name:__node:=node_name"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-r", "old_name:__node:=nodename123"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-r", "__node:=nodename123"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-r", "__ns:=/foo/bar"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-r", "__ns:=/"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-r", "_:=kq"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-r", "nodename:__ns:=/foobar"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-r", "foo:=bar"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-r", "~/foo:=~/bar"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-r", "/foo/bar:=bar"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-r", "foo:=/bar"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-r", "/foo123:=/bar123"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-r", "node:/foo123:=/bar123"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-r", "rostopic:=/foo/bar"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-r", "rosservice:=baz"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-r", "rostopic://rostopic:=rosservice"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-r", "rostopic:///rosservice:=rostopic"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-r", "rostopic:///foo/bar:=baz"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-p", "foo:=bar"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-p", "~/foo:=~/bar"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-p", "/foo/bar:=bar"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-p", "foo:=/bar"}));
-  EXPECT_TRUE(are_valid_ros_args(3, {"--ros-args", "-p", "/foo123:=/bar123"}));
-  EXPECT_TRUE(are_valid_ros_args(2, {"--ros-args", "__params:=file_name.yaml"}));
+TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), check_known_vs_unknown_args) {
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "__node:=node_name"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "old_name:__node:=node_name"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "old_name:__node:=nodename123"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "__node:=nodename123"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "__ns:=/foo/bar"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "__ns:=/"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "_:=kq"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "nodename:__ns:=/foobar"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "foo:=bar"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "~/foo:=~/bar"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "/foo/bar:=bar"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "foo:=/bar"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "/foo123:=/bar123"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "node:/foo123:=/bar123"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "rostopic:=/foo/bar"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "rosservice:=baz"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "rostopic://rostopic:=rosservice"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "rostopic:///rosservice:=rostopic"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "rostopic:///foo/bar:=baz"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-p", "foo:=bar"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-p", "~/foo:=~/bar"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-p", "/foo/bar:=bar"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-p", "foo:=/bar"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "-p", "/foo123:=/bar123"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "__params:=file_name.yaml"}));
 
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-r", ":="}));
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-r", "foo:="}));
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-r", ":=bar"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-r"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "--remap"}));
 
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-p", ":="}));
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-p", "foo:="}));
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-p", ":=bar"}));
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-r", "__ns:="}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-r", ":="}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-r", "foo:="}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-r", ":=bar"}));
 
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-r", "__node:="}));
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-r", "__node:=/foo/bar"}));
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-r", "__ns:=foo"}));
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-r", ":__node:=nodename"}));
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-r", "~:__node:=nodename"}));
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-r", "}foo:=/bar"}));
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-r", "f oo:=/bar"}));
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-r", "foo:=/b ar"}));
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-r", "f{oo:=/bar"}));
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-r", "foo:=/b}ar"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-p"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "--param"}));
 
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-p", "}foo:=/bar"}));
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-p", "f oo:=/bar"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-p", ":="}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-p", "foo:="}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-p", ":=bar"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-r", "__ns:="}));
 
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-r", "rostopic://:=rosservice"}));
-  EXPECT_FALSE(are_valid_ros_args(3, {"--ros-args", "-r", "rostopic::=rosservice"}));
-  EXPECT_FALSE(are_valid_ros_args(2, {"--ros-args", "__param:=file_name.yaml"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-r", "__node:="}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-r", "__node:=/foo/bar"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-r", "__ns:=foo"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-r", ":__node:=nodename"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-r", "~:__node:=nodename"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-r", "}foo:=/bar"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-r", "f oo:=/bar"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-r", "foo:=/b ar"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-r", "f{oo:=/bar"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-r", "foo:=/b}ar"}));
+
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-p", "}foo:=/bar"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-p", "f oo:=/bar"}));
+
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-r", "rostopic://:=rosservice"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "-r", "rostopic::=rosservice"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "__param:=file_name.yaml"}));
 
   // Setting logger level
-  EXPECT_TRUE(are_valid_ros_args(2, {"--ros-args", "__log_level:=UNSET"}));
-  EXPECT_TRUE(are_valid_ros_args(2, {"--ros-args", "__log_level:=DEBUG"}));
-  EXPECT_TRUE(are_valid_ros_args(2, {"--ros-args", "__log_level:=INFO"}));
-  EXPECT_TRUE(are_valid_ros_args(2, {"--ros-args", "__log_level:=WARN"}));
-  EXPECT_TRUE(are_valid_ros_args(2, {"--ros-args", "__log_level:=ERROR"}));
-  EXPECT_TRUE(are_valid_ros_args(2, {"--ros-args", "__log_level:=FATAL"}));
-  EXPECT_TRUE(are_valid_ros_args(2, {"--ros-args", "__log_level:=debug"}));
-  EXPECT_TRUE(are_valid_ros_args(2, {"--ros-args", "__log_level:=Info"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "__log_level:=UNSET"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "__log_level:=DEBUG"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "__log_level:=INFO"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "__log_level:=WARN"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "__log_level:=ERROR"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "__log_level:=FATAL"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "__log_level:=debug"}));
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "__log_level:=Info"}));
 
-  EXPECT_FALSE(are_valid_ros_args(2, {"--ros-args", "__log:=foo"}));
-  EXPECT_FALSE(are_valid_ros_args(2, {"--ros-args", "__loglevel:=foo"}));
-  EXPECT_FALSE(are_valid_ros_args(2, {"--ros-args", "__log_level:="}));
-  EXPECT_FALSE(are_valid_ros_args(2, {"--ros-args", "__log_level:=foo"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "__log:=foo"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "__loglevel:=foo"}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "__log_level:="}));
+  EXPECT_FALSE(are_known_ros_args({"--ros-args", "__log_level:=foo"}));
 }
 
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_no_args) {

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -106,9 +106,10 @@ public:
 bool
 are_known_ros_args(std::vector<const char *> argv)
 {
+  const int argc = static_cast<int>(argv.size());
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
   rcl_ret_t ret = rcl_parse_arguments(
-    argv.size(), argv.data(), rcl_get_default_allocator(), &parsed_args);
+    argc, argv.data(), rcl_get_default_allocator(), &parsed_args);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   bool is_valid = (
     0 == rcl_arguments_get_count_unparsed(&parsed_args) &&

--- a/rcl/test/rcl/test_remap.cpp
+++ b/rcl/test/rcl/test_remap.cpp
@@ -42,7 +42,7 @@ public:
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), global_namespace_replacement) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "__ns:=/foo/bar");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "-r", "__ns:=/foo/bar");
 
   char * output = NULL;
   ret = rcl_remap_node_namespace(
@@ -59,9 +59,9 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), nodename_prefix_namespac
     global_arguments,
     "process_name",
     "--ros-args",
-    "Node1:__ns:=/foo/bar",
-    "Node2:__ns:=/this_one",
-    "Node3:__ns:=/bar/foo");
+    "-r", "Node1:__ns:=/foo/bar",
+    "-r", "Node2:__ns:=/this_one",
+    "-r", "Node3:__ns:=/bar/foo");
 
   {
     char * output = NULL;
@@ -104,9 +104,9 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), no_namespace_replacement
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), local_namespace_replacement_before_global) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "__ns:=/global_args");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "-r", "__ns:=/global_args");
   rcl_arguments_t local_arguments;
-  SCOPE_ARGS(local_arguments, "process_name", "--ros-args", "__ns:=/local_args");
+  SCOPE_ARGS(local_arguments, "process_name", "--ros-args", "-r", "__ns:=/local_args");
 
   char * output = NULL;
   ret = rcl_remap_node_namespace(
@@ -135,9 +135,9 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), other_rules_before_names
     global_arguments,
     "process_name",
     "--ros-args",
-    "/foobar:=/foo/bar",
-    "__ns:=/namespace",
-    "__node:=new_name");
+    "-r", "/foobar:=/foo/bar",
+    "-r", "__ns:=/namespace",
+    "-r", "__node:=new_name");
 
   rcl_allocator_t allocator = rcl_get_default_allocator();
   char * output = NULL;
@@ -150,7 +150,7 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), other_rules_before_names
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), global_topic_name_replacement) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "/bar/foo:=/foo/bar");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "-r", "/bar/foo:=/foo/bar");
 
   {
     char * output = NULL;
@@ -172,7 +172,7 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), global_topic_name_replac
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), relative_topic_name_remap) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "foo:=bar");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "-r", "foo:=bar");
 
   char * output = NULL;
   ret = rcl_remap_topic_name(
@@ -189,9 +189,9 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), nodename_prefix_topic_re
     global_arguments,
     "process_name",
     "--ros-args",
-    "Node1:/foo:=/foo/bar",
-    "Node2:/foo:=/this_one",
-    "Node3:/foo:=/bar/foo");
+    "-r", "Node1:/foo:=/foo/bar",
+    "-r", "Node2:/foo:=/this_one",
+    "-r", "Node3:/foo:=/bar/foo");
 
   {
     char * output = NULL;
@@ -246,9 +246,9 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), no_topic_name_replacemen
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), local_topic_replacement_before_global) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "/bar/foo:=/foo/global_args");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "-r", "/bar/foo:=/foo/global_args");
   rcl_arguments_t local_arguments;
-  SCOPE_ARGS(local_arguments, "process_name", "--ros-args", "/bar/foo:=/foo/local_args");
+  SCOPE_ARGS(local_arguments, "process_name", "--ros-args", "-r", "/bar/foo:=/foo/local_args");
 
   char * output = NULL;
   ret = rcl_remap_topic_name(
@@ -266,9 +266,9 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), other_rules_before_topic
     global_arguments,
     "process_name",
     "--ros-args",
-    "__ns:=/namespace",
-    "__node:=remap_name",
-    "/foobar:=/foo/bar");
+    "-r", "__ns:=/namespace",
+    "-r", "__node:=remap_name",
+    "-r", "/foobar:=/foo/bar");
 
   rcl_allocator_t allocator = rcl_get_default_allocator();
   char * output = NULL;
@@ -282,7 +282,7 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), other_rules_before_topic
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), global_service_name_replacement) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "/bar/foo:=/foo/bar");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "-r", "/bar/foo:=/foo/bar");
 
   {
     char * output = NULL;
@@ -304,7 +304,7 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), global_service_name_repl
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), relative_service_name_remap) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "foo:=bar");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "-r", "foo:=bar");
 
   char * output = NULL;
   ret = rcl_remap_service_name(
@@ -321,9 +321,9 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), nodename_prefix_service_
     global_arguments,
     "process_name",
     "--ros-args",
-    "Node1:/foo:=/foo/bar",
-    "Node2:/foo:=/this_one",
-    "Node3:/foo:=/bar/foo");
+    "-r", "Node1:/foo:=/foo/bar",
+    "-r", "Node2:/foo:=/this_one",
+    "-r", "Node3:/foo:=/bar/foo");
 
   {
     char * output = NULL;
@@ -379,9 +379,9 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), no_service_name_replacem
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), local_service_replacement_before_global) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "/bar/foo:=/foo/global_args");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "-r", "/bar/foo:=/foo/global_args");
   rcl_arguments_t local_arguments;
-  SCOPE_ARGS(local_arguments, "process_name", "--ros-args", "/bar/foo:=/foo/local_args");
+  SCOPE_ARGS(local_arguments, "process_name", "--ros-args", "-r", "/bar/foo:=/foo/local_args");
 
   char * output = NULL;
   ret = rcl_remap_service_name(
@@ -399,9 +399,9 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), other_rules_before_servi
     global_arguments,
     "process_name",
     "--ros-args",
-    "__ns:=/namespace",
-    "__node:=remap_name",
-    "/foobar:=/foo/bar");
+    "-r", "__ns:=/namespace",
+    "-r", "__node:=remap_name",
+    "-r", "/foobar:=/foo/bar");
 
   rcl_allocator_t allocator = rcl_get_default_allocator();
   char * output = NULL;
@@ -415,7 +415,7 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), other_rules_before_servi
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), global_nodename_replacement) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "__node:=globalname");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "-r", "__node:=globalname");
 
   rcl_allocator_t allocator = rcl_get_default_allocator();
   char * output = NULL;
@@ -440,9 +440,9 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), no_nodename_replacement)
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), local_nodename_replacement_before_global) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "__node:=global_name");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "-r", "__node:=global_name");
   rcl_arguments_t local_arguments;
-  SCOPE_ARGS(local_arguments, "process_name", "--ros-args", "__node:=local_name");
+  SCOPE_ARGS(local_arguments, "process_name", "--ros-args", "-r", "__node:=local_name");
 
   char * output = NULL;
   ret = rcl_remap_node_name(
@@ -471,8 +471,8 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), use_first_nodename_rule)
     global_arguments,
     "process_name",
     "--ros-args",
-    "__node:=firstname",
-    "__node:=secondname");
+    "-r", "__node:=firstname",
+    "-r", "__node:=secondname");
 
   rcl_allocator_t allocator = rcl_get_default_allocator();
   char * output = NULL;
@@ -489,9 +489,9 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), other_rules_before_noden
     global_arguments,
     "process_name",
     "--ros-args",
-    "/foobar:=/foo",
-    "__ns:=/namespace",
-    "__node:=remap_name");
+    "-r", "/foobar:=/foo",
+    "-r", "__ns:=/namespace",
+    "-r", "__node:=remap_name");
 
   rcl_allocator_t allocator = rcl_get_default_allocator();
   char * output = NULL;
@@ -504,7 +504,7 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), other_rules_before_noden
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), url_scheme_rosservice) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "rosservice://foo:=bar");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "-r", "rosservice://foo:=bar");
 
   char * output = NULL;
   ret = rcl_remap_service_name(
@@ -522,7 +522,7 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), url_scheme_rosservice) {
 TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), url_scheme_rostopic) {
   rcl_ret_t ret;
   rcl_arguments_t global_arguments;
-  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "rostopic://foo:=bar");
+  SCOPE_ARGS(global_arguments, "process_name", "--ros-args", "-r", "rostopic://foo:=bar");
 
   char * output = NULL;
   ret = rcl_remap_topic_name(

--- a/rcl/test/rcl/test_remap_integration.cpp
+++ b/rcl/test/rcl/test_remap_integration.cpp
@@ -49,9 +49,9 @@ TEST_F(CLASSNAME(TestRemapIntegrationFixture, RMW_IMPLEMENTATION), remap_using_g
     argc, argv,
     "process_name",
     "--ros-args",
-    "__node:=new_name",
-    "__ns:=/new_ns",
-    "/foo/bar:=/bar/foo");
+    "-r", "__node:=new_name",
+    "-r", "__ns:=/new_ns",
+    "-r", "/foo/bar:=/bar/foo");
 
   rcl_node_t node = rcl_get_zero_initialized_node();
   rcl_node_options_t default_options = rcl_node_get_default_options();
@@ -120,9 +120,9 @@ TEST_F(CLASSNAME(TestRemapIntegrationFixture, RMW_IMPLEMENTATION), ignore_global
     argc, argv,
     "process_name",
     "--ros-args",
-    "__node:=new_name",
-    "__ns:=/new_ns",
-    "/foo/bar:=/bar/foo");
+    "-r", "__node:=new_name",
+    "-r", "__ns:=/new_ns",
+    "-r", "/foo/bar:=/bar/foo");
   rcl_arguments_t local_arguments;
   SCOPE_ARGS(local_arguments, "local_process_name");
 
@@ -193,17 +193,17 @@ TEST_F(CLASSNAME(TestRemapIntegrationFixture, RMW_IMPLEMENTATION), local_rules_b
     argc, argv,
     "process_name",
     "--ros-args",
-    "__node:=global_name",
-    "__ns:=/global_ns",
-    "/foo/bar:=/bar/global");
+    "-r", "__node:=global_name",
+    "-r", "__ns:=/global_ns",
+    "-r", "/foo/bar:=/bar/global");
   rcl_arguments_t local_arguments;
   SCOPE_ARGS(
     local_arguments,
     "process_name",
     "--ros-args",
-    "__node:=local_name",
-    "__ns:=/local_ns",
-    "/foo/bar:=/bar/local");
+    "-r", "__node:=local_name",
+    "-r", "__ns:=/local_ns",
+    "-r", "/foo/bar:=/bar/local");
 
   rcl_node_t node = rcl_get_zero_initialized_node();
   rcl_node_options_t options = rcl_node_get_default_options();
@@ -267,7 +267,7 @@ TEST_F(CLASSNAME(TestRemapIntegrationFixture, RMW_IMPLEMENTATION), local_rules_b
 TEST_F(CLASSNAME(TestRemapIntegrationFixture, RMW_IMPLEMENTATION), remap_relative_topic) {
   int argc;
   char ** argv;
-  SCOPE_GLOBAL_ARGS(argc, argv, "process_name", "--ros-args", "/foo/bar:=remap/global");
+  SCOPE_GLOBAL_ARGS(argc, argv, "process_name", "--ros-args", "-r", "/foo/bar:=remap/global");
 
   rcl_node_t node = rcl_get_zero_initialized_node();
   rcl_node_options_t default_options = rcl_node_get_default_options();
@@ -322,7 +322,7 @@ TEST_F(CLASSNAME(TestRemapIntegrationFixture, RMW_IMPLEMENTATION), remap_using_n
   int argc;
   char ** argv;
   SCOPE_GLOBAL_ARGS(
-    argc, argv, "process_name", "--ros-args", "original_name:__ns:=/new_ns");
+    argc, argv, "process_name", "--ros-args", "-r", "original_name:__ns:=/new_ns");
 
   rcl_node_t node = rcl_get_zero_initialized_node();
   rcl_node_options_t default_options = rcl_node_get_default_options();


### PR DESCRIPTION
Follow up after #483. This pull request actually makes using `-r/--remap` flags a requirement. It also updates `rcl` arguments API documentation.