### PR TITLE
Not creating rosout publisher instance unless required.

### DIFF
--- a/rcl/include/rcl/logging.h
+++ b/rcl/include/rcl/logging.h
@@ -71,6 +71,25 @@ RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t rcl_logging_fini();
 
+/// See if logging rosout is enabled.
+/**
+ * This function is meant to be used to check if logging rosout is enabled
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | Yes
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \return `TRUE` if logging rosout is enabled, or
+ * \return `FALSE` if logging rosout is disabled.
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+bool rcl_logging_rosout_enabled();
+
 #ifdef __cplusplus
 }
 #endif

--- a/rcl/include/rcl/logging.h
+++ b/rcl/include/rcl/logging.h
@@ -73,7 +73,7 @@ rcl_ret_t rcl_logging_fini();
 
 /// See if logging rosout is enabled.
 /**
- * This function is meant to be used to check if logging rosout is enabled
+ * This function is meant to be used to check if logging rosout is enabled.
  *
  * <hr>
  * Attribute          | Adherence

--- a/rcl/src/rcl/logging.c
+++ b/rcl/src/rcl/logging.c
@@ -119,6 +119,11 @@ rcl_ret_t rcl_logging_fini()
   return status;
 }
 
+bool rcl_logging_rosout_enabled()
+{
+  return g_rcl_logging_rosout_enabled;
+}
+
 static
 void
 rcl_logging_multiple_output_handler(


### PR DESCRIPTION
Signed-off-by: Tomoya.Fujita <Tomoya.Fujita@sony.com>

# Overview

fix for https://github.com/ros2/rcl/issues/510
it does not even make rosout publisher object unless it is required.

# Verification

## Environment

Ubuntu18.04 ros2.repo(master) source build

## Test Log

terminal-1
```
root@6cc2c62d0dd0:~/ros2_colcon_ws# ros2 run demo_nodes_cpp talker __log_disable_rosout:=True
```

terminal-2
```
root@6cc2c62d0dd0:~/ros2_colcon_ws# ros2 node info /talker
Failed to load entry point 'multicast': No module named 'ros2node.command.multicast'
/talker
  Subscribers:
    /parameter_events: rcl_interfaces/msg/ParameterEvent
  Publishers:
    /chatter: std_msgs/msg/String
    /parameter_events: rcl_interfaces/msg/ParameterEvent
  Services:
    /talker/describe_parameters: rcl_interfaces/srv/DescribeParameters
    /talker/get_parameter_types: rcl_interfaces/srv/GetParameterTypes
    /talker/get_parameters: rcl_interfaces/srv/GetParameters
    /talker/list_parameters: rcl_interfaces/srv/ListParameters
    /talker/set_parameters: rcl_interfaces/srv/SetParameters
    /talker/set_parameters_atomically: rcl_interfaces/srv/SetParametersAtomically
  Actions Servers:

  Actions Clients:

```

-> make sure there is no **rosout** topic in Publishers.
