### PR TITLE
Set allocator before goto fail.

### DIFF
--- a/rcl/src/rcl/init.c
+++ b/rcl/src/rcl/init.c
@@ -83,6 +83,9 @@ rcl_init(
   // Zero initialize rmw context first so its validity can by checked in cleanup.
   context->impl->rmw_context = rmw_get_zero_initialized_context();
 
+  // Store the allocator.
+  context->impl->allocator = allocator;
+
   // Copy the options into the context for future reference.
   rcl_ret_t ret = rcl_init_options_copy(options, &(context->impl->init_options));
   if (RCL_RET_OK != ret) {
@@ -150,9 +153,6 @@ rcl_init(
     fail_ret = rcl_convert_rmw_ret_to_rcl_ret(rmw_ret);
     goto fail;
   }
-
-  // Store the allocator.
-  context->impl->allocator = allocator;
 
   TRACEPOINT(rcl_init, (const void *)context);
 


### PR DESCRIPTION
Cherry-pick #540 to `master`.

Fixes #539 

CI (testing `rcl` and `test_communication`):
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8785)](http://ci.ros2.org/job/ci_linux/8785/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=4606)](http://ci.ros2.org/job/ci_linux-aarch64/4606/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=7194)](http://ci.ros2.org/job/ci_osx/7194/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=8704)](http://ci.ros2.org/job/ci_windows/8704/)