### PR TITLE
Revert "should also check if action status publisher is ready. (#541)"

### DIFF
--- a/rcl_action/src/rcl_action/action_client.c
+++ b/rcl_action/src/rcl_action/action_client.c
@@ -284,13 +284,6 @@ rcl_action_server_is_available(
   }
   *is_available = *is_available && (number_of_publishers != 0);
 
-  ret = rcl_subscription_get_publisher_count(
-    &(client->impl->status_subscription), &number_of_publishers);
-  if (RCL_RET_OK != ret) {
-    return ret;  // error is already set
-  }
-  *is_available = *is_available && (number_of_publishers != 0);
-
   return RCL_RET_OK;
 }
 


### PR DESCRIPTION
This reverts commit 80340c8b5ae117bbb36e18485d3f078e56926d3b.

I still think that #541 is reasonable, but I have tested locally that all the [failures](https://ci.ros2.org/view/nightly/job/nightly_linux_release/1383/#showFailuresLink) in `rclpy` were caused by this.

Full CI to double check that reverting actually solves the problem:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=8797)](http://ci.ros2.org/job/ci_linux/8797/)