### PR TITLE
Add localhost option to node creation

### DIFF
--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -44,6 +44,7 @@ set(${PROJECT_NAME}_sources
   src/rcl/init_options.c
   src/rcl/lexer.c
   src/rcl/lexer_lookahead.c
+  src/rcl/localhost.c
   src/rcl/logging_rosout.c
   src/rcl/logging.c
   src/rcl/node.c

--- a/rcl/include/rcl/localhost.h
+++ b/rcl/include/rcl/localhost.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef RCL__LOCALHOST_H
-#define RCL__LOCALHOST_H
+#ifndef RCL__LOCALHOST_H_
+#define RCL__LOCALHOST_H_
 
 #ifdef __cplusplus
 extern "C"
@@ -23,7 +23,7 @@ extern "C"
 #include "rcl/types.h"
 #include "rcl/visibility_control.h"
 
-extern const char * RCL_LOCALHOST_ENV_VAR;
+extern const char * const RCL_LOCALHOST_ENV_VAR;
 
 /// Determine if the user wants to communicate using loopback only.
 /**
@@ -39,4 +39,4 @@ rcl_localhost_only();
 }
 #endif
 
-#endif // RCL__LOCALHOST_H
+#endif  // RCL__LOCALHOST_H_

--- a/rcl/include/rcl/localhost.h
+++ b/rcl/include/rcl/localhost.h
@@ -1,0 +1,42 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCL__LOCALHOST_H
+#define RCL__LOCALHOST_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rcl/types.h"
+#include "rcl/visibility_control.h"
+
+extern const char * RCL_LOCALHOST_ENV_VAR;
+
+/// Determine if the user wants to communicate using loopback only.
+/**
+ * Checks if localhost should be used for network communication checking ROS_LOCALHOST_ONLY env
+ * variable
+ * \returns true if ROS_LOCALHOST_ONLY is set and is 1, false otherwise.
+ */
+RCL_PUBLIC
+bool
+rcl_localhost_only();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RCL__LOCALHOST_H

--- a/rcl/src/rcl/localhost.c
+++ b/rcl/src/rcl/localhost.c
@@ -1,0 +1,30 @@
+// Copyright 2019 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rcl/localhost.h>
+
+#include "rcutils/get_env.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+const char * RCL_LOCALHOST_ENV_VAR = "ROS_LOCALHOST_ONLY";
+
+bool
+rcl_localhost_only()
+{
+  const char * ros_local_host_env_val = NULL;
+  return rcutils_get_env(RCL_LOCALHOST_ENV_VAR, &ros_local_host_env_val) == NULL &&
+    ros_local_host_env_val != NULL && strcmp(ros_local_host_env_val, "1") == 0;
+}

--- a/rcl/src/rcl/localhost.c
+++ b/rcl/src/rcl/localhost.c
@@ -14,17 +14,17 @@
 
 #include <rcl/localhost.h>
 
-#include "rcutils/get_env.h"
-
 #include <stdlib.h>
 #include <string.h>
 
-const char * RCL_LOCALHOST_ENV_VAR = "ROS_LOCALHOST_ONLY";
+#include "rcutils/get_env.h"
+
+const char * const RCL_LOCALHOST_ENV_VAR = "ROS_LOCALHOST_ONLY";
 
 bool
 rcl_localhost_only()
 {
   const char * ros_local_host_env_val = NULL;
   return rcutils_get_env(RCL_LOCALHOST_ENV_VAR, &ros_local_host_env_val) == NULL &&
-    ros_local_host_env_val != NULL && strcmp(ros_local_host_env_val, "1") == 0;
+         ros_local_host_env_val != NULL && strcmp(ros_local_host_env_val, "1") == 0;
 }

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -41,6 +41,7 @@ extern "C"
 #include "rcutils/snprintf.h"
 #include "rcutils/strdup.h"
 #include "rmw/error_handling.h"
+#include "rmw/localhost.h"
 #include "rmw/node_security_options.h"
 #include "rmw/rmw.h"
 #include "rmw/validate_namespace.h"
@@ -328,7 +329,7 @@ rcl_node_init(
   }
   node->impl->rmw_node_handle = rmw_create_node(
     &(node->context->impl->rmw_context),
-    name, local_namespace_, domain_id, &node_security_options);
+    name, local_namespace_, domain_id, &node_security_options, rmw_localhost_only());
 
   RCL_CHECK_FOR_NULL_WITH_MSG(
     node->impl->rmw_node_handle, rmw_get_error_string().str, goto fail);

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -26,6 +26,7 @@ extern "C"
 
 #include "rcl/arguments.h"
 #include "rcl/error_handling.h"
+#include "rcl/localhost.h"
 #include "rcl/logging.h"
 #include "rcl/logging_rosout.h"
 #include "rcl/rcl.h"
@@ -41,7 +42,6 @@ extern "C"
 #include "rcutils/snprintf.h"
 #include "rcutils/strdup.h"
 #include "rmw/error_handling.h"
-#include "rmw/localhost.h"
 #include "rmw/node_security_options.h"
 #include "rmw/rmw.h"
 #include "rmw/validate_namespace.h"
@@ -329,7 +329,7 @@ rcl_node_init(
   }
   node->impl->rmw_node_handle = rmw_create_node(
     &(node->context->impl->rmw_context),
-    name, local_namespace_, domain_id, &node_security_options, rmw_localhost_only());
+    name, local_namespace_, domain_id, &node_security_options, rcl_localhost_only());
 
   RCL_CHECK_FOR_NULL_WITH_MSG(
     node->impl->rmw_node_handle, rmw_get_error_string().str, goto fail);


### PR DESCRIPTION
Add the boolean that determines if the user provided the env var ROS_LOCALHOST_ONLY as 1 to restrict network traffic. Connected to this [issue](https://github.com/ros2/ros2/issues/798)

- Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8441)](https://ci.ros2.org/job/ci_linux/8441/)
- Arch [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4343)](https://ci.ros2.org/job/ci_linux-aarch64/4343/)
- Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8352)](https://ci.ros2.org/job/ci_windows/8352/)
- OSX [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=6866)](https://ci.ros2.org/job/ci_osx/6866/)