### PR TITLE
Fix behavior when provided a malformed parameters file

### DIFF
--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -625,8 +625,8 @@ rcl_parse_arguments(
           args_impl->num_param_files_args);
         continue;
       } else if (RCL_RET_ERROR == ret) {
-        // If we return RCL_RET_ERROR then the argument contained the prefix '__params:=',
-        // but the parameter file may be malformed or does not exist.
+        // If _rcl_parse_param_file_rule() returned RCL_RET_ERROR then the argument contained the
+        // '__params:=' prefix, but parsing the parameter file failed.
         goto fail;
       }
       RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -897,6 +897,26 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_deprecated_para
   EXPECT_EQ(1, *(param_value->integer_value));
 }
 
+// Regression test for https://github.com/ros2/rcl/issues/553
+// Testing behaviour that was broken in Eloquent
+TEST_F(
+  CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_deprecated_param_argument_malformed)
+{
+  const std::string parameters_filepath = (test_path / "test_malformed_parameters.1.yaml").string();
+  const std::string parameter_rule = "__params:=" + parameters_filepath;
+  const char * argv[] = {
+    "process_name", parameter_rule.c_str()
+  };
+  int argc = sizeof(argv) / sizeof(const char *);
+  rcl_ret_t ret;
+
+  rcl_allocator_t alloc = rcl_get_default_allocator();
+  rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
+
+  ret = rcl_parse_arguments(argc, argv, alloc, &parsed_args);
+  ASSERT_EQ(RCL_RET_ERROR, ret) << rcl_get_error_string().str;
+}
+
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_multiple) {
   const std::string parameters_filepath1 = (test_path / "test_parameters.1.yaml").string();
   const std::string parameters_filepath2 = (test_path / "test_parameters.2.yaml").string();

--- a/rcl/test/resources/test_arguments/test_malformed_parameters.1.yaml
+++ b/rcl/test/resources/test_arguments/test_malformed_parameters.1.yaml
@@ -1,0 +1,5 @@
+some_node:
+  ros_parameters:
+    int_param: 1
+    param_group:
+      string_param: foo

--- a/rcl_yaml_param_parser/src/parser.c
+++ b/rcl_yaml_param_parser/src/parser.c
@@ -1705,7 +1705,6 @@ bool rcl_parse_yaml_file(
     if (NULL != ns_tracker.parameter_ns) {
       allocator.deallocate(ns_tracker.parameter_ns, allocator.state);
     }
-    rcl_yaml_node_struct_fini(params_st);
     return false;
   }
 


### PR DESCRIPTION
Fixes #553. 

* Don't finalize parameters struct in rcl_parse_yaml_file function
The function assumes that the structure has already been initialized, so it should be the callers
responsibility to finalize it. Otherwise, this may lead to a double free as reported in #553.
* Return an error code if there's a malformed parameters file
This restores behavior that was lost when the '__params:=' syntax was deprecated in #495.
* An extra guard was also added when finalizing the parameters struct.