### PR TITLE
Use absolute topic name for `rosout`

### DIFF
--- a/rcl/src/rcl/logging_rosout.c
+++ b/rcl/src/rcl/logging_rosout.c
@@ -33,7 +33,7 @@ extern "C"
 {
 #endif
 
-#define ROSOUT_TOPIC_NAME "rosout"
+#define ROSOUT_TOPIC_NAME "/rosout"
 
 /* Return RCL_RET_OK from this macro because we won't check throughout rcl if rosout is
  * initialized or not and in the case it's not we want things to continue working.

--- a/rcl/test/rcl/test_logging_rosout.cpp
+++ b/rcl/test/rcl/test_logging_rosout.cpp
@@ -95,7 +95,7 @@ public:
     // create rosout subscription
     const rosidl_message_type_support_t * ts =
       ROSIDL_GET_MSG_TYPE_SUPPORT(rcl_interfaces, msg, Log);
-    const char * topic = "rosout";
+    const char * topic = "/rosout";
     this->subscription_ptr = new rcl_subscription_t;
     *this->subscription_ptr = rcl_get_zero_initialized_subscription();
     rcl_subscription_options_t subscription_options = rcl_subscription_get_default_options();


### PR DESCRIPTION
Similarly to https://github.com/ros2/rclcpp/pull/929, having one `rosout` topic per namespace doesn't seem to have much sense.
This propose to use `/rosout` instead (as worked in ROS 1).