### PR TITLE
reset error message before setting a new one, embed the original one

### DIFF
--- a/rcl_lifecycle/src/rcl_lifecycle.c
+++ b/rcl_lifecycle/src/rcl_lifecycle.c
@@ -236,14 +236,18 @@ rcl_lifecycle_state_machine_fini(
   rcl_ret_t fcn_ret = RCL_RET_OK;
 
   if (rcl_lifecycle_com_interface_fini(&state_machine->com_interface, node_handle) != RCL_RET_OK) {
-    RCL_SET_ERROR_MSG("could not free lifecycle com interface. Leaking memory!\n");
+    rcl_error_string_t error_string = rcl_get_error_string();
+    rcutils_reset_error();
+    RCL_SET_ERROR_MSG_WITH_FORMAT_STRING("could not free lifecycle com interface. Leaking memory!\n%s", error_string.str);
     fcn_ret = RCL_RET_ERROR;
   }
 
   if (rcl_lifecycle_transition_map_fini(
       &state_machine->transition_map, allocator) != RCL_RET_OK)
   {
-    RCL_SET_ERROR_MSG("could not free lifecycle transition map. Leaking memory!\n");
+    rcl_error_string_t error_string = rcl_get_error_string();
+    rcutils_reset_error();
+    RCL_SET_ERROR_MSG_WITH_FORMAT_STRING("could not free lifecycle transition map. Leaking memory!\n%s", error_string.str);
     fcn_ret = RCL_RET_ERROR;
   }
 
@@ -333,7 +337,9 @@ _trigger_transition(
     rcl_ret_t ret = rcl_lifecycle_com_interface_publish_notification(
       &state_machine->com_interface, transition->start, state_machine->current_state);
     if (ret != RCL_RET_OK) {
-      RCL_SET_ERROR_MSG("Could not publish transition");
+      rcl_error_string_t error_string = rcl_get_error_string();
+      rcutils_reset_error();
+      RCL_SET_ERROR_MSG_WITH_FORMAT_STRING("Could not publish transition: %s", error_string.str);
       return RCL_RET_ERROR;
     }
   }

--- a/rcl_lifecycle/src/rcl_lifecycle.c
+++ b/rcl_lifecycle/src/rcl_lifecycle.c
@@ -238,7 +238,8 @@ rcl_lifecycle_state_machine_fini(
   if (rcl_lifecycle_com_interface_fini(&state_machine->com_interface, node_handle) != RCL_RET_OK) {
     rcl_error_string_t error_string = rcl_get_error_string();
     rcutils_reset_error();
-    RCL_SET_ERROR_MSG_WITH_FORMAT_STRING("could not free lifecycle com interface. Leaking memory!\n%s", error_string.str);
+    RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
+      "could not free lifecycle com interface. Leaking memory!\n%s", error_string.str);
     fcn_ret = RCL_RET_ERROR;
   }
 
@@ -247,7 +248,8 @@ rcl_lifecycle_state_machine_fini(
   {
     rcl_error_string_t error_string = rcl_get_error_string();
     rcutils_reset_error();
-    RCL_SET_ERROR_MSG_WITH_FORMAT_STRING("could not free lifecycle transition map. Leaking memory!\n%s", error_string.str);
+    RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
+      "could not free lifecycle transition map. Leaking memory!\n%s", error_string.str);
     fcn_ret = RCL_RET_ERROR;
   }
 


### PR DESCRIPTION
Fixes https://github.com/ros-planning/navigation2/issues/1079#issuecomment-528056225

Prevents to overwrite the error state.

CI builds testing `--packages-above rcl-lifecycle`:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8151)](http://ci.ros2.org/job/ci_linux/8151/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4137)](http://ci.ros2.org/job/ci_linux-aarch64/4137/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6640)](http://ci.ros2.org/job/ci_osx/6640/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8033)](http://ci.ros2.org/job/ci_windows/8033/)