### PR TITLE
Handle zero non-ROS specific args properly in rcl_remove_ros_arguments

### DIFF
--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -587,24 +587,30 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_remove_ros_
 
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
       NULL, &parsed_args, default_allocator, &nonros_argc, &nonros_argv));
+  rcl_reset_error();
 
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
       argv, NULL, default_allocator, &nonros_argc, &nonros_argv));
+  rcl_reset_error();
 
   rcl_allocator_t zero_initialized_allocator =
     (rcl_allocator_t)rcutils_get_zero_initialized_allocator();
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
       argv, &parsed_args, zero_initialized_allocator, &nonros_argc, &nonros_argv));
+  rcl_reset_error();
 
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
       argv, &parsed_args, default_allocator, NULL, &nonros_argv));
+  rcl_reset_error();
 
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
       argv, &parsed_args, default_allocator, &nonros_argc, NULL));
+  rcl_reset_error();
 
   rcl_arguments_t zero_initialized_parsed_args = rcl_get_zero_initialized_arguments();
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
       argv, &zero_initialized_parsed_args, default_allocator, &nonros_argc, &nonros_argv));
+  rcl_reset_error();
 
   const char * stack_allocated_nonros_argv[] = {"--foo", "--bar"};
   const char ** initialized_nonros_argv = stack_allocated_nonros_argv;
@@ -612,6 +618,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_remove_ros_
 
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
       argv, &parsed_args, default_allocator, &initialized_nonros_argc, &initialized_nonros_argv));
+  rcl_reset_error();
 
   rcl_arguments_t no_parsed_args = rcl_get_zero_initialized_arguments();
   ret = rcl_parse_arguments(0, NULL, default_allocator, &no_parsed_args);


### PR DESCRIPTION
This pull request changes `rcl_remove_ros_arguments()` behavior to deal with zero non ROS specific arguments instead of immediately flagging it as an error condition. 

This simplifies API usage by removing the need for redundant checks and handling null `argv` as zero-length lists -- consistently with how `rcl_parse_arguments` handles null `argv`. Also, IMHO it makes for a better realization of the public and documented API.