### PR TITLE
Parse CLI parameters and YAML files

### DIFF
--- a/rcl/include/rcl/arguments.h
+++ b/rcl/include/rcl/arguments.h
@@ -283,8 +283,11 @@ rcl_arguments_get_param_files(
   rcl_allocator_t allocator,
   char *** parameter_files);
 
-/// Return all parameter overrides specified on the command line.
+/// Return all parameter overrides parsed from the command line.
 /**
+ * Parameter overrides are parsed directly from command line arguments and
+ * parameter files provided in the command line.
+ *
  * <hr>
  * Attribute          | Adherence
  * ------------------ | -------------
@@ -294,8 +297,8 @@ rcl_arguments_get_param_files(
  * Lock-Free          | Yes
  *
  * \param[in] arguments An arguments structure that has been parsed.
- * \param[out] parameter_overrides Zero or more parameter overrides.
- *   This structure must be finalized by the caller.
+ * \param[out] parameter_overrides Parameter overrides as parsed from command line arguments.
+ *   The output is NULL if no parameter overrides were parsed.
  * \return `RCL_RET_OK` if everything goes correctly, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any function arguments are invalid, or
  * \return `RCL_RET_BAD_ALLOC` if allocating memory failed, or

--- a/rcl/include/rcl/arguments.h
+++ b/rcl/include/rcl/arguments.h
@@ -298,6 +298,7 @@ rcl_arguments_get_param_files(
  *
  * \param[in] arguments An arguments structure that has been parsed.
  * \param[out] parameter_overrides Parameter overrides as parsed from command line arguments.
+ *   This structure must be finalized by the caller.
  *   The output is NULL if no parameter overrides were parsed.
  * \return `RCL_RET_OK` if everything goes correctly, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any function arguments are invalid, or

--- a/rcl/package.xml
+++ b/rcl/package.xml
@@ -25,6 +25,7 @@
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>rcpputils</test_depend>
   <test_depend>rmw</test_depend>
   <test_depend>rmw_implementation_cmake</test_depend>
   <test_depend>launch</test_depend>

--- a/rcl/src/rcl/arguments_impl.h
+++ b/rcl/src/rcl/arguments_impl.h
@@ -39,6 +39,7 @@ typedef struct rcl_arguments_impl_t
 
   /// Parameter override rules parsed from arguments.
   rcl_params_t * parameter_overrides;
+
   /// Array of yaml parameter file paths
   char ** parameter_files;
   /// Length of parameter_files.

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -3,6 +3,7 @@ find_package(launch_testing_ament_cmake REQUIRED)
 
 find_package(test_msgs REQUIRED)
 
+find_package(rcpputils REQUIRED)
 find_package(rmw_implementation_cmake REQUIRED)
 
 find_package(osrf_testing_tools_cpp REQUIRED)
@@ -148,7 +149,7 @@ function(test_target_function)
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
-    AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
+    AMENT_DEPENDENCIES "osrf_testing_tools_cpp" "rcpputils"
   )
 
   rcl_add_custom_gtest(test_remap${target_suffix}

--- a/rcl/test/cmake/rcl_add_custom_gtest.cmake
+++ b/rcl/test/cmake/rcl_add_custom_gtest.cmake
@@ -43,13 +43,16 @@ set(rcl_add_custom_gtest_INCLUDED TRUE)
 # :type LIBRARIES: list of strings
 # :param AMENT_DEPENDENCIES: list of depends to pass ament_target_dependencies
 # :type AMENT_DEPENDENCIES: list of strings
-#
+# :param WORKING_DIRECTORY: the working directory for invoking the
+#   executable in, default defined by ``ament_add_test()``
+# :type WORKING_DIRECTORY: string
+
 # @public
 #
 macro(rcl_add_custom_gtest target)
   cmake_parse_arguments(_ARG
     "SKIP_TEST;TRACE"
-    "TIMEOUT"
+    "TIMEOUT;WORKING_DIRECTORY"
     "SRCS;ENV;APPEND_ENV;APPEND_LIBRARY_DIRS;INCLUDE_DIRS;LIBRARIES;AMENT_DEPENDENCIES"
     ${ARGN})
   if(_ARG_UNPARSED_ARGUMENTS)
@@ -72,10 +75,13 @@ macro(rcl_add_custom_gtest target)
   if(_ARG_TIMEOUT)
     set(_ARG_TIMEOUT "TIMEOUT" ${_ARG_TIMEOUT})
   endif()
+  if(_ARG_WORKING_DIRECTORY)
+    set(_ARG_WORKING_DIRECTORY "WORKING_DIRECTORY" ${_ARG_WORKING_DIRECTORY})
+  endif()
 
   # Pass args along to ament_add_gtest().
   ament_add_gtest(${target} ${_ARG_SRCS} ${_ARG_ENV} ${_ARG_APPEND_ENV} ${_ARG_APPEND_LIBRARY_DIRS}
-                  ${_ARG_SKIP_TEST} ${_ARG_TIMEOUT})
+                  ${_ARG_SKIP_TEST} ${_ARG_TIMEOUT} ${_ARG_WORKING_DIRECTORY})
   # Check if the target was actually created.
   if(TARGET ${target})
     if(_ARG_TRACE)

--- a/rcl/test/cmake/rcl_add_custom_gtest.cmake
+++ b/rcl/test/cmake/rcl_add_custom_gtest.cmake
@@ -43,16 +43,13 @@ set(rcl_add_custom_gtest_INCLUDED TRUE)
 # :type LIBRARIES: list of strings
 # :param AMENT_DEPENDENCIES: list of depends to pass ament_target_dependencies
 # :type AMENT_DEPENDENCIES: list of strings
-# :param WORKING_DIRECTORY: the working directory for invoking the
-#   executable in, default defined by ``ament_add_test()``
-# :type WORKING_DIRECTORY: string
-
+#
 # @public
 #
 macro(rcl_add_custom_gtest target)
   cmake_parse_arguments(_ARG
     "SKIP_TEST;TRACE"
-    "TIMEOUT;WORKING_DIRECTORY"
+    "TIMEOUT"
     "SRCS;ENV;APPEND_ENV;APPEND_LIBRARY_DIRS;INCLUDE_DIRS;LIBRARIES;AMENT_DEPENDENCIES"
     ${ARGN})
   if(_ARG_UNPARSED_ARGUMENTS)
@@ -75,13 +72,10 @@ macro(rcl_add_custom_gtest target)
   if(_ARG_TIMEOUT)
     set(_ARG_TIMEOUT "TIMEOUT" ${_ARG_TIMEOUT})
   endif()
-  if(_ARG_WORKING_DIRECTORY)
-    set(_ARG_WORKING_DIRECTORY "WORKING_DIRECTORY" ${_ARG_WORKING_DIRECTORY})
-  endif()
 
   # Pass args along to ament_add_gtest().
   ament_add_gtest(${target} ${_ARG_SRCS} ${_ARG_ENV} ${_ARG_APPEND_ENV} ${_ARG_APPEND_LIBRARY_DIRS}
-                  ${_ARG_SKIP_TEST} ${_ARG_TIMEOUT} ${_ARG_WORKING_DIRECTORY})
+                  ${_ARG_SKIP_TEST} ${_ARG_TIMEOUT})
   # Check if the target was actually created.
   if(TARGET ${target})
     if(_ARG_TRACE)

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -14,15 +14,18 @@
 
 #include <gtest/gtest.h>
 #include <sstream>
+#include <string>
 #include <vector>
 
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
+#include "rcpputils/filesystem_helper.hpp"
 
 #include "rcl/rcl.h"
 #include "rcl/arguments.h"
 #include "rcl/error_handling.h"
 
 #include "rcl_yaml_param_parser/parser.h"
+
 
 #ifdef RMW_IMPLEMENTATION
 # define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
@@ -31,16 +34,20 @@
 # define CLASSNAME(NAME, SUFFIX) NAME
 #endif
 
+
 class CLASSNAME (TestArgumentsFixture, RMW_IMPLEMENTATION) : public ::testing::Test
 {
 public:
   void SetUp()
   {
+    test_path /= "test_arguments";
   }
 
   void TearDown()
   {
   }
+
+  rcpputils::fs::path test_path{TEST_RESOURCES_DIRECTORY};
 };
 
 #define EXPECT_UNPARSED(parsed_args, ...) \
@@ -143,7 +150,9 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), check_known_vs_unkno
   EXPECT_TRUE(are_known_ros_args({"--ros-args", "-p", "/foo/bar:=bar"}));
   EXPECT_TRUE(are_known_ros_args({"--ros-args", "-p", "foo:=/bar"}));
   EXPECT_TRUE(are_known_ros_args({"--ros-args", "-p", "/foo123:=/bar123"}));
-  EXPECT_TRUE(are_known_ros_args({"--ros-args", "--params-file", "file_name.yaml"}));
+
+  const std::string parameters_filepath = (test_path / "test_parameters.1.yaml").string();
+  EXPECT_TRUE(are_known_ros_args({"--ros-args", "--params-file", parameters_filepath.c_str()}));
 
   EXPECT_FALSE(are_known_ros_args({"--ros-args", "--custom-ros-arg"}));
   EXPECT_FALSE(are_known_ros_args({"--ros-args", "__node:=node_name"}));
@@ -204,7 +213,9 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), check_known_deprecat
   EXPECT_TRUE(are_known_ros_args({"rostopic:///foo/bar:=baz"}));
 
   // Setting params file
-  EXPECT_TRUE(are_known_ros_args({"__params:=file_name.yaml"}));
+  const std::string parameters_filepath = (test_path / "test_parameters.1.yaml").string();
+  const std::string parameter_rule = "__params:=" + parameters_filepath;
+  EXPECT_TRUE(are_known_ros_args({parameter_rule.c_str()}));
 
   // Setting config logging file
   EXPECT_TRUE(are_known_ros_args({"__log_config_file:=file.config"}));
@@ -245,9 +256,10 @@ are_valid_ros_args(std::vector<const char *> argv)
 }
 
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), check_valid_vs_invalid_args) {
+  const std::string parameters_filepath = (test_path / "test_parameters.1.yaml").string();
   EXPECT_TRUE(are_valid_ros_args({
     "--ros-args", "-p", "foo:=bar", "-r", "__node:=node_name",
-    "--params-file", "file_name.yaml", "--log-level", "INFO",
+    "--params-file", parameters_filepath.c_str(), "--log-level", "INFO",
     "--log-config-file", "file.config"
   }));
 
@@ -676,9 +688,10 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_
 }
 
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_single) {
+  const std::string parameters_filepath = (test_path / "test_parameters.1.yaml").string();
   const char * argv[] = {
     "process_name", "--ros-args", "-r", "__ns:=/namespace", "random:=arg",
-    "--params-file", "parameter_filepath"
+    "--params-file", parameters_filepath.c_str()
   };
   int argc = sizeof(argv) / sizeof(const char *);
   rcl_ret_t ret;
@@ -694,20 +707,42 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_
   char ** parameter_files = NULL;
   ret = rcl_arguments_get_param_files(&parsed_args, alloc, &parameter_files);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  EXPECT_STREQ("parameter_filepath", parameter_files[0]);
+  EXPECT_STREQ(parameters_filepath.c_str(), parameter_files[0]);
 
   for (int i = 0; i < parameter_filecount; ++i) {
     alloc.deallocate(parameter_files[i], alloc.state);
   }
   alloc.deallocate(parameter_files, alloc.state);
+
+  rcl_params_t * params = NULL;
+  ret = rcl_arguments_get_param_overrides(&parsed_args, &params);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    rcl_yaml_node_struct_fini(params);
+  });
+  EXPECT_EQ(1U, params->num_nodes);
+
+  rcl_variant_t * param_value =
+    rcl_yaml_node_struct_get("some_node", "param_group.string_param", params);
+  ASSERT_TRUE(NULL != param_value);
+  ASSERT_TRUE(NULL != param_value->string_value);
+  EXPECT_STREQ("foo", param_value->string_value);
+
+  param_value = rcl_yaml_node_struct_get("some_node", "int_param", params);
+  ASSERT_TRUE(NULL != param_value);
+  ASSERT_TRUE(NULL != param_value->integer_value);
+  EXPECT_EQ(1, *(param_value->integer_value));
+
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
 }
 
 // \deprecated to be removed in F-Turtle
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_deprecated_param_argument_single) {
+  const std::string parameters_filepath = (test_path / "test_parameters.1.yaml").string();
+  const std::string parameter_rule = "__params:=" + parameters_filepath;
   const char * argv[] = {
     "process_name", "--ros-args", "-r", "__ns:=/namespace", "random:=arg", "--",
-    "__params:=parameter_filepath"
+    parameter_rule.c_str()
   };
   int argc = sizeof(argv) / sizeof(const char *);
   rcl_ret_t ret;
@@ -723,19 +758,41 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_deprecated_para
   char ** parameter_files = NULL;
   ret = rcl_arguments_get_param_files(&parsed_args, alloc, &parameter_files);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  EXPECT_STREQ("parameter_filepath", parameter_files[0]);
+  EXPECT_STREQ(parameters_filepath.c_str(), parameter_files[0]);
 
   for (int i = 0; i < parameter_filecount; ++i) {
     alloc.deallocate(parameter_files[i], alloc.state);
   }
   alloc.deallocate(parameter_files, alloc.state);
+
+  rcl_params_t * params = NULL;
+  ret = rcl_arguments_get_param_overrides(&parsed_args, &params);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    rcl_yaml_node_struct_fini(params);
+  });
+  EXPECT_EQ(1U, params->num_nodes);
+
+  rcl_variant_t * param_value =
+    rcl_yaml_node_struct_get("some_node", "param_group.string_param", params);
+  ASSERT_TRUE(NULL != param_value);
+  ASSERT_TRUE(NULL != param_value->string_value);
+  EXPECT_STREQ("foo", param_value->string_value);
+
+  param_value = rcl_yaml_node_struct_get("some_node", "int_param", params);
+  ASSERT_TRUE(NULL != param_value);
+  ASSERT_TRUE(NULL != param_value->integer_value);
+  EXPECT_EQ(1, *(param_value->integer_value));
+
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
 }
 
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_multiple) {
+  const std::string parameters_filepath1 = (test_path / "test_parameters.1.yaml").string();
+  const std::string parameters_filepath2 = (test_path / "test_parameters.2.yaml").string();
   const char * argv[] = {
-    "process_name", "--ros-args", "--params-file", "parameter_filepath1",
-    "-r", "__ns:=/namespace", "random:=arg", "--params-file", "parameter_filepath2"
+    "process_name", "--ros-args", "--params-file", parameters_filepath1.c_str(),
+    "-r", "__ns:=/namespace", "random:=arg", "--params-file", parameters_filepath2.c_str()
   };
   int argc = sizeof(argv) / sizeof(const char *);
   rcl_ret_t ret;
@@ -751,12 +808,33 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_
   char ** parameter_files = NULL;
   ret = rcl_arguments_get_param_files(&parsed_args, alloc, &parameter_files);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  EXPECT_STREQ("parameter_filepath1", parameter_files[0]);
-  EXPECT_STREQ("parameter_filepath2", parameter_files[1]);
+  EXPECT_STREQ(parameters_filepath1.c_str(), parameter_files[0]);
+  EXPECT_STREQ(parameters_filepath2.c_str(), parameter_files[1]);
   for (int i = 0; i < parameter_filecount; ++i) {
     alloc.deallocate(parameter_files[i], alloc.state);
   }
+
   alloc.deallocate(parameter_files, alloc.state);
+
+  rcl_params_t * params = NULL;
+  ret = rcl_arguments_get_param_overrides(&parsed_args, &params);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    rcl_yaml_node_struct_fini(params);
+  });
+  EXPECT_EQ(2U, params->num_nodes);
+
+  rcl_variant_t * param_value =
+    rcl_yaml_node_struct_get("some_node", "int_param", params);
+  ASSERT_TRUE(NULL != param_value);
+  ASSERT_TRUE(NULL != param_value->integer_value);
+  EXPECT_EQ(1, *(param_value->integer_value));
+
+  param_value = rcl_yaml_node_struct_get("another_node", "double_param", params);
+  ASSERT_TRUE(NULL != param_value);
+  ASSERT_TRUE(NULL != param_value->double_value);
+  EXPECT_DOUBLE_EQ(1.0, *(param_value->double_value));
+
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
 }
 
@@ -788,16 +866,17 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_no_param_overri
   params = NULL;
   ret = rcl_arguments_get_param_overrides(&parsed_args, &params);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  EXPECT_EQ(0U, params->num_nodes);
-  rcl_yaml_node_struct_fini(params);
+  EXPECT_TRUE(NULL == params);
 
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_two_param_overrides) {
+TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_overrides) {
+  const std::string parameters_filepath = (test_path / "test_parameters.1.yaml").string();
   const char * argv[] = {
     "process_name", "--ros-args",
-    "--param", "string_param:=test_string",
+    "--params-file", parameters_filepath.c_str(),
+    "--param", "string_param:=bar",
     "-p", "some_node:int_param:=4"
   };
   int argc = sizeof(argv) / sizeof(const char *);
@@ -823,10 +902,15 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_two_param_overr
     rcl_yaml_node_struct_get("/**", "string_param", params);
   ASSERT_TRUE(NULL != param_value);
   ASSERT_TRUE(NULL != param_value->string_value);
-  EXPECT_STREQ("test_string", param_value->string_value);
+  EXPECT_STREQ("bar", param_value->string_value);
 
   param_value = rcl_yaml_node_struct_get("some_node", "int_param", params);
   ASSERT_TRUE(NULL != param_value);
   ASSERT_TRUE(NULL != param_value->integer_value);
   EXPECT_EQ(4, *(param_value->integer_value));
+
+  param_value = rcl_yaml_node_struct_get("some_node", "param_group.string_param", params);
+  ASSERT_TRUE(NULL != param_value);
+  ASSERT_TRUE(NULL != param_value->string_value);
+  EXPECT_STREQ("foo", param_value->string_value);
 }

--- a/rcl/test/resources/test_arguments/test_parameters.1.yaml
+++ b/rcl/test/resources/test_arguments/test_parameters.1.yaml
@@ -1,0 +1,5 @@
+some_node:
+  ros__parameters:
+    int_param: 1
+    param_group:
+      string_param: foo

--- a/rcl/test/resources/test_arguments/test_parameters.2.yaml
+++ b/rcl/test/resources/test_arguments/test_parameters.2.yaml
@@ -1,0 +1,5 @@
+another_node:
+  ros__parameters:
+    double_param: 1.0
+    param_group:
+      boo_array_param: [true, false, false]

--- a/rcl/test/resources/test_arguments/test_parameters.2.yaml
+++ b/rcl/test/resources/test_arguments/test_parameters.2.yaml
@@ -1,5 +1,8 @@
+some_node:
+  ros__parameters:
+    int_param: 3
 another_node:
   ros__parameters:
     double_param: 1.0
     param_group:
-      boo_array_param: [true, false, false]
+      bool_array_param: [true, false, false]

--- a/rcl_yaml_param_parser/test/overlay.yaml
+++ b/rcl_yaml_param_parser/test/overlay.yaml
@@ -1,0 +1,13 @@
+# config/test_yaml
+---
+
+lidar_ns:
+  lidar_2:
+    ros__parameters:
+      is_back: true
+camera:
+  ros__parameters:
+    loc: back
+intel:
+  ros__parameters:
+    num_cores: 12

--- a/rcl_yaml_param_parser/test/test_parse_yaml.cpp
+++ b/rcl_yaml_param_parser/test/test_parse_yaml.cpp
@@ -48,6 +48,15 @@ TEST(test_parser, correct_syntax) {
   bool res = rcl_parse_yaml_file(path, params_hdl);
   ASSERT_TRUE(res) << rcutils_get_error_string().str;
 
+  char * another_path = rcutils_join_path(test_path, "overlay.yaml", allocator);
+  ASSERT_TRUE(NULL != another_path) << rcutils_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    allocator.deallocate(another_path, allocator.state);
+  });
+  ASSERT_TRUE(rcutils_exists(another_path)) << "No test YAML file found at " << another_path;
+  res = rcl_parse_yaml_file(another_path, params_hdl);
+  ASSERT_TRUE(res) << rcutils_get_error_string().str;
+
   rcl_params_t * copy_of_params_hdl = rcl_yaml_node_struct_copy(params_hdl);
   ASSERT_TRUE(NULL != copy_of_params_hdl) << rcutils_get_error_string().str;
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
@@ -59,11 +68,11 @@ TEST(test_parser, correct_syntax) {
     rcl_variant_t * param_value = rcl_yaml_node_struct_get("lidar_ns/lidar_2", "is_back", params);
     ASSERT_TRUE(NULL != param_value) << rcutils_get_error_string().str;
     ASSERT_TRUE(NULL != param_value->bool_value);
-    EXPECT_FALSE(*param_value->bool_value);
-    res = rcl_parse_yaml_value("lidar_ns/lidar_2", "is_back", "true", params);
+    EXPECT_TRUE(*param_value->bool_value);
+    res = rcl_parse_yaml_value("lidar_ns/lidar_2", "is_back", "false", params);
     EXPECT_TRUE(res) << rcutils_get_error_string().str;
     ASSERT_TRUE(NULL != param_value->bool_value);
-    EXPECT_TRUE(*param_value->bool_value);
+    EXPECT_FALSE(*param_value->bool_value);
 
     param_value = rcl_yaml_node_struct_get("lidar_ns/lidar_2", "id", params);
     ASSERT_TRUE(NULL != param_value) << rcutils_get_error_string().str;
@@ -74,6 +83,15 @@ TEST(test_parser, correct_syntax) {
     ASSERT_TRUE(NULL != param_value->integer_value);
     EXPECT_EQ(12, *param_value->integer_value);
 
+    param_value = rcl_yaml_node_struct_get("camera", "loc", params);
+    ASSERT_TRUE(NULL != param_value) << rcutils_get_error_string().str;
+    ASSERT_TRUE(NULL != param_value->string_value);
+    EXPECT_STREQ("back", param_value->string_value);
+    res = rcl_parse_yaml_value("camera", "loc", "front", params);
+    EXPECT_TRUE(res) << rcutils_get_error_string().str;
+    ASSERT_TRUE(NULL != param_value->string_value);
+    EXPECT_STREQ("front", param_value->string_value);
+
     param_value = rcl_yaml_node_struct_get("camera", "cam_spec.angle", params);
     ASSERT_TRUE(NULL != param_value) << rcutils_get_error_string().str;
     ASSERT_TRUE(NULL != param_value->double_value);
@@ -82,6 +100,15 @@ TEST(test_parser, correct_syntax) {
     EXPECT_TRUE(res) << rcutils_get_error_string().str;
     ASSERT_TRUE(NULL != param_value->double_value);
     EXPECT_DOUBLE_EQ(2.2, *param_value->double_value);
+
+    param_value = rcl_yaml_node_struct_get("intel", "num_cores", params);
+    ASSERT_TRUE(NULL != param_value) << rcutils_get_error_string().str;
+    ASSERT_TRUE(NULL != param_value->integer_value);
+    EXPECT_EQ(12, *param_value->integer_value);
+    res = rcl_parse_yaml_value("intel", "num_cores", "8", params);
+    EXPECT_TRUE(res) << rcutils_get_error_string().str;
+    ASSERT_TRUE(NULL != param_value->integer_value);
+    EXPECT_EQ(8, *param_value->integer_value);
 
     param_value = rcl_yaml_node_struct_get("intel", "arch", params);
     ASSERT_TRUE(NULL != param_value) << rcutils_get_error_string().str;


### PR DESCRIPTION
This pull request adds parameter parsing functionality to `rcl`. Parameters overrides provided directly through the command line and indirectly through parameter YAML files are combined in a single `rcl_params_t` structure -- last override always takes precedence.

Depends on #507.