### PR TITLE
Add compile flag to disable string parameter size limit

### DIFF
--- a/rcl_yaml_param_parser/CMakeLists.txt
+++ b/rcl_yaml_param_parser/CMakeLists.txt
@@ -27,6 +27,10 @@ add_library(
   ${rcl_yaml_parser_sources})
 ament_target_dependencies(${PROJECT_NAME} "yaml" "rcutils")
 
+# This compile definition used to enable bounding of string parameters
+# see MAX_STRING_SIZE definition in src/parser.c
+# target_compile_definitions(${PROJECT_NAME} PRIVATE "RCL_ENFORCE_MAX_STRING_SIZE")
+
 # Set the visibility to hidden by default if possible
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
   # Set the visibility of symbols to hidden by default for gcc and clang

--- a/rcl_yaml_param_parser/src/parser.c
+++ b/rcl_yaml_param_parser/src/parser.c
@@ -207,10 +207,13 @@ static rcutils_ret_t add_name_to_ns(
 
     tot_len = ns_len + sep_len + name_len + 1U;
 
+#ifdef RCL_ENFORCE_MAX_STRING_SIZE
     if (tot_len > MAX_STRING_SIZE) {
       RCUTILS_SET_ERROR_MSG("New namespace string is exceeding max string size");
       return RCUTILS_RET_ERROR;
     }
+#endif
+
     cur_ns = allocator.reallocate(cur_ns, tot_len, allocator.state);
     if (NULL == cur_ns) {
       return RCUTILS_RET_BAD_ALLOC;
@@ -1116,19 +1119,21 @@ static rcutils_ret_t parse_value(
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(
     value, "event argument has no value", return RCUTILS_RET_INVALID_ARGUMENT);
 
+#ifdef RCL_ENFORCE_MAX_STRING_SIZE
   if (val_size > MAX_STRING_SIZE) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
       "Scalar value at line %u has %zu bytes which is bigger than the compile "
       "time limit of %u bytes", line_num, val_size, MAX_STRING_SIZE);
     return RCUTILS_RET_ERROR;
-  } else {
-    if (style != YAML_SINGLE_QUOTED_SCALAR_STYLE &&
-      style != YAML_DOUBLE_QUOTED_SCALAR_STYLE &&
-      0U == val_size)
-    {
-      RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("No value at line %d", line_num);
-      return RCUTILS_RET_ERROR;
-    }
+  }
+#endif
+
+  if (style != YAML_SINGLE_QUOTED_SCALAR_STYLE &&
+    style != YAML_DOUBLE_QUOTED_SCALAR_STYLE &&
+    0U == val_size)
+  {
+    RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("No value at line %d", line_num);
+    return RCUTILS_RET_ERROR;
   }
 
   if (NULL == params_st->params[node_idx].parameter_values) {
@@ -1315,16 +1320,18 @@ static rcutils_ret_t parse_key(
   RCUTILS_CHECK_FOR_NULL_WITH_MSG(
     value, "event argument has no value", return RCUTILS_RET_INVALID_ARGUMENT);
 
+#ifdef RCL_ENFORCE_MAX_STRING_SIZE
   if (val_size > MAX_STRING_SIZE) {
     RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
       "Scalar value at line %d is bigger than %d bytes",
       line_num, MAX_STRING_SIZE);
     return RCUTILS_RET_ERROR;
-  } else {
-    if (0U == val_size) {
-      RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("No key at line %d", line_num);
-      return RCUTILS_RET_ERROR;
-    }
+  }
+#endif
+
+  if (0U == val_size) {
+    RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("No key at line %d", line_num);
+    return RCUTILS_RET_ERROR;
   }
 
   rcutils_ret_t ret = RCUTILS_RET_OK;
@@ -1426,12 +1433,14 @@ static rcutils_ret_t parse_key(
           const size_t param_name_len = strlen(value);
           const size_t tot_len = (params_ns_len + param_name_len + 2U);
 
+#ifdef RCL_ENFORCE_MAX_STRING_SIZE
           if (tot_len > MAX_STRING_SIZE) {
             RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
               "The name length exceeds the MAX size %d at line %d", MAX_STRING_SIZE, line_num);
             ret = RCUTILS_RET_ERROR;
             break;
           }
+#endif
 
           param_name = allocator.zero_allocate(1U, tot_len, allocator.state);
           if (NULL == param_name) {


### PR DESCRIPTION
This is intended to be a minimal change for potential inclusion for the Eloquent release with follow-on work to come for making an easier interface to recover this behavior than rebuilding from source. See #244 for additional discussion on this topic.

If a change like this that makes string parameters unbounded by default is considered a breaking change that can't be done mid-distribution, I'd really appreciate a quick evaluation if we can consider including it for this release. I think of this as fixing a notable regression from ROS1.

Thanks,
Josh