### PR TITLE
Rcl issues 469 test arguments

### DIFF
--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -1102,7 +1102,8 @@ rcl_arguments_fini(
     }
 
     if (NULL != args->impl->external_log_config_file) {
-      args->impl->allocator.deallocate(args->impl->external_log_config_file, args->impl->allocator.state);
+      args->impl->allocator.deallocate(args->impl->external_log_config_file,
+                                       args->impl->allocator.state);
       args->impl->external_log_config_file = NULL;
     }
 

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -984,6 +984,7 @@ rcl_arguments_copy(
   args_out->impl->parameter_overrides = NULL;
   args_out->impl->parameter_files = NULL;
   args_out->impl->num_param_files_args = 0;
+  args_out->impl->external_log_config_file = NULL;
 
   if (args->impl->num_unparsed_args) {
     // Copy unparsed args

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -338,10 +338,6 @@ rcl_parse_arguments(
     return ret;
   }
   rcl_arguments_impl_t * args_impl = args_output->impl;
-  args_impl->log_level = -1;
-  args_impl->log_stdout_disabled = false;
-  args_impl->log_rosout_disabled = false;
-  args_impl->log_ext_lib_disabled = false;
 
   if (argc == 0) {
     // there are no arguments to parse
@@ -2095,13 +2091,10 @@ _rcl_allocate_initialized_arguments_impl(rcl_arguments_t * args, rcl_allocator_t
     return RCL_RET_BAD_ALLOC;
   }
 
-  // TODO(y-okumura-isp): log_level and log_*disabled are initialized in rcl_parse_arguments()
-  //                      but not in rcl_arguments_copy().
-  //                      Check they are only forgotten or there is some reason.
   rcl_arguments_impl_t * args_impl = args->impl;
   args_impl->num_remap_rules = 0;
   args_impl->remap_rules = NULL;
-  // args_impl->log_level = -1;
+  args_impl->log_level = -1;
   args_impl->external_log_config_file = NULL;
   args_impl->unparsed_args = NULL;
   args_impl->num_unparsed_args = 0;
@@ -2110,9 +2103,9 @@ _rcl_allocate_initialized_arguments_impl(rcl_arguments_t * args, rcl_allocator_t
   args_impl->parameter_overrides = NULL;
   args_impl->parameter_files = NULL;
   args_impl->num_param_files_args = 0;
-  // args_impl->log_stdout_disabled = false;
-  // args_impl->log_rosout_disabled = false;
-  // args_impl->log_ext_lib_disabled = false;
+  args_impl->log_stdout_disabled = false;
+  args_impl->log_rosout_disabled = false;
+  args_impl->log_ext_lib_disabled = false;
   args_impl->allocator = *allocator;
 
   return RCL_RET_OK;

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -962,12 +962,10 @@ rcl_arguments_copy(
 
   rcl_allocator_t allocator = args->impl->allocator;
 
-  do {
-    rcl_ret_t ret = _rcl_allocate_initialized_arguments_impl(args_out, &allocator);
-    if (RCL_RET_OK != ret) {
-      return ret;
-    }
-  } while(false);
+  rcl_ret_t ret = _rcl_allocate_initialized_arguments_impl(args_out, &allocator);
+  if (RCL_RET_OK != ret) {
+    return ret;
+  }
 
   if (args->impl->num_unparsed_args) {
     // Copy unparsed args
@@ -1014,7 +1012,7 @@ rcl_arguments_copy(
     args_out->impl->num_remap_rules = args->impl->num_remap_rules;
     for (int i = 0; i < args->impl->num_remap_rules; ++i) {
       args_out->impl->remap_rules[i] = rcl_get_zero_initialized_remap();
-      rcl_ret_t ret = rcl_remap_copy(
+      ret = rcl_remap_copy(
         &(args->impl->remap_rules[i]), &(args_out->impl->remap_rules[i]));
       if (RCL_RET_OK != ret) {
         if (RCL_RET_OK != rcl_arguments_fini(args_out)) {
@@ -1102,8 +1100,8 @@ rcl_arguments_fini(
     }
 
     if (NULL != args->impl->external_log_config_file) {
-      args->impl->allocator.deallocate(args->impl->external_log_config_file,
-                                       args->impl->allocator.state);
+      args->impl->allocator.deallocate(
+        args->impl->external_log_config_file, args->impl->allocator.state);
       args->impl->external_log_config_file = NULL;
     }
 

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -1117,6 +1117,11 @@ rcl_arguments_fini(
       args->impl->parameter_files = NULL;
     }
 
+    if (NULL != args->impl->external_log_config_file) {
+      args->impl->allocator.deallocate(args->impl->external_log_config_file, args->impl->allocator.state);
+      args->impl->external_log_config_file = NULL;
+    }
+
     args->impl->allocator.deallocate(args->impl, args->impl->allocator.state);
     args->impl = NULL;
     return ret;

--- a/rcl_yaml_param_parser/src/parser.c
+++ b/rcl_yaml_param_parser/src/parser.c
@@ -1347,7 +1347,7 @@ static rcutils_ret_t parse_key(
             break;
           }
 
-	  allocator.deallocate(node_name_ns, allocator.state);
+          allocator.deallocate(node_name_ns, allocator.state);
 
 	  ret = rem_name_from_ns(ns_tracker, NS_TYPE_NODE, allocator);
           if (RCUTILS_RET_OK != ret) {

--- a/rcl_yaml_param_parser/src/parser.c
+++ b/rcl_yaml_param_parser/src/parser.c
@@ -1343,13 +1343,12 @@ static rcutils_ret_t parse_key(
           }
 
           ret = find_node(node_name_ns, params_st, node_idx);
+          allocator.deallocate(node_name_ns, allocator.state);
           if (RCUTILS_RET_OK != ret) {
             break;
           }
 
-          allocator.deallocate(node_name_ns, allocator.state);
-
-	  ret = rem_name_from_ns(ns_tracker, NS_TYPE_NODE, allocator);
+          ret = rem_name_from_ns(ns_tracker, NS_TYPE_NODE, allocator);
           if (RCUTILS_RET_OK != ret) {
             RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
               "Internal error adding node namespace at line %d", line_num);

--- a/rcl_yaml_param_parser/src/parser.c
+++ b/rcl_yaml_param_parser/src/parser.c
@@ -1347,7 +1347,9 @@ static rcutils_ret_t parse_key(
             break;
           }
 
-          ret = rem_name_from_ns(ns_tracker, NS_TYPE_NODE, allocator);
+	  allocator.deallocate(node_name_ns, allocator.state);
+
+	  ret = rem_name_from_ns(ns_tracker, NS_TYPE_NODE, allocator);
           if (RCUTILS_RET_OK != ret) {
             RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
               "Internal error adding node namespace at line %d", line_num);


### PR DESCRIPTION
Related with #469.

This is PR about problems in test_arguments found by using asan.

- rcl_arguments
  - memory leak and initializtion problem about external_log_config_file handling
- rcl_yaml_param_parser
  - memory leak

There are still 2 problems(seems complicated).
