### PR TITLE
Don't use launch_testing features that will be deprecated

### DIFF
--- a/rcl/test/rcl/test_rmw_impl_id_check.py.in
+++ b/rcl/test/rcl/test_rmw_impl_id_check.py.in
@@ -7,6 +7,7 @@ from launch.actions import ExecuteProcess
 from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 import launch_testing.util
 
@@ -33,7 +34,6 @@ import unittest
 def generate_test_description(
     rmw_implementation_env,
     rcl_assert_rmw_id_matches_env,
-    ready_fn
 ):
     launch_description = LaunchDescription()
 
@@ -52,15 +52,15 @@ def generate_test_description(
     # Keep the test fixture alive till tests end.
     launch_description.add_action(launch_testing.util.KeepAliveProc())
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 
 class TestRMWImplementationIDCheck(unittest.TestCase):
 
-    def test_process_terminates_in_a_finite_amount_of_time(self, executable_under_test):
+    def test_process_terminates_in_a_finite_amount_of_time(self, executable_under_test, proc_info):
         """Test that executable under test terminates in a finite amount of time."""
-        self.proc_info.assertWaitForShutdown(process=executable_under_test, timeout=10)
+        proc_info.assertWaitForShutdown(process=executable_under_test, timeout=10)
 
 @launch_testing.post_shutdown_test()
 class TestRMWImplementationIDCheckAfterShutdown(unittest.TestCase):

--- a/rcl/test/rcl/test_two_executables.py.in
+++ b/rcl/test/rcl/test_two_executables.py.in
@@ -7,12 +7,13 @@ from launch.actions import ExecuteProcess
 from launch.actions import OpaqueFunction
 
 import launch_testing
+import launch_testing.actions
 import launch_testing.asserts
 
 import unittest
 
 
-def generate_test_description(ready_fn):
+def generate_test_description():
     launch_description = LaunchDescription()
 
     launch_description.add_action(
@@ -29,25 +30,25 @@ def generate_test_description(ready_fn):
     launch_description.add_action(executable_under_test)
 
     launch_description.add_action(
-        OpaqueFunction(function=lambda context: ready_fn())
+        launch_testing.actions.ReadyToTest()
     )
     return launch_description, locals()
 
 
 class TestTwoExecutables(unittest.TestCase):
 
-    def @TEST_NAME@(self, executable_under_test):
+    def @TEST_NAME@(self, executable_under_test, proc_info):
         """Test that the executable under test terminates after a finite amount of time."""
-        self.proc_info.assertWaitForShutdown(process=executable_under_test, timeout=10)
+        proc_info.assertWaitForShutdown(process=executable_under_test, timeout=10)
 
 
 @launch_testing.post_shutdown_test()
 class TestTwoExecutablesAfterShutdown(unittest.TestCase):
 
-    def @TEST_NAME@(self, executable_under_test):
+    def @TEST_NAME@(self, executable_under_test, proc_info):
         """Test that the executable under test finished cleanly."""
         launch_testing.asserts.assertExitCodes(
-            self.proc_info,
+            proc_info,
             [launch_testing.asserts.EXIT_OK],
             executable_under_test
         )


### PR DESCRIPTION
Removing some of the 'magic' features from launch_testing that we want to deprecate.

For reference, see https://github.com/ros2/launch/pull/346

Signed-off-by: Pete Baughman <pete.baughman@apex.ai>