### PR TITLE
Ensure no redundant rcl_logging initialization and finalization.

### DIFF
--- a/rcl/include/rcl/logging.h
+++ b/rcl/include/rcl/logging.h
@@ -29,16 +29,16 @@ extern "C"
 
 /// Configure the logging system.
 /**
- * This function should be called during the ROS initialization process.
+ * This function should be called once during the ROS initialization process.
  * It will add the enabled log output appenders to the root logger.
  *
  * <hr>
  * Attribute          | Adherence
  * ------------------ | -------------
  * Allocates Memory   | Yes
- * Thread-Safe        | No
+ * Thread-Safe        | Yes
  * Uses Atomics       | No
- * Lock-Free          | Yes
+ * Lock-Free          | No
  *
  * \param global_args The global arguments for the system
  * \param allocator Used to allocate memory used by the logging system
@@ -49,7 +49,7 @@ extern "C"
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
-rcl_logging_configure(
+rcl_logging_init(
   const rcl_arguments_t * global_args,
   const rcl_allocator_t * allocator);
 
@@ -60,9 +60,9 @@ rcl_logging_configure(
  * Attribute          | Adherence
  * ------------------ | -------------
  * Allocates Memory   | No
- * Thread-Safe        | No
+ * Thread-Safe        | Yes
  * Uses Atomics       | No
- * Lock-Free          | Yes
+ * Lock-Free          | No
  *
  * \return `RCL_RET_OK` if successful.
  * \return `RCL_RET_ERR` if a general error occurs

--- a/rcl/include/rcl/logging.h
+++ b/rcl/include/rcl/logging.h
@@ -29,16 +29,16 @@ extern "C"
 
 /// Configure the logging system.
 /**
- * This function should be called once during the ROS initialization process.
+ * This function should be called during the ROS initialization process.
  * It will add the enabled log output appenders to the root logger.
  *
  * <hr>
  * Attribute          | Adherence
  * ------------------ | -------------
  * Allocates Memory   | Yes
- * Thread-Safe        | Yes
+ * Thread-Safe        | No
  * Uses Atomics       | No
- * Lock-Free          | No
+ * Lock-Free          | Yes
  *
  * \param global_args The global arguments for the system
  * \param allocator Used to allocate memory used by the logging system
@@ -60,9 +60,9 @@ rcl_logging_init(
  * Attribute          | Adherence
  * ------------------ | -------------
  * Allocates Memory   | No
- * Thread-Safe        | Yes
+ * Thread-Safe        | No
  * Uses Atomics       | No
- * Lock-Free          | No
+ * Lock-Free          | Yes
  *
  * \return `RCL_RET_OK` if successful.
  * \return `RCL_RET_ERR` if a general error occurs

--- a/rcl/src/rcl/init.c
+++ b/rcl/src/rcl/init.c
@@ -122,7 +122,7 @@ rcl_init(
     goto fail;
   }
 
-  ret = rcl_logging_configure(&context->global_arguments, &allocator);
+  ret = rcl_logging_init(&context->global_arguments, &allocator);
   if (RCL_RET_OK != ret) {
     fail_ret = ret;
     RCUTILS_LOG_ERROR_NAMED(

--- a/rcl/src/rcl/logging.c
+++ b/rcl/src/rcl/logging.c
@@ -44,7 +44,7 @@ static bool g_rcl_logging_stdout_enabled = false;
 static bool g_rcl_logging_rosout_enabled = false;
 static bool g_rcl_logging_ext_lib_enabled = false;
 
-static atomic_uint_least64_t __rcl_logging_init_count = ATOMIC_VAR_INIT(0);
+static atomic_uint_least64_t g_rcl_logging_init_count = ATOMIC_VAR_INIT(0);
 
 /**
  * An output function that sends to multiple output appenders.
@@ -71,7 +71,7 @@ rcl_logging_init(const rcl_arguments_t * global_args, const rcl_allocator_t * al
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(global_args, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(allocator, RCL_RET_INVALID_ARGUMENT);
-  if (rcutils_atomic_fetch_add_uint64_t(&__rcl_logging_init_count, 1)) {
+  if (rcutils_atomic_fetch_add_uint64_t(&g_rcl_logging_init_count, 1)) {
     return RCL_RET_OK;
   }
   RCUTILS_LOGGING_AUTOINIT
@@ -114,8 +114,8 @@ rcl_ret_t rcl_logging_fini()
 {
   rcl_ret_t status = RCL_RET_OK;
 
-  if (rcutils_atomic_load_uint64_t(&__rcl_logging_init_count) > 0) {
-    uint64_t current_count = rcutils_atomic_fetch_add_uint64_t(&__rcl_logging_init_count, -1);
+  if (rcutils_atomic_load_uint64_t(&g_rcl_logging_init_count) > 0) {
+    uint64_t current_count = rcutils_atomic_fetch_add_uint64_t(&g_rcl_logging_init_count, -1);
     if (current_count != 1) {
       return RCL_RET_OK;
     }
@@ -131,6 +131,7 @@ rcl_ret_t rcl_logging_fini()
   if (RCL_RET_OK == status && g_rcl_logging_ext_lib_enabled) {
     status = rcl_logging_external_shutdown();
   }
+
   return status;
 }
 


### PR DESCRIPTION
this is fix for https://github.com/ros2/rcl/issues/551.

the following, i would like to hear from others.

- Does it have to introduce thread safe? once mutex is introduced, there would be pain for maintenance and possibilities to increase deadlock. (which we do not really like...)
- it seems to be probable we can avoid multiple call for rcl_logging init/init without thread safe. and even if that happens, there would be no such problem for user application.