### PR TITLE
code style only: wrap after open parenthesis if not in one line

### DIFF
--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -397,8 +397,8 @@ rcl_parse_arguments(
         if (i + 1 < argc) {
           // Attempt to parse next argument as parameter override rule
           if (RCL_RET_OK == _rcl_parse_param_rule(argv[i + 1], args_impl->parameter_overrides)) {
-            RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
-              "Got param override rule : %s\n", argv[i + 1]);
+            RCUTILS_LOG_DEBUG_NAMED(
+              ROS_PACKAGE_NAME, "Got param override rule : %s\n", argv[i + 1]);
             ++i;  // Skip flag here, for loop will skip rule.
             continue;
           }
@@ -414,8 +414,8 @@ rcl_parse_arguments(
         ret = RCL_RET_INVALID_ROS_ARGS;
         goto fail;
       }
-      RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
-        "Arg %d (%s) is not a %s nor a %s flag.",
+      RCUTILS_LOG_DEBUG_NAMED(
+        ROS_PACKAGE_NAME, "Arg %d (%s) is not a %s nor a %s flag.",
         i, argv[i], RCL_PARAM_FLAG, RCL_SHORT_PARAM_FLAG);
 
       // Attempt to parse argument as remap rule flag
@@ -442,9 +442,9 @@ rcl_parse_arguments(
         ret = RCL_RET_INVALID_ROS_ARGS;
         goto fail;
       }
-      RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
-        "Arg %d (%s) is not a %s nor a %s flag.", i,
-        argv[i], RCL_REMAP_FLAG, RCL_SHORT_REMAP_FLAG);
+      RCUTILS_LOG_DEBUG_NAMED(
+        ROS_PACKAGE_NAME, "Arg %d (%s) is not a %s nor a %s flag.",
+        i, argv[i], RCL_REMAP_FLAG, RCL_SHORT_REMAP_FLAG);
 
       // Attempt to parse argument as parameter file rule
       if (strcmp(RCL_PARAM_FILE_FLAG, argv[i]) == 0) {
@@ -457,7 +457,8 @@ rcl_parse_arguments(
               &args_impl->parameter_files[args_impl->num_param_files_args]))
           {
             ++(args_impl->num_param_files_args);
-            RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
+            RCUTILS_LOG_DEBUG_NAMED(
+              ROS_PACKAGE_NAME,
               "Got params file : %s\ntotal num param files %d",
               args_impl->parameter_files[args_impl->num_param_files_args - 1],
               args_impl->num_param_files_args);
@@ -476,8 +477,9 @@ rcl_parse_arguments(
         ret = RCL_RET_INVALID_ROS_ARGS;
         goto fail;
       }
-      RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
-        "Arg %d (%s) is not a %s flag.", i, argv[i], RCL_PARAM_FILE_FLAG);
+      RCUTILS_LOG_DEBUG_NAMED(
+        ROS_PACKAGE_NAME, "Arg %d (%s) is not a %s flag.",
+        i, argv[i], RCL_PARAM_FILE_FLAG);
 
       // Attempt to parse argument as log level configuration
       if (strcmp(RCL_LOG_LEVEL_FLAG, argv[i]) == 0) {
@@ -501,16 +503,16 @@ rcl_parse_arguments(
         ret = RCL_RET_INVALID_ROS_ARGS;
         goto fail;
       }
-      RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
-        "Arg %d (%s) is not a %s flag.",
+      RCUTILS_LOG_DEBUG_NAMED(
+        ROS_PACKAGE_NAME, "Arg %d (%s) is not a %s flag.",
         i, argv[i], RCL_LOG_LEVEL_FLAG);
 
       // Attempt to parse argument as log configuration file
       if (strcmp(RCL_EXTERNAL_LOG_CONFIG_FLAG, argv[i]) == 0) {
         if (i + 1 < argc) {
           if (NULL != args_impl->external_log_config_file) {
-            RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
-              "Overriding log configuration file : %s\n",
+            RCUTILS_LOG_DEBUG_NAMED(
+              ROS_PACKAGE_NAME, "Overriding log configuration file : %s\n",
               args_impl->external_log_config_file);
             allocator.deallocate(args_impl->external_log_config_file, allocator.state);
             args_impl->external_log_config_file = NULL;
@@ -518,8 +520,8 @@ rcl_parse_arguments(
           if (RCL_RET_OK == _rcl_parse_external_log_config_file(
               argv[i + 1], allocator, &args_impl->external_log_config_file))
           {
-            RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
-              "Got log configuration file : %s\n",
+            RCUTILS_LOG_DEBUG_NAMED(
+              ROS_PACKAGE_NAME, "Got log configuration file : %s\n",
               args_impl->external_log_config_file);
             ++i;  // Skip flag here, for loop will skip value.
             continue;
@@ -536,19 +538,21 @@ rcl_parse_arguments(
         ret = RCL_RET_INVALID_ROS_ARGS;
         goto fail;
       }
-      RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
-        "Arg %d (%s) is not a %s flag.",
+      RCUTILS_LOG_DEBUG_NAMED(
+        ROS_PACKAGE_NAME, "Arg %d (%s) is not a %s flag.",
         i, argv[i], RCL_EXTERNAL_LOG_CONFIG_FLAG);
 
       // Attempt to parse --enable/disable-stdout-logs flag
       ret = _rcl_parse_disabling_flag(
         argv[i], RCL_LOG_STDOUT_FLAG_SUFFIX, &args_impl->log_stdout_disabled);
       if (RCL_RET_OK == ret) {
-        RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
-          "Disable log stdout ? %s\n", args_impl->log_stdout_disabled ? "true" : "false");
+        RCUTILS_LOG_DEBUG_NAMED(
+          ROS_PACKAGE_NAME, "Disable log stdout ? %s\n",
+          args_impl->log_stdout_disabled ? "true" : "false");
         continue;
       }
-      RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
+      RCUTILS_LOG_DEBUG_NAMED(
+        ROS_PACKAGE_NAME,
         "Couldn't parse arg %d (%s) as %s%s or %s%s flag. Error: %s",
         i, argv[i], RCL_ENABLE_FLAG_PREFIX, RCL_LOG_STDOUT_FLAG_SUFFIX,
         RCL_DISABLE_FLAG_PREFIX, RCL_LOG_STDOUT_FLAG_SUFFIX, rcl_get_error_string().str);
@@ -558,11 +562,13 @@ rcl_parse_arguments(
       ret = _rcl_parse_disabling_flag(
         argv[i], RCL_LOG_ROSOUT_FLAG_SUFFIX, &args_impl->log_rosout_disabled);
       if (RCL_RET_OK == ret) {
-        RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
-          "Disable log rosout ? %s\n", args_impl->log_rosout_disabled ? "true" : "false");
+        RCUTILS_LOG_DEBUG_NAMED(
+          ROS_PACKAGE_NAME, "Disable log rosout ? %s\n",
+          args_impl->log_rosout_disabled ? "true" : "false");
         continue;
       }
-      RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
+      RCUTILS_LOG_DEBUG_NAMED(
+        ROS_PACKAGE_NAME,
         "Couldn't parse arg %d (%s) as %s%s or %s%s flag. Error: %s",
         i, argv[i], RCL_ENABLE_FLAG_PREFIX, RCL_LOG_ROSOUT_FLAG_SUFFIX,
         RCL_DISABLE_FLAG_PREFIX, RCL_LOG_ROSOUT_FLAG_SUFFIX, rcl_get_error_string().str);
@@ -572,11 +578,13 @@ rcl_parse_arguments(
       ret = _rcl_parse_disabling_flag(
         argv[i], RCL_LOG_EXT_LIB_FLAG_SUFFIX, &args_impl->log_ext_lib_disabled);
       if (RCL_RET_OK == ret) {
-        RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
-          "Disable log external lib ? %s\n", args_impl->log_ext_lib_disabled ? "true" : "false");
+        RCUTILS_LOG_DEBUG_NAMED(
+          ROS_PACKAGE_NAME, "Disable log external lib ? %s\n",
+          args_impl->log_ext_lib_disabled ? "true" : "false");
         continue;
       }
-      RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
+      RCUTILS_LOG_DEBUG_NAMED(
+        ROS_PACKAGE_NAME,
         "Couldn't parse arg %d (%s) as %s%s or %s%s flag. Error: %s",
         i, argv[i], RCL_ENABLE_FLAG_PREFIX, RCL_LOG_EXT_LIB_FLAG_SUFFIX,
         RCL_DISABLE_FLAG_PREFIX, RCL_LOG_EXT_LIB_FLAG_SUFFIX, rcl_get_error_string().str);
@@ -596,14 +604,16 @@ rcl_parse_arguments(
       rcl_remap_t * rule = &(args_impl->remap_rules[args_impl->num_remap_rules]);
       *rule = rcl_get_zero_initialized_remap();
       if (RCL_RET_OK == _rcl_parse_remap_rule(argv[i], allocator, rule)) {
-        RCUTILS_LOG_WARN_NAMED(ROS_PACKAGE_NAME,
+        RCUTILS_LOG_WARN_NAMED(
+          ROS_PACKAGE_NAME,
           "Found remap rule '%s'. This syntax is deprecated. Use '%s %s %s' instead.",
           argv[i], RCL_ROS_ARGS_FLAG, RCL_REMAP_FLAG, argv[i]);
         RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Got remap rule : %s\n", argv[i + 1]);
         ++(args_impl->num_remap_rules);
         continue;
       }
-      RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
+      RCUTILS_LOG_DEBUG_NAMED(
+        ROS_PACKAGE_NAME,
         "Couldn't parse arg %d (%s) as a remap rule in its deprecated form. Error: %s",
         i, argv[i], rcl_get_error_string().str);
       rcl_reset_error();
@@ -616,17 +626,20 @@ rcl_parse_arguments(
           &args_impl->parameter_files[args_impl->num_param_files_args]))
       {
         ++(args_impl->num_param_files_args);
-        RCUTILS_LOG_WARN_NAMED(ROS_PACKAGE_NAME,
+        RCUTILS_LOG_WARN_NAMED(
+          ROS_PACKAGE_NAME,
           "Found parameter file rule '%s'. This syntax is deprecated. Use '%s %s %s' instead.",
           argv[i], RCL_ROS_ARGS_FLAG, RCL_PARAM_FILE_FLAG,
           args_impl->parameter_files[args_impl->num_param_files_args - 1]);
-        RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
+        RCUTILS_LOG_DEBUG_NAMED(
+          ROS_PACKAGE_NAME,
           "params rule : %s\n total num param rules %d",
           args_impl->parameter_files[args_impl->num_param_files_args - 1],
           args_impl->num_param_files_args);
         continue;
       }
-      RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
+      RCUTILS_LOG_DEBUG_NAMED(
+        ROS_PACKAGE_NAME,
         "Couldn't parse arg %d (%s) as a deprecated parameter file rule. Error: %s",
         i, argv[i], rcl_get_error_string().str);
       rcl_reset_error();
@@ -634,13 +647,15 @@ rcl_parse_arguments(
       // Attempt to parse argument as log level configuration
       int log_level;
       if (RCL_RET_OK == _rcl_parse_log_level_rule(argv[i], allocator, &log_level)) {
-        RCUTILS_LOG_WARN_NAMED(ROS_PACKAGE_NAME,
+        RCUTILS_LOG_WARN_NAMED(
+          ROS_PACKAGE_NAME,
           "Found log level rule '%s'. This syntax is deprecated. Use '%s %s %s' instead.",
           argv[i], RCL_ROS_ARGS_FLAG, RCL_LOG_LEVEL_FLAG, g_rcutils_log_severity_names[log_level]);
         args_impl->log_level = log_level;
         continue;
       }
-      RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
+      RCUTILS_LOG_DEBUG_NAMED(
+        ROS_PACKAGE_NAME,
         "Couldn't parse arg %d (%s) as a deprecated log level rule. Error: %s",
         i, argv[i], rcl_get_error_string().str);
       rcl_reset_error();
@@ -649,16 +664,18 @@ rcl_parse_arguments(
       rcl_ret_t ret = _rcl_parse_external_log_config_file_rule(
         argv[i], allocator, &args_impl->external_log_config_file);
       if (RCL_RET_OK == ret) {
-        RCUTILS_LOG_WARN_NAMED(ROS_PACKAGE_NAME,
+        RCUTILS_LOG_WARN_NAMED(
+          ROS_PACKAGE_NAME,
           "Found log config rule '%s'. This syntax is deprecated. Use '%s %s %s' instead.",
           argv[i], RCL_ROS_ARGS_FLAG, RCL_EXTERNAL_LOG_CONFIG_FLAG,
           args_impl->external_log_config_file);
-        RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
-          "Got log configuration file : %s\n",
+        RCUTILS_LOG_DEBUG_NAMED(
+          ROS_PACKAGE_NAME, "Got log configuration file : %s\n",
           args_impl->external_log_config_file);
         continue;
       }
-      RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
+      RCUTILS_LOG_DEBUG_NAMED(
+        ROS_PACKAGE_NAME,
         "Couldn't parse arg %d (%s) as a deprecated log config rule. Error: %s",
         i, argv[i], rcl_get_error_string().str);
       rcl_reset_error();
@@ -669,14 +686,17 @@ rcl_parse_arguments(
       if (RCL_RET_OK == ret) {
         const char * flag_prefix =
           args_impl->log_stdout_disabled ? RCL_DISABLE_FLAG_PREFIX : RCL_ENABLE_FLAG_PREFIX;
-        RCUTILS_LOG_WARN_NAMED(ROS_PACKAGE_NAME,
+        RCUTILS_LOG_WARN_NAMED(
+          ROS_PACKAGE_NAME,
           "Found '%s'. This syntax is deprecated. Use '%s %s%s' instead.",
           argv[i], RCL_ROS_ARGS_FLAG, flag_prefix, RCL_LOG_STDOUT_FLAG_SUFFIX);
-        RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
-          "Disable log stdout ? %s\n", args_impl->log_stdout_disabled ? "true" : "false");
+        RCUTILS_LOG_DEBUG_NAMED(
+          ROS_PACKAGE_NAME, "Disable log stdout ? %s\n",
+          args_impl->log_stdout_disabled ? "true" : "false");
         continue;
       }
-      RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
+      RCUTILS_LOG_DEBUG_NAMED(
+        ROS_PACKAGE_NAME,
         "Couldn't parse arg %d (%s) as a deprecated log_stdout_disabled rule. Error: %s",
         i, argv[i], rcl_get_error_string().str);
       rcl_reset_error();
@@ -687,14 +707,17 @@ rcl_parse_arguments(
       if (RCL_RET_OK == ret) {
         const char * flag_prefix =
           args_impl->log_rosout_disabled ? RCL_DISABLE_FLAG_PREFIX : RCL_ENABLE_FLAG_PREFIX;
-        RCUTILS_LOG_WARN_NAMED(ROS_PACKAGE_NAME,
+        RCUTILS_LOG_WARN_NAMED(
+          ROS_PACKAGE_NAME,
           "Found '%s'. This syntax is deprecated. Use '%s %s%s' instead.",
           argv[i], RCL_ROS_ARGS_FLAG, flag_prefix, RCL_LOG_ROSOUT_FLAG_SUFFIX);
-        RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
-          "Disable log rosout ? %s\n", args_impl->log_rosout_disabled ? "true" : "false");
+        RCUTILS_LOG_DEBUG_NAMED(
+          ROS_PACKAGE_NAME, "Disable log rosout ? %s\n",
+          args_impl->log_rosout_disabled ? "true" : "false");
         continue;
       }
-      RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
+      RCUTILS_LOG_DEBUG_NAMED(
+        ROS_PACKAGE_NAME,
         "Couldn't parse arg %d (%s) as a deprecated log_rosout_disabled rule. Error: %s",
         i, argv[i], rcl_get_error_string().str);
       rcl_reset_error();
@@ -705,14 +728,17 @@ rcl_parse_arguments(
       if (RCL_RET_OK == ret) {
         const char * flag_prefix =
           args_impl->log_ext_lib_disabled ? RCL_DISABLE_FLAG_PREFIX : RCL_ENABLE_FLAG_PREFIX;
-        RCUTILS_LOG_WARN_NAMED(ROS_PACKAGE_NAME,
+        RCUTILS_LOG_WARN_NAMED(
+          ROS_PACKAGE_NAME,
           "Found '%s'. This syntax is deprecated. Use '%s %s%s' instead.",
           argv[i], RCL_ROS_ARGS_FLAG, flag_prefix, RCL_LOG_EXT_LIB_FLAG_SUFFIX);
-        RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
-          "Disable log external lib ? %s\n", args_impl->log_ext_lib_disabled ? "true" : "false");
+        RCUTILS_LOG_DEBUG_NAMED(
+          ROS_PACKAGE_NAME, "Disable log external lib ? %s\n",
+          args_impl->log_ext_lib_disabled ? "true" : "false");
         continue;
       }
-      RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
+      RCUTILS_LOG_DEBUG_NAMED(
+        ROS_PACKAGE_NAME,
         "Couldn't parse arg %d (%s) as a deprecated log_ext_lib_disabled rule. Error: %s",
         i, argv[i], rcl_get_error_string().str);
       rcl_reset_error();

--- a/rcl/src/rcl/init.c
+++ b/rcl/src/rcl/init.c
@@ -186,7 +186,8 @@ rcl_shutdown(rcl_context_t * context)
   }
 
   rcl_ret_t rcl_ret = rcl_logging_fini();
-  RCUTILS_LOG_ERROR_EXPRESSION_NAMED(RCL_RET_OK != rcl_ret, ROS_PACKAGE_NAME,
+  RCUTILS_LOG_ERROR_EXPRESSION_NAMED(
+    RCL_RET_OK != rcl_ret, ROS_PACKAGE_NAME,
     "Failed to fini logging, rcl_ret_t: %i, rcl_error_str: %s", rcl_ret,
     rcl_get_error_string().str);
   rcl_reset_error();

--- a/rcl/src/rcl/logging_rosout.c
+++ b/rcl/src/rcl/logging_rosout.c
@@ -93,9 +93,11 @@ rcl_ret_t rcl_logging_rosout_init(
     return RCL_RET_OK;
   }
   __logger_map = rcutils_get_zero_initialized_hash_map();
-  RCL_RET_FROM_RCUTIL_RET(status,
-    rcutils_hash_map_init(&__logger_map, 2, sizeof(const char *), sizeof(rosout_map_entry_t),
-    rcutils_hash_map_string_hash_func, rcutils_hash_map_string_cmp_func, allocator));
+  RCL_RET_FROM_RCUTIL_RET(
+    status,
+    rcutils_hash_map_init(
+      &__logger_map, 2, sizeof(const char *), sizeof(rosout_map_entry_t),
+      rcutils_hash_map_string_hash_func, rcutils_hash_map_string_cmp_func, allocator));
   if (RCL_RET_OK == status) {
     __rosout_allocator = *allocator;
     __is_initialized = true;
@@ -111,8 +113,8 @@ rcl_ret_t rcl_logging_rosout_fini()
   rosout_map_entry_t entry;
 
   // fini all the outstanding publishers
-  rcutils_ret_t hashmap_ret = rcutils_hash_map_get_next_key_and_data(&__logger_map, NULL, &key,
-      &entry);
+  rcutils_ret_t hashmap_ret = rcutils_hash_map_get_next_key_and_data(
+    &__logger_map, NULL, &key, &entry);
   while (RCL_RET_OK == status && RCUTILS_RET_OK == hashmap_ret) {
     // Teardown publisher
     status = rcl_publisher_fini(&entry.publisher, entry.node);
@@ -157,7 +159,8 @@ rcl_ret_t rcl_logging_rosout_init_publisher_for_node(
   if (rcutils_hash_map_key_exists(&__logger_map, &logger_name)) {
     // @TODO(nburek) Update behavior to either enforce unique names or work with non-unique
     // names based on the outcome here: https://github.com/ros2/design/issues/187
-    RCUTILS_LOG_WARN_NAMED("rcl.logging_rosout",
+    RCUTILS_LOG_WARN_NAMED(
+      "rcl.logging_rosout",
       "Publisher already registered for provided node name. If this is due to multiple nodes "
       "with the same name then all logs for that logger name will go out over the existing "
       "publisher. As soon as any node with that name is destructed it will unregister the "

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -381,7 +381,8 @@ fail:
       node->impl->logger_name)
     {
       ret = rcl_logging_rosout_fini_publisher_for_node(node);
-      RCUTILS_LOG_ERROR_EXPRESSION_NAMED((ret != RCL_RET_OK && ret != RCL_RET_NOT_INIT),
+      RCUTILS_LOG_ERROR_EXPRESSION_NAMED(
+        (ret != RCL_RET_OK && ret != RCL_RET_NOT_INIT),
         ROS_PACKAGE_NAME, "Failed to fini publisher for node: %i", ret);
       allocator->deallocate((char *)node->impl->logger_name, allocator->state);
     }

--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -169,8 +169,8 @@ rcl_publisher_init(
     remapped_topic_name,
     &(options->qos),
     &(options->rmw_publisher_options));
-  RCL_CHECK_FOR_NULL_WITH_MSG(publisher->impl->rmw_handle,
-    rmw_get_error_string().str, goto fail);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    publisher->impl->rmw_handle, rmw_get_error_string().str, goto fail);
   // get actual qos, and store it
   rmw_ret = rmw_publisher_get_actual_qos(
     publisher->impl->rmw_handle,
@@ -303,8 +303,8 @@ rcl_publish_serialized_message(
     return RCL_RET_PUBLISHER_INVALID;  // error already set
   }
   RCL_CHECK_ARGUMENT_FOR_NULL(serialized_message, RCL_RET_INVALID_ARGUMENT);
-  rmw_ret_t ret = rmw_publish_serialized_message(publisher->impl->rmw_handle, serialized_message,
-      allocation);
+  rmw_ret_t ret = rmw_publish_serialized_message(
+    publisher->impl->rmw_handle, serialized_message, allocation);
   if (ret != RMW_RET_OK) {
     RCL_SET_ERROR_MSG(rmw_get_error_string().str);
     if (ret == RMW_RET_BAD_ALLOC) {
@@ -420,8 +420,8 @@ rcl_publisher_get_subscription_count(
   }
   RCL_CHECK_ARGUMENT_FOR_NULL(subscription_count, RCL_RET_INVALID_ARGUMENT);
 
-  rmw_ret_t ret = rmw_publisher_count_matched_subscriptions(publisher->impl->rmw_handle,
-      subscription_count);
+  rmw_ret_t ret = rmw_publisher_count_matched_subscriptions(
+    publisher->impl->rmw_handle, subscription_count);
 
   if (ret != RMW_RET_OK) {
     RCL_SET_ERROR_MSG(rmw_get_error_string().str);

--- a/rcl/src/rcl/security_directory.c
+++ b/rcl/src/rcl/security_directory.c
@@ -104,9 +104,9 @@ static bool get_best_matching_directory(
     }
     if (file.is_dir) {
       size_t matched_name_length = strnlen(file.name, sizeof(file.name) - 1);
-      if (0 ==
-        strncmp(file.name, node_name,
-        matched_name_length) && matched_name_length > max_match_length)
+      if (
+        0 == strncmp(file.name, node_name, matched_name_length) &&
+        matched_name_length > max_match_length)
       {
         max_match_length = matched_name_length;
         memcpy(matched_name, file.name, max_match_length);
@@ -230,8 +230,10 @@ char * rcl_get_secure_root(
       allocator->deallocate(ros_secure_root_env, allocator->state);
       return NULL;
     }
-    if (0 == strcmp(ros_security_lookup_type,
-      g_security_lookup_type_strings[ROS_SECURITY_LOOKUP_MATCH_PREFIX]))
+    if (
+      0 == strcmp(
+        ros_security_lookup_type,
+        g_security_lookup_type_strings[ROS_SECURITY_LOOKUP_MATCH_PREFIX]))
     {
       node_secure_root = g_security_lookup_fns[ROS_SECURITY_LOOKUP_MATCH_PREFIX]
           (node_name, node_namespace, ros_secure_root_env, allocator);

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -265,9 +265,8 @@ rcl_take(
   rmw_message_info_t * message_info_local = message_info ? message_info : &dummy_message_info;
   // Call rmw_take_with_info.
   bool taken = false;
-  rmw_ret_t ret =
-    rmw_take_with_info(subscription->impl->rmw_handle, ros_message, &taken,
-      message_info_local, allocation);
+  rmw_ret_t ret = rmw_take_with_info(
+    subscription->impl->rmw_handle, ros_message, &taken, message_info_local, allocation);
   if (ret != RMW_RET_OK) {
     RCL_SET_ERROR_MSG(rmw_get_error_string().str);
     if (RMW_RET_BAD_ALLOC == ret) {
@@ -418,8 +417,8 @@ rcl_subscription_get_publisher_count(
     return RCL_RET_SUBSCRIPTION_INVALID;
   }
   RCL_CHECK_ARGUMENT_FOR_NULL(publisher_count, RCL_RET_INVALID_ARGUMENT);
-  rmw_ret_t ret = rmw_subscription_count_matched_publishers(subscription->impl->rmw_handle,
-      publisher_count);
+  rmw_ret_t ret = rmw_subscription_count_matched_publishers(
+    subscription->impl->rmw_handle, publisher_count);
 
   if (ret != RMW_RET_OK) {
     RCL_SET_ERROR_MSG(rmw_get_error_string().str);

--- a/rcl/src/rcl/time.c
+++ b/rcl/src/rcl/time.c
@@ -121,8 +121,8 @@ rcl_clock_fini(
   rcl_clock_t * clock)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT);
-  RCL_CHECK_ALLOCATOR_WITH_MSG(&clock->allocator, "clock has invalid allocator",
-    return RCL_RET_ERROR);
+  RCL_CHECK_ALLOCATOR_WITH_MSG(
+    &clock->allocator, "clock has invalid allocator", return RCL_RET_ERROR);
   switch (clock->type) {
     case RCL_ROS_TIME:
       return rcl_ros_clock_fini(clock);
@@ -384,8 +384,8 @@ rcl_clock_add_jump_callback(
 {
   // Make sure parameters are valid
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT);
-  RCL_CHECK_ALLOCATOR_WITH_MSG(&(clock->allocator), "invalid allocator",
-    return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ALLOCATOR_WITH_MSG(
+    &(clock->allocator), "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(callback, RCL_RET_INVALID_ARGUMENT);
   if (threshold.min_forward.nanoseconds < 0) {
     RCL_SET_ERROR_MSG("forward jump threshold must be positive or zero");
@@ -427,8 +427,8 @@ rcl_clock_remove_jump_callback(
 {
   // Make sure parameters are valid
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT);
-  RCL_CHECK_ALLOCATOR_WITH_MSG(&(clock->allocator), "invalid allocator",
-    return RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ALLOCATOR_WITH_MSG(
+    &(clock->allocator), "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(callback, RCL_RET_INVALID_ARGUMENT);
 
   // Delete callback if found, moving all callbacks after back one

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -422,19 +422,22 @@ rcl_wait_set_resize(
   }
 
   SET_RESIZE(timer,;,;);  // NOLINT
-  SET_RESIZE(client,
+  SET_RESIZE(
+    client,
     SET_RESIZE_RMW_DEALLOC(
       rmw_clients.clients, rmw_clients.client_count),
     SET_RESIZE_RMW_REALLOC(
       client, rmw_clients.clients, rmw_clients.client_count)
   );
-  SET_RESIZE(service,
+  SET_RESIZE(
+    service,
     SET_RESIZE_RMW_DEALLOC(
       rmw_services.services, rmw_services.service_count),
     SET_RESIZE_RMW_REALLOC(
       service, rmw_services.services, rmw_services.service_count)
   );
-  SET_RESIZE(event,
+  SET_RESIZE(
+    event,
     SET_RESIZE_RMW_DEALLOC(
       rmw_events.events, rmw_events.event_count),
     SET_RESIZE_RMW_REALLOC(
@@ -451,7 +454,8 @@ rcl_wait_set_add_guard_condition(
   size_t * index)
 {
   SET_ADD(guard_condition)
-  SET_ADD_RMW(guard_condition, rmw_guard_conditions.guard_conditions,
+  SET_ADD_RMW(
+    guard_condition, rmw_guard_conditions.guard_conditions,
     rmw_guard_conditions.guard_condition_count)
 
   return RCL_RET_OK;

--- a/rcl/test/rcl/arg_macros.hpp
+++ b/rcl/test/rcl/arg_macros.hpp
@@ -56,7 +56,8 @@ destroy_args(int argc, char ** args)
     rcl_ret_t ret = rcl_init(argc, argv, &init_options, &context); \
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str; \
   } \
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({ \
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT( \
+  { \
     EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str; \
     destroy_args(argc, argv); \
     ASSERT_EQ(RCL_RET_OK, rcl_shutdown(&context)) << rcl_get_error_string().str; \
@@ -72,7 +73,8 @@ destroy_args(int argc, char ** args)
       local_argc, local_argv, rcl_get_default_allocator(), &local_arguments); \
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str; \
   } \
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({ \
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT( \
+  { \
     ASSERT_EQ(RCL_RET_OK, rcl_arguments_fini(&local_arguments)); \
   })
 

--- a/rcl/test/rcl/client_fixture.cpp
+++ b/rcl/test/rcl/client_fixture.cpp
@@ -70,7 +70,8 @@ wait_for_client_to_be_ready(
       ROS_PACKAGE_NAME, "Error in wait set init: %s", rcl_get_error_string().str);
     return false;
   }
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     if (rcl_wait_set_fini(&wait_set) != RCL_RET_OK) {
       RCUTILS_LOG_ERROR_NAMED(
         ROS_PACKAGE_NAME, "Error in wait set fini: %s", rcl_get_error_string().str);
@@ -124,7 +125,8 @@ int main(int argc, char ** argv)
         ROS_PACKAGE_NAME, "Error in rcl init: %s", rcl_get_error_string().str);
       return -1;
     }
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       if (rcl_shutdown(&context) != RCL_RET_OK) {
         RCUTILS_LOG_ERROR_NAMED(
           ROS_PACKAGE_NAME, "Error shutting down rcl: %s", rcl_get_error_string().str);
@@ -145,7 +147,8 @@ int main(int argc, char ** argv)
         ROS_PACKAGE_NAME, "Error in node init: %s", rcl_get_error_string().str);
       return -1;
     }
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       if (rcl_node_fini(&node) != RCL_RET_OK) {
         RCUTILS_LOG_ERROR_NAMED(
           ROS_PACKAGE_NAME, "Error in node fini: %s", rcl_get_error_string().str);
@@ -166,7 +169,8 @@ int main(int argc, char ** argv)
       return -1;
     }
 
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       if (rcl_client_fini(&client, &node)) {
         RCUTILS_LOG_ERROR_NAMED(
           ROS_PACKAGE_NAME, "Error in client fini: %s", rcl_get_error_string().str);

--- a/rcl/test/rcl/service_fixture.cpp
+++ b/rcl/test/rcl/service_fixture.cpp
@@ -43,7 +43,8 @@ wait_for_service_to_be_ready(
       ROS_PACKAGE_NAME, "Error in wait set init: %s", rcl_get_error_string().str);
     return false;
   }
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     if (rcl_wait_set_fini(&wait_set) != RCL_RET_OK) {
       RCUTILS_LOG_ERROR_NAMED(
         ROS_PACKAGE_NAME, "Error in wait set fini: %s", rcl_get_error_string().str);
@@ -97,7 +98,8 @@ int main(int argc, char ** argv)
         ROS_PACKAGE_NAME, "Error in rcl init: %s", rcl_get_error_string().str);
       return -1;
     }
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       if (rcl_shutdown(&context) != RCL_RET_OK) {
         RCUTILS_LOG_ERROR_NAMED(
           ROS_PACKAGE_NAME, "Error shutting down rcl: %s", rcl_get_error_string().str);
@@ -118,7 +120,8 @@ int main(int argc, char ** argv)
         ROS_PACKAGE_NAME, "Error in node init: %s", rcl_get_error_string().str);
       return -1;
     }
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       if (rcl_node_fini(&node) != RCL_RET_OK) {
         RCUTILS_LOG_ERROR_NAMED(
           ROS_PACKAGE_NAME, "Error in node fini: %s", rcl_get_error_string().str);
@@ -139,7 +142,8 @@ int main(int argc, char ** argv)
       return -1;
     }
 
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       if (rcl_service_fini(&service, &node)) {
         RCUTILS_LOG_ERROR_NAMED(
           ROS_PACKAGE_NAME, "Error in service fini: %s", rcl_get_error_string().str);
@@ -153,7 +157,8 @@ int main(int argc, char ** argv)
     // https://github.com/ros2/ros2/issues/397 is implemented
     memset(&service_response, 0, sizeof(test_msgs__srv__BasicTypes_Response));
     test_msgs__srv__BasicTypes_Response__init(&service_response);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       test_msgs__srv__BasicTypes_Response__fini(&service_response);
     });
 
@@ -170,7 +175,8 @@ int main(int argc, char ** argv)
     // https://github.com/ros2/ros2/issues/397 is implemented
     memset(&service_request, 0, sizeof(test_msgs__srv__BasicTypes_Request));
     test_msgs__srv__BasicTypes_Request__init(&service_request);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       test_msgs__srv__BasicTypes_Request__fini(&service_request);
     });
     rmw_request_id_t header;

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -260,7 +260,9 @@ are_valid_ros_args(std::vector<const char *> argv)
 
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), check_valid_vs_invalid_args) {
   const std::string parameters_filepath = (test_path / "test_parameters.1.yaml").string();
-  EXPECT_TRUE(are_valid_ros_args({
+  EXPECT_TRUE(
+    are_valid_ros_args(
+  {
     "--ros-args", "-p", "foo:=bar", "-r", "__node:=node_name",
     "--params-file", parameters_filepath.c_str(), "--log-level", "INFO",
     "--log-config-file", "file.config"
@@ -532,7 +534,8 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_uninitialized_p
   rcl_arguments_t parsed_args;
   int not_null = 1;
   parsed_args.impl = reinterpret_cast<rcl_arguments_impl_t *>(&not_null);
-  ASSERT_EQ(RCL_RET_INVALID_ARGUMENT,
+  ASSERT_EQ(
+    RCL_RET_INVALID_ARGUMENT,
     rcl_parse_arguments(argc, argv, rcl_get_default_allocator(), &parsed_args));
   rcl_reset_error();
 }
@@ -543,12 +546,15 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_double_parse) {
   };
   int argc = sizeof(argv) / sizeof(const char *);
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
-  ASSERT_EQ(RCL_RET_OK,
+  ASSERT_EQ(
+    RCL_RET_OK,
     rcl_parse_arguments(argc, argv, rcl_get_default_allocator(), &parsed_args));
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
   });
-  ASSERT_EQ(RCL_RET_INVALID_ARGUMENT,
+  ASSERT_EQ(
+    RCL_RET_INVALID_ARGUMENT,
     rcl_parse_arguments(argc, argv, rcl_get_default_allocator(), &parsed_args));
   rcl_reset_error();
 }
@@ -583,37 +589,44 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_remove_ros_
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
   rcl_ret_t ret = rcl_parse_arguments(argc, argv, default_allocator, &parsed_args);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
   });
 
   const char ** nonros_argv = NULL;
   int nonros_argc = 0;
 
-  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
+  EXPECT_EQ(
+    RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
       NULL, &parsed_args, default_allocator, &nonros_argc, &nonros_argv));
   rcl_reset_error();
 
-  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
+  EXPECT_EQ(
+    RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
       argv, NULL, default_allocator, &nonros_argc, &nonros_argv));
   rcl_reset_error();
 
   rcl_allocator_t zero_initialized_allocator =
     (rcl_allocator_t)rcutils_get_zero_initialized_allocator();
-  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
+  EXPECT_EQ(
+    RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
       argv, &parsed_args, zero_initialized_allocator, &nonros_argc, &nonros_argv));
   rcl_reset_error();
 
-  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
+  EXPECT_EQ(
+    RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
       argv, &parsed_args, default_allocator, NULL, &nonros_argv));
   rcl_reset_error();
 
-  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
+  EXPECT_EQ(
+    RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
       argv, &parsed_args, default_allocator, &nonros_argc, NULL));
   rcl_reset_error();
 
   rcl_arguments_t zero_initialized_parsed_args = rcl_get_zero_initialized_arguments();
-  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
+  EXPECT_EQ(
+    RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
       argv, &zero_initialized_parsed_args, default_allocator, &nonros_argc, &nonros_argv));
   rcl_reset_error();
 
@@ -621,14 +634,16 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_remove_ros_
   const char ** initialized_nonros_argv = stack_allocated_nonros_argv;
   int initialized_nonros_argc = sizeof(stack_allocated_nonros_argv) / sizeof(const char *);
 
-  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
+  EXPECT_EQ(
+    RCL_RET_INVALID_ARGUMENT, rcl_remove_ros_arguments(
       argv, &parsed_args, default_allocator, &initialized_nonros_argc, &initialized_nonros_argv));
   rcl_reset_error();
 
   rcl_arguments_t no_parsed_args = rcl_get_zero_initialized_arguments();
   ret = rcl_parse_arguments(0, NULL, default_allocator, &no_parsed_args);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&no_parsed_args));
   });
 
@@ -650,13 +665,15 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_remove_ros_args
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
   rcl_ret_t ret = rcl_parse_arguments(argc, argv, alloc, &parsed_args);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
   });
 
   int nonros_argc = 0;
   const char ** nonros_argv = NULL;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     alloc.deallocate(nonros_argv, alloc.state);
   });
 
@@ -690,13 +707,15 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_remove_deprecat
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
   rcl_ret_t ret = rcl_parse_arguments(argc, argv, alloc, &parsed_args);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
   });
 
   int nonros_argc = 0;
   const char ** nonros_argv = NULL;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     alloc.deallocate(nonros_argv, alloc.state);
   });
 
@@ -724,13 +743,15 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_remove_ros_args
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
   rcl_ret_t ret = rcl_parse_arguments(argc, argv, alloc, &parsed_args);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
   });
 
   int nonros_argc = 0;
   const char ** nonros_argv = NULL;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     alloc.deallocate(nonros_argv, alloc.state);
   });
 
@@ -756,13 +777,15 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_remove_ros_args
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
   rcl_ret_t ret = rcl_parse_arguments(argc, argv, alloc, &parsed_args);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
   });
 
   int nonros_argc = 0;
   const char ** nonros_argv = NULL;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     alloc.deallocate(nonros_argv, alloc.state);
   });
 
@@ -788,7 +811,8 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_
 
   rcl_ret_t ret = rcl_parse_arguments(argc, argv, alloc, &parsed_args);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
   });
 
@@ -809,7 +833,8 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_
 
   rcl_ret_t ret = rcl_parse_arguments(argc, argv, alloc, &parsed_args);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
   });
 
@@ -828,7 +853,8 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_
   rcl_params_t * params = NULL;
   ret = rcl_arguments_get_param_overrides(&parsed_args, &params);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_yaml_node_struct_fini(params);
   });
   EXPECT_EQ(1U, params->num_nodes);
@@ -861,7 +887,8 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_deprecated_para
 
   ret = rcl_parse_arguments(argc, argv, alloc, &parsed_args);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
   });
 
@@ -880,7 +907,8 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_deprecated_para
   rcl_params_t * params = NULL;
   ret = rcl_arguments_get_param_overrides(&parsed_args, &params);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_yaml_node_struct_fini(params);
   });
   EXPECT_EQ(1U, params->num_nodes);
@@ -912,7 +940,8 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_
 
   ret = rcl_parse_arguments(argc, argv, alloc, &parsed_args);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
   });
 
@@ -932,7 +961,8 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_
   rcl_params_t * params = NULL;
   ret = rcl_arguments_get_param_overrides(&parsed_args, &params);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_yaml_node_struct_fini(params);
   });
   EXPECT_EQ(2U, params->num_nodes);
@@ -972,7 +1002,8 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_no_param_overri
 
   rcl_ret_t ret = rcl_parse_arguments(argc, argv, alloc, &parsed_args);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
   });
 
@@ -1013,14 +1044,16 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_overrides
 
   rcl_ret_t ret = rcl_parse_arguments(argc, argv, alloc, &parsed_args);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
   });
 
   rcl_params_t * params = NULL;
   ret = rcl_arguments_get_param_overrides(&parsed_args, &params);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_yaml_node_struct_fini(params);
   });
   EXPECT_EQ(2U, params->num_nodes);

--- a/rcl/test/rcl/test_client.cpp
+++ b/rcl/test/rcl/test_client.cpp
@@ -36,7 +36,8 @@ public:
       rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
       ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
       ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+      {
         EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
       });
       this->context_ptr = new rcl_context_t;
@@ -85,7 +86,8 @@ TEST_F(TestClientFixture, test_client_nominal) {
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   EXPECT_EQ(strcmp(rcl_client_get_service_name(&client), expected_topic_name), 0);
 
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_client_fini(&client, this->node_ptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });

--- a/rcl/test/rcl/test_context.cpp
+++ b/rcl/test/rcl/test_context.cpp
@@ -45,7 +45,8 @@ TEST_F(CLASSNAME(TestContextFixture, RMW_IMPLEMENTATION), nominal) {
   ASSERT_EQ(ret, RCL_RET_OK);
   ret = rcl_init(0, nullptr, &init_options, &context);
   ASSERT_EQ(ret, RCL_RET_OK);
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ret = rcl_shutdown(&context);
     EXPECT_EQ(ret, RCL_RET_OK);
     ret = rcl_context_fini(&context);
@@ -54,14 +55,16 @@ TEST_F(CLASSNAME(TestContextFixture, RMW_IMPLEMENTATION), nominal) {
 
   // test rcl_context_get_init_options
   const rcl_init_options_t * init_options_ptr;
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     init_options_ptr = rcl_context_get_init_options(nullptr);
   });
   EXPECT_EQ(init_options_ptr, nullptr);
   EXPECT_TRUE(rcl_error_is_set());
   rcl_reset_error();
 
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     init_options_ptr = rcl_context_get_init_options(&context);
   });
   EXPECT_NE(init_options_ptr, nullptr) << rcl_get_error_string().str;
@@ -69,14 +72,16 @@ TEST_F(CLASSNAME(TestContextFixture, RMW_IMPLEMENTATION), nominal) {
 
   // test rcl_context_get_instance_id
   rcl_context_instance_id_t instance_id;
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     instance_id = rcl_context_get_instance_id(nullptr);
   });
   EXPECT_EQ(instance_id, 0UL);
   EXPECT_TRUE(rcl_error_is_set());
   rcl_reset_error();
 
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     instance_id = rcl_context_get_instance_id(&context);
   });
   EXPECT_NE(instance_id, 0UL) << rcl_get_error_string().str;
@@ -84,14 +89,16 @@ TEST_F(CLASSNAME(TestContextFixture, RMW_IMPLEMENTATION), nominal) {
 
   // test rcl_context_is_valid
   bool is_valid;
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     is_valid = rcl_context_is_valid(nullptr);
   });
   EXPECT_FALSE(is_valid);
   EXPECT_TRUE(rcl_error_is_set());
   rcl_reset_error();
 
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     is_valid = rcl_context_is_valid(&context);
   });
   EXPECT_TRUE(is_valid) << rcl_get_error_string().str;
@@ -99,14 +106,16 @@ TEST_F(CLASSNAME(TestContextFixture, RMW_IMPLEMENTATION), nominal) {
 
   // test rcl_context_get_rmw_context
   rmw_context_t * rmw_context_ptr;
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     rmw_context_ptr = rcl_context_get_rmw_context(nullptr);
   });
   EXPECT_EQ(rmw_context_ptr, nullptr);
   EXPECT_TRUE(rcl_error_is_set());
   rcl_reset_error();
 
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     rmw_context_ptr = rcl_context_get_rmw_context(&context);
   });
   EXPECT_NE(rmw_context_ptr, nullptr) << rcl_get_error_string().str;

--- a/rcl/test/rcl/test_count_matched.cpp
+++ b/rcl/test/rcl/test_count_matched.cpp
@@ -80,7 +80,8 @@ void check_state(
     ret = rcl_wait_set_add_guard_condition(wait_set_ptr, graph_guard_condition, NULL);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     std::chrono::nanoseconds time_to_sleep = std::chrono::milliseconds(200);
-    RCUTILS_LOG_INFO_NAMED(ROS_PACKAGE_NAME,
+    RCUTILS_LOG_INFO_NAMED(
+      ROS_PACKAGE_NAME,
       "  state wrong, waiting up to '%s' nanoseconds for graph changes... ",
       std::to_string(time_to_sleep.count()).c_str());
     ret = rcl_wait(wait_set_ptr, time_to_sleep.count());
@@ -187,7 +188,8 @@ TEST_F(CLASSNAME(TestCountFixture, RMW_IMPLEMENTATION), test_count_matched_funct
   check_state(wait_set_ptr, nullptr, &sub2, graph_guard_condition, -1, 0, 9);
 }
 
-TEST_F(CLASSNAME(TestCountFixture, RMW_IMPLEMENTATION),
+TEST_F(
+  CLASSNAME(TestCountFixture, RMW_IMPLEMENTATION),
   test_count_matched_functions_mismatched_qos) {
   std::string topic_name("/test_count_matched_functions_mismatched_qos__");
   rcl_ret_t ret;

--- a/rcl/test/rcl/test_events.cpp
+++ b/rcl/test/rcl/test_events.cpp
@@ -57,7 +57,8 @@ public:
       rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
       ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
       ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
-      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+      {
         EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
       });
       this->context_ptr = new rcl_context_t;
@@ -239,7 +240,8 @@ wait_for_msgs_and_events(
     context,
     rcl_get_default_allocator());
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_wait_set_fini(&wait_set);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
   });
@@ -345,7 +347,8 @@ conditional_wait_for_msgs_and_events(
  */
 TEST_F(CLASSNAME(TestEventFixture, RMW_IMPLEMENTATION), test_pubsub_no_deadline_missed)
 {
-  setup_publisher_and_subscriber(RCL_PUBLISHER_OFFERED_DEADLINE_MISSED,
+  setup_publisher_and_subscriber(
+    RCL_PUBLISHER_OFFERED_DEADLINE_MISSED,
     RCL_SUBSCRIPTION_REQUESTED_DEADLINE_MISSED);
   rcl_ret_t ret;
 
@@ -372,7 +375,8 @@ TEST_F(CLASSNAME(TestEventFixture, RMW_IMPLEMENTATION), test_pubsub_no_deadline_
   if (msg_ready) {
     test_msgs__msg__Strings msg;
     test_msgs__msg__Strings__init(&msg);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       test_msgs__msg__Strings__fini(&msg);
     });
     ret = rcl_take(&subscription, &msg, nullptr, nullptr);
@@ -409,7 +413,8 @@ TEST_F(CLASSNAME(TestEventFixture, RMW_IMPLEMENTATION), test_pubsub_no_deadline_
  */
 TEST_F(CLASSNAME(TestEventFixture, RMW_IMPLEMENTATION), test_pubsub_deadline_missed)
 {
-  setup_publisher_and_subscriber(RCL_PUBLISHER_OFFERED_DEADLINE_MISSED,
+  setup_publisher_and_subscriber(
+    RCL_PUBLISHER_OFFERED_DEADLINE_MISSED,
     RCL_SUBSCRIPTION_REQUESTED_DEADLINE_MISSED);
   rcl_ret_t ret;
 
@@ -442,12 +447,14 @@ TEST_F(CLASSNAME(TestEventFixture, RMW_IMPLEMENTATION), test_pubsub_deadline_mis
   if (msg_persist_ready) {
     test_msgs__msg__Strings msg;
     test_msgs__msg__Strings__init(&msg);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       test_msgs__msg__Strings__fini(&msg);
     });
     ret = rcl_take(&subscription, &msg, nullptr, nullptr);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
-    EXPECT_EQ(std::string(msg.string_value.data, msg.string_value.size),
+    EXPECT_EQ(
+      std::string(msg.string_value.data, msg.string_value.size),
       std::string(test_string));
   }
 
@@ -480,7 +487,8 @@ TEST_F(CLASSNAME(TestEventFixture, RMW_IMPLEMENTATION), test_pubsub_deadline_mis
  */
 TEST_F(CLASSNAME(TestEventFixture, RMW_IMPLEMENTATION), test_pubsub_liveliness_kill_pub)
 {
-  setup_publisher_and_subscriber(RCL_PUBLISHER_LIVELINESS_LOST,
+  setup_publisher_and_subscriber(
+    RCL_PUBLISHER_LIVELINESS_LOST,
     RCL_SUBSCRIPTION_LIVELINESS_CHANGED);
   rcl_ret_t ret;
 
@@ -515,12 +523,14 @@ TEST_F(CLASSNAME(TestEventFixture, RMW_IMPLEMENTATION), test_pubsub_liveliness_k
   if (msg_persist_ready) {
     test_msgs__msg__Strings msg;
     test_msgs__msg__Strings__init(&msg);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       test_msgs__msg__Strings__fini(&msg);
     });
     ret = rcl_take(&subscription, &msg, nullptr, nullptr);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
-    EXPECT_EQ(std::string(msg.string_value.data, msg.string_value.size),
+    EXPECT_EQ(
+      std::string(msg.string_value.data, msg.string_value.size),
       std::string(test_string));
   }
 

--- a/rcl/test/rcl/test_get_actual_qos.cpp
+++ b/rcl/test/rcl/test_get_actual_qos.cpp
@@ -37,15 +37,18 @@
 #endif
 
 #define EXPAND(x) x
-#define TEST_FIXTURE_P_RMW(test_fixture_name) CLASSNAME(test_fixture_name, \
-    RMW_IMPLEMENTATION)
+#define TEST_FIXTURE_P_RMW(test_fixture_name) CLASSNAME( \
+    test_fixture_name, RMW_IMPLEMENTATION)
 #define APPLY(macro, ...) EXPAND(macro(__VA_ARGS__))
 #define TEST_P_RMW(test_case_name, test_name) \
-  APPLY(TEST_P, \
+  APPLY( \
+    TEST_P, \
     CLASSNAME(test_case_name, RMW_IMPLEMENTATION), test_name)
 #define INSTANTIATE_TEST_CASE_P_RMW(instance_name, test_case_name, ...) \
-  EXPAND(APPLY(INSTANTIATE_TEST_CASE_P, instance_name, \
-    CLASSNAME(test_case_name, RMW_IMPLEMENTATION), __VA_ARGS__))
+  EXPAND( \
+    APPLY( \
+      INSTANTIATE_TEST_CASE_P, instance_name, \
+      CLASSNAME(test_case_name, RMW_IMPLEMENTATION), __VA_ARGS__))
 
 /**
  * Parameterized test.
@@ -111,7 +114,8 @@ public:
     *this->context_ptr = rcl_get_zero_initialized_context();
     ret = rcl_init(0, nullptr, &init_options, this->context_ptr);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
     });
     this->node_ptr = new rcl_node_t;
@@ -385,7 +389,8 @@ get_parameters(bool for_publisher)
   /*
    * Testing with default qos settings.
    */
-  parameters.push_back({
+  parameters.push_back(
+  {
     rmw_qos_profile_default,
     expected_default_qos_profile(),
     "default_qos"
@@ -399,7 +404,8 @@ get_parameters(bool for_publisher)
     /*
      * Test with non-default settings.
      */
-    parameters.push_back({
+    parameters.push_back(
+    {
       nondefault_qos_profile_for_fastrtps(),
       expected_nondefault_qos_profile_for_fastrtps(),
       "nondefault_qos"
@@ -409,13 +415,15 @@ get_parameters(bool for_publisher)
      * Test with system default settings.
      */
     if (for_publisher) {
-      parameters.push_back({
+      parameters.push_back(
+      {
         rmw_qos_profile_system_default,
         expected_system_default_publisher_qos_profile_for_fastrtps(),
         "system_default_publisher_qos"
       });
     } else {
-      parameters.push_back({
+      parameters.push_back(
+      {
         rmw_qos_profile_system_default,
         expected_system_default_subscription_qos_profile_for_fastrtps(),
         "system_default_publisher_qos"
@@ -429,7 +437,8 @@ get_parameters(bool for_publisher)
       /*
        * Test with non-default settings.
        */
-      parameters.push_back({
+      parameters.push_back(
+      {
         nondefault_qos_profile(),
         expected_nondefault_qos_profile(),
         "nondefault_qos"
@@ -439,13 +448,15 @@ get_parameters(bool for_publisher)
        * Test with system default settings.
        */
       if (for_publisher) {
-        parameters.push_back({
+        parameters.push_back(
+        {
           rmw_qos_profile_system_default,
           expected_system_default_publisher_qos_profile(),
           "system_default_publisher_qos"
         });
       } else {
-        parameters.push_back({
+        parameters.push_back(
+        {
           rmw_qos_profile_system_default,
           expected_system_default_subscription_qos_profile(),
           "system_default_publisher_qos"

--- a/rcl/test/rcl/test_get_node_names.cpp
+++ b/rcl/test/rcl/test_get_node_names.cpp
@@ -55,13 +55,15 @@ TEST_F(CLASSNAME(TestGetNodeNames, RMW_IMPLEMENTATION), test_rcl_get_node_names)
   rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
   ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
   });
   rcl_context_t context = rcl_get_zero_initialized_context();
   ret = rcl_init(0, nullptr, &init_options, &context);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_shutdown(&context)) << rcl_get_error_string().str;
     EXPECT_EQ(RCL_RET_OK, rcl_context_fini(&context)) << rcl_get_error_string().str;
   });
@@ -118,8 +120,10 @@ TEST_F(CLASSNAME(TestGetNodeNames, RMW_IMPLEMENTATION), test_rcl_get_node_names)
   EXPECT_EQ(node_names.size, node_namespaces.size) << ss.str();
 
   for (size_t i = 0; i < node_names.size; ++i) {
-    discovered_nodes.insert(std::make_pair(std::string(node_names.data[i]),
-      std::string(node_namespaces.data[i])));
+    discovered_nodes.insert(
+      std::make_pair(
+        std::string(node_names.data[i]),
+        std::string(node_namespaces.data[i])));
   }
   EXPECT_EQ(discovered_nodes, expected_nodes);
 

--- a/rcl/test/rcl/test_graph.cpp
+++ b/rcl/test/rcl/test_graph.cpp
@@ -69,7 +69,8 @@ public:
     rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
     ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
     });
     this->old_context_ptr = new rcl_context_t;
@@ -678,7 +679,8 @@ check_graph_state(
   bool expected_in_tnat,
   size_t number_of_tries)
 {
-  RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
+  RCUTILS_LOG_DEBUG_NAMED(
+    ROS_PACKAGE_NAME,
     "Expecting %zu publishers, %zu subscribers, and that the topic is%s in the graph.",
     expected_publisher_count,
     expected_subscriber_count,
@@ -716,7 +718,8 @@ check_graph_state(
       rcl_reset_error();
     }
 
-    RCUTILS_LOG_INFO_NAMED(ROS_PACKAGE_NAME,
+    RCUTILS_LOG_INFO_NAMED(
+      ROS_PACKAGE_NAME,
       " Try %zu: %zu publishers, %zu subscribers, and that the topic is%s in the graph.",
       i + 1,
       publisher_count,
@@ -741,7 +744,8 @@ check_graph_state(
     ret = rcl_wait_set_add_guard_condition(wait_set_ptr, graph_guard_condition, nullptr);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     std::chrono::nanoseconds time_to_sleep = std::chrono::milliseconds(400);
-    RCUTILS_LOG_INFO_NAMED(ROS_PACKAGE_NAME,
+    RCUTILS_LOG_INFO_NAMED(
+      ROS_PACKAGE_NAME,
       "  state wrong, waiting up to '%s' nanoseconds for graph changes... ",
       std::to_string(time_to_sleep.count()).c_str());
     ret = rcl_wait(wait_set_ptr, time_to_sleep.count());
@@ -764,9 +768,9 @@ check_graph_state(
 /**
  * Type define a get topics function.
  */
-typedef std::function<rcl_ret_t(const rcl_node_t *,
-    const char * node_name,
-    rcl_names_and_types_t *)> GetTopicsFunc;
+typedef std::function<
+    rcl_ret_t(const rcl_node_t *, const char * node_name, rcl_names_and_types_t *)
+> GetTopicsFunc;
 
 /**
  * Expect a certain number of topics on a given subsystem.
@@ -789,7 +793,8 @@ void expect_topics_types(
   if (expect) {
     EXPECT_EQ(num_topics, nat.names.size);
   } else {
-    RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Expected topics %zu, actual topics %zu", num_topics,
+    RCUTILS_LOG_DEBUG_NAMED(
+      ROS_PACKAGE_NAME, "Expected topics %zu, actual topics %zu", num_topics,
       nat.names.size);
   }
   ret = rcl_names_and_types_fini(&nat);
@@ -829,7 +834,8 @@ public:
     rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
     ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) <<
         rcl_get_error_string().str;
     });
@@ -842,35 +848,40 @@ public:
     *this->remote_context_ptr = rcl_get_zero_initialized_context();
     ret = rcl_init(0, nullptr, &init_options, this->remote_context_ptr);
 
-    ret = rcl_node_init(remote_node_ptr, remote_node_name, "", this->remote_context_ptr,
-        &node_options);
+    ret = rcl_node_init(
+      remote_node_ptr, remote_node_name, "", this->remote_context_ptr,
+      &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    sub_func = std::bind(rcl_get_subscriber_names_and_types_by_node,
-        std::placeholders::_1,
-        &this->allocator,
-        false,
-        std::placeholders::_2,
-        "/",
-        std::placeholders::_3);
-    pub_func = std::bind(rcl_get_publisher_names_and_types_by_node,
-        std::placeholders::_1,
-        &this->allocator,
-        false,
-        std::placeholders::_2,
-        "/",
-        std::placeholders::_3);
-    service_func = std::bind(rcl_get_service_names_and_types_by_node,
-        std::placeholders::_1,
-        &this->allocator,
-        std::placeholders::_2,
-        "/",
-        std::placeholders::_3);
-    client_func = std::bind(rcl_get_client_names_and_types_by_node,
-        std::placeholders::_1,
-        &this->allocator,
-        std::placeholders::_2,
-        "/",
-        std::placeholders::_3);
+    sub_func = std::bind(
+      rcl_get_subscriber_names_and_types_by_node,
+      std::placeholders::_1,
+      &this->allocator,
+      false,
+      std::placeholders::_2,
+      "/",
+      std::placeholders::_3);
+    pub_func = std::bind(
+      rcl_get_publisher_names_and_types_by_node,
+      std::placeholders::_1,
+      &this->allocator,
+      false,
+      std::placeholders::_2,
+      "/",
+      std::placeholders::_3);
+    service_func = std::bind(
+      rcl_get_service_names_and_types_by_node,
+      std::placeholders::_1,
+      &this->allocator,
+      std::placeholders::_2,
+      "/",
+      std::placeholders::_3);
+    client_func = std::bind(
+      rcl_get_client_names_and_types_by_node,
+      std::placeholders::_1,
+      &this->allocator,
+      std::placeholders::_2,
+      "/",
+      std::placeholders::_3);
     WaitForAllNodesAlive();
   }
 
@@ -896,7 +907,8 @@ public:
     rcl_ret_t ret;
     rcutils_string_array_t node_names = rcutils_get_zero_initialized_string_array();
     rcutils_string_array_t node_namespaces = rcutils_get_zero_initialized_string_array();
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       ret = rcutils_string_array_fini(&node_names);
       ASSERT_EQ(RCUTILS_RET_OK, ret);
       ret = rcutils_string_array_fini(&node_namespaces);
@@ -937,39 +949,49 @@ public:
       // verify each node contains the same node graph.
       for (auto node : node_vec) {
         RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Checking subscribers from node");
-        expect_topics_types(node, sub_func, node_state.subscribers,
+        expect_topics_types(
+          node, sub_func, node_state.subscribers,
           test_graph_node_name, is_expect, is_success);
         RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Checking services from node");
-        expect_topics_types(node, service_func, node_state.services,
+        expect_topics_types(
+          node, service_func, node_state.services,
           test_graph_node_name, is_expect, is_success);
         RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Checking clients from node");
-        expect_topics_types(node, client_func, node_state.clients,
+        expect_topics_types(
+          node, client_func, node_state.clients,
           test_graph_node_name, is_expect, is_success);
         RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Checking publishers from node");
-        expect_topics_types(node, pub_func, node_state.publishers,
+        expect_topics_types(
+          node, pub_func, node_state.publishers,
           test_graph_node_name, is_expect, is_success);
 
         RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Checking subscribers from remote node");
-        expect_topics_types(node, sub_func, remote_node_state.subscribers,
+        expect_topics_types(
+          node, sub_func, remote_node_state.subscribers,
           this->remote_node_name, is_expect, is_success);
         RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Checking publishers from remote node");
-        expect_topics_types(node, pub_func, remote_node_state.publishers,
+        expect_topics_types(
+          node, pub_func, remote_node_state.publishers,
           this->remote_node_name, is_expect, is_success);
         RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Checking services from remote node");
-        expect_topics_types(node, service_func, remote_node_state.services,
+        expect_topics_types(
+          node, service_func, remote_node_state.services,
           this->remote_node_name, is_expect, is_success);
         RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Checking clients from remote node");
-        expect_topics_types(node, client_func, remote_node_state.clients,
+        expect_topics_types(
+          node, client_func, remote_node_state.clients,
           this->remote_node_name, is_expect, is_success);
         if (!is_success) {
           ret = rcl_wait_set_clear(wait_set_ptr);
           ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
           ret =
-            rcl_wait_set_add_guard_condition(wait_set_ptr, rcl_node_get_graph_guard_condition(
-                node), NULL);
+            rcl_wait_set_add_guard_condition(
+            wait_set_ptr, rcl_node_get_graph_guard_condition(
+              node), NULL);
           ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
           std::chrono::nanoseconds time_to_sleep = std::chrono::milliseconds(400);
-          RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME,
+          RCUTILS_LOG_DEBUG_NAMED(
+            ROS_PACKAGE_NAME,
             "  state wrong, waiting up to '%s' nanoseconds for graph changes... ",
             std::to_string(time_to_sleep.count()).c_str());
           ret = rcl_wait(wait_set_ptr, time_to_sleep.count());
@@ -1217,7 +1239,8 @@ TEST_F(CLASSNAME(TestGraphFixture, RMW_IMPLEMENTATION), test_graph_guard_conditi
     ret = rcl_wait_set_add_guard_condition(this->wait_set_ptr, graph_guard_condition, NULL);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     std::chrono::nanoseconds time_to_sleep = std::chrono::milliseconds(400);
-    RCUTILS_LOG_INFO_NAMED(ROS_PACKAGE_NAME,
+    RCUTILS_LOG_INFO_NAMED(
+      ROS_PACKAGE_NAME,
       "waiting up to '%s' nanoseconds for graph changes",
       std::to_string(time_to_sleep.count()).c_str());
     ret = rcl_wait(this->wait_set_ptr, time_to_sleep.count());
@@ -1242,7 +1265,8 @@ TEST_F(CLASSNAME(TestGraphFixture, RMW_IMPLEMENTATION), test_rcl_service_server_
   rcl_client_options_t client_options = rcl_client_get_default_options();
   ret = rcl_client_init(&client, this->node_ptr, ts, service_name, &client_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_client_fini(&client, this->node_ptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -1274,7 +1298,8 @@ TEST_F(CLASSNAME(TestGraphFixture, RMW_IMPLEMENTATION), test_rcl_service_server_
         ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
         ret = rcl_wait_set_add_guard_condition(this->wait_set_ptr, graph_guard_condition, NULL);
         ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-        RCUTILS_LOG_INFO_NAMED(ROS_PACKAGE_NAME,
+        RCUTILS_LOG_INFO_NAMED(
+          ROS_PACKAGE_NAME,
           "waiting up to '%s' nanoseconds for graph changes",
           std::to_string(time_to_sleep.count()).c_str());
         ret = rcl_wait(this->wait_set_ptr, time_to_sleep.count());
@@ -1309,7 +1334,8 @@ TEST_F(CLASSNAME(TestGraphFixture, RMW_IMPLEMENTATION), test_rcl_service_server_
     rcl_service_options_t service_options = rcl_service_get_default_options();
     ret = rcl_service_init(&service, this->node_ptr, ts, service_name, &service_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       rcl_ret_t ret = rcl_service_fini(&service, this->node_ptr);
       EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     });

--- a/rcl/test/rcl/test_guard_condition.cpp
+++ b/rcl/test/rcl/test_guard_condition.cpp
@@ -66,7 +66,8 @@ TEST_F(
   rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
   ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     osrf_testing_tools_cpp::memory_tools::disable_monitoring_in_all_threads();
     ASSERT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options));
   });
@@ -74,7 +75,8 @@ TEST_F(
   ret = rcl_init(0, nullptr, &init_options, &context);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   // Setup automatic rcl_shutdown()
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     osrf_testing_tools_cpp::memory_tools::disable_monitoring_in_all_threads();
     ASSERT_EQ(RCL_RET_OK, rcl_shutdown(&context));
     ASSERT_EQ(RCL_RET_OK, rcl_context_fini(&context));
@@ -89,7 +91,8 @@ TEST_F(
   ret = rcl_guard_condition_init(&guard_condition, &context, default_options);
   ASSERT_EQ(RCL_RET_OK, ret);
   // Setup automatic finalization of guard condition.
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     osrf_testing_tools_cpp::memory_tools::disable_monitoring_in_all_threads();
     rcl_ret_t ret = rcl_guard_condition_fini(&guard_condition);
     EXPECT_EQ(RCL_RET_OK, ret);
@@ -103,7 +106,8 @@ TEST_F(
   actual_options = rcl_guard_condition_get_options(&zero_guard_condition);
   EXPECT_EQ(nullptr, actual_options);
   rcl_reset_error();
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     actual_options = rcl_guard_condition_get_options(&guard_condition);
   });
   EXPECT_NE(nullptr, actual_options);
@@ -118,7 +122,8 @@ TEST_F(
   gc_handle = rcl_guard_condition_get_rmw_handle(&zero_guard_condition);
   EXPECT_EQ(nullptr, gc_handle);
   rcl_reset_error();
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     gc_handle = rcl_guard_condition_get_rmw_handle(&guard_condition);
   });
   EXPECT_NE(nullptr, gc_handle);
@@ -141,13 +146,15 @@ TEST_F(
   rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
   ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     osrf_testing_tools_cpp::memory_tools::disable_monitoring_in_all_threads();
     ASSERT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options));
   });
   ret = rcl_init(0, nullptr, &init_options, &context);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ASSERT_EQ(RCL_RET_OK, rcl_shutdown(&context));
     ASSERT_EQ(RCL_RET_OK, rcl_context_fini(&context));
   });

--- a/rcl/test/rcl/test_info_by_topic.cpp
+++ b/rcl/test/rcl/test_info_by_topic.cpp
@@ -59,7 +59,8 @@ public:
     rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
     ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
     });
     this->old_context = rcl_get_zero_initialized_context();
@@ -114,9 +115,11 @@ public:
     EXPECT_EQ(qos_profile1.lifespan.nsec, qos_profile2.lifespan.nsec);
     EXPECT_EQ(qos_profile1.reliability, qos_profile2.reliability);
     EXPECT_EQ(qos_profile1.liveliness, qos_profile2.liveliness);
-    EXPECT_EQ(qos_profile1.liveliness_lease_duration.sec,
+    EXPECT_EQ(
+      qos_profile1.liveliness_lease_duration.sec,
       qos_profile2.liveliness_lease_duration.sec);
-    EXPECT_EQ(qos_profile1.liveliness_lease_duration.nsec,
+    EXPECT_EQ(
+      qos_profile1.liveliness_lease_duration.nsec,
       qos_profile2.liveliness_lease_duration.nsec);
     EXPECT_EQ(qos_profile1.durability, qos_profile2.durability);
   }
@@ -126,12 +129,14 @@ public:
  * This does not test content of the response.
  * It only tests if the return code is the one expected.
  */
-TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
+TEST_F(
+  CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
   test_rcl_get_publishers_info_by_topic_null_node)
 {
   rcl_allocator_t allocator = rcl_get_default_allocator();
-  const auto ret = rcl_get_publishers_info_by_topic(nullptr,
-      &allocator, this->topic_name, false, &this->topic_endpoint_info_array);
+  const auto ret = rcl_get_publishers_info_by_topic(
+    nullptr, &allocator, this->topic_name, false,
+    &this->topic_endpoint_info_array);
   EXPECT_EQ(RCL_RET_NODE_INVALID, ret);
 }
 
@@ -139,12 +144,14 @@ TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
  * This does not test content of the response.
  * It only tests if the return code is the one expected.
  */
-TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
+TEST_F(
+  CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
   test_rcl_get_subscriptions_info_by_topic_null_node)
 {
   rcl_allocator_t allocator = rcl_get_default_allocator();
-  const auto ret = rcl_get_subscriptions_info_by_topic(nullptr,
-      &allocator, this->topic_name, false, &this->topic_endpoint_info_array);
+  const auto ret = rcl_get_subscriptions_info_by_topic(
+    nullptr, &allocator, this->topic_name, false,
+    &this->topic_endpoint_info_array);
   EXPECT_EQ(RCL_RET_NODE_INVALID, ret);
 }
 
@@ -152,13 +159,15 @@ TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
  * This does not test content of the response.
  * It only tests if the return code is the one expected.
  */
-TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
+TEST_F(
+  CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
   test_rcl_get_publishers_info_by_topic_invalid_node)
 {
   // this->old_node is an invalid node.
   rcl_allocator_t allocator = rcl_get_default_allocator();
-  const auto ret = rcl_get_publishers_info_by_topic(&this->old_node,
-      &allocator, this->topic_name, false, &this->topic_endpoint_info_array);
+  const auto ret = rcl_get_publishers_info_by_topic(
+    &this->old_node, &allocator, this->topic_name, false,
+    &this->topic_endpoint_info_array);
   EXPECT_EQ(RCL_RET_NODE_INVALID, ret);
 }
 
@@ -166,13 +175,15 @@ TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
  * This does not test content of the response.
  * It only tests if the return code is the one expected.
  */
-TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
+TEST_F(
+  CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
   test_rcl_get_subscriptions_info_by_topic_invalid_node)
 {
   // this->old_node is an invalid node.
   rcl_allocator_t allocator = rcl_get_default_allocator();
-  const auto ret = rcl_get_subscriptions_info_by_topic(&this->old_node,
-      &allocator, this->topic_name, false, &this->topic_endpoint_info_array);
+  const auto ret = rcl_get_subscriptions_info_by_topic(
+    &this->old_node, &allocator, this->topic_name, false,
+    &this->topic_endpoint_info_array);
   EXPECT_EQ(RCL_RET_NODE_INVALID, ret);
 }
 
@@ -180,12 +191,13 @@ TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
  * This does not test content of the response.
  * It only tests if the return code is the one expected.
  */
-TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
+TEST_F(
+  CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
   test_rcl_get_publishers_info_by_topic_null_allocator)
 {
-  const auto ret = rcl_get_publishers_info_by_topic(&this->node, nullptr, this->topic_name,
-      false,
-      &this->topic_endpoint_info_array);
+  const auto ret = rcl_get_publishers_info_by_topic(
+    &this->node, nullptr, this->topic_name, false,
+    &this->topic_endpoint_info_array);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
 }
 
@@ -193,12 +205,13 @@ TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
  * This does not test content of the response.
  * It only tests if the return code is the one expected.
  */
-TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
+TEST_F(
+  CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
   test_rcl_get_subscriptions_info_by_topic_null_allocator)
 {
-  const auto ret = rcl_get_subscriptions_info_by_topic(&this->node, nullptr, this->topic_name,
-      false,
-      &this->topic_endpoint_info_array);
+  const auto ret = rcl_get_subscriptions_info_by_topic(
+    &this->node, nullptr, this->topic_name, false,
+    &this->topic_endpoint_info_array);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
 }
 
@@ -206,12 +219,13 @@ TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
  * This does not test content of the response.
  * It only tests if the return code is the one expected.
  */
-TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
+TEST_F(
+  CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
   test_rcl_get_publishers_info_by_topic_null_topic)
 {
   rcl_allocator_t allocator = rcl_get_default_allocator();
-  const auto ret = rcl_get_publishers_info_by_topic(&this->node,
-      &allocator, nullptr, false, &this->topic_endpoint_info_array);
+  const auto ret = rcl_get_publishers_info_by_topic(
+    &this->node, &allocator, nullptr, false, &this->topic_endpoint_info_array);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
 }
 
@@ -219,12 +233,13 @@ TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
  * This does not test content of the response.
  * It only tests if the return code is the one expected.
  */
-TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
+TEST_F(
+  CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
   test_rcl_get_subscriptions_info_by_topic_null_topic)
 {
   rcl_allocator_t allocator = rcl_get_default_allocator();
-  const auto ret = rcl_get_subscriptions_info_by_topic(&this->node,
-      &allocator, nullptr, false, &this->topic_endpoint_info_array);
+  const auto ret = rcl_get_subscriptions_info_by_topic(
+    &this->node, &allocator, nullptr, false, &this->topic_endpoint_info_array);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
 }
 
@@ -232,12 +247,13 @@ TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
  * This does not test content of the response.
  * It only tests if the return code is the one expected.
  */
-TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
+TEST_F(
+  CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
   test_rcl_get_publishers_info_by_topic_null_participants)
 {
   rcl_allocator_t allocator = rcl_get_default_allocator();
-  const auto ret = rcl_get_publishers_info_by_topic(&this->node,
-      &allocator, this->topic_name, false, nullptr);
+  const auto ret = rcl_get_publishers_info_by_topic(
+    &this->node, &allocator, this->topic_name, false, nullptr);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
 }
 
@@ -245,12 +261,13 @@ TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
  * This does not test content of the response.
  * It only tests if the return code is the one expected.
  */
-TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
+TEST_F(
+  CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
   test_rcl_get_subscriptions_info_by_topic_null_participants)
 {
   rcl_allocator_t allocator = rcl_get_default_allocator();
-  const auto ret = rcl_get_subscriptions_info_by_topic(&this->node,
-      &allocator, this->topic_name, false, nullptr);
+  const auto ret = rcl_get_subscriptions_info_by_topic(
+    &this->node, &allocator, this->topic_name, false, nullptr);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
 }
 
@@ -258,18 +275,21 @@ TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
  * This does not test content of the response.
  * It only tests if the return code is the one expected.
  */
-TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
+TEST_F(
+  CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
   test_rcl_get_publishers_info_by_topic_invalid_participants)
 {
   // topic_endpoint_info_array is invalid because it is expected to be zero initialized
   // and the info_array variable inside it is expected to be null.
   this->topic_endpoint_info_array.info_array = new rmw_topic_endpoint_info_t();
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     free(this->topic_endpoint_info_array.info_array);
   });
   rcl_allocator_t allocator = rcl_get_default_allocator();
-  const auto ret = rcl_get_publishers_info_by_topic(&this->node,
-      &allocator, this->topic_name, false, &this->topic_endpoint_info_array);
+  const auto ret = rcl_get_publishers_info_by_topic(
+    &this->node, &allocator, this->topic_name, false,
+    &this->topic_endpoint_info_array);
   EXPECT_EQ(RCL_RET_ERROR, ret);
 }
 
@@ -277,22 +297,26 @@ TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
  * This does not test content of the response.
  * It only tests if the return code is the one expected.
  */
-TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
+TEST_F(
+  CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
   test_rcl_get_subscriptions_info_by_topic_invalid_participants)
 {
   // topic_endpoint_info_array is invalid because it is expected to be zero initialized
   // and the info_array variable inside it is expected to be null.
   this->topic_endpoint_info_array.info_array = new rmw_topic_endpoint_info_t();
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     free(this->topic_endpoint_info_array.info_array);
   });
   rcl_allocator_t allocator = rcl_get_default_allocator();
-  const auto ret = rcl_get_subscriptions_info_by_topic(&this->node,
-      &allocator, this->topic_name, false, &this->topic_endpoint_info_array);
+  const auto ret = rcl_get_subscriptions_info_by_topic(
+    &this->node, &allocator, this->topic_name, false,
+    &this->topic_endpoint_info_array);
   EXPECT_EQ(RCL_RET_ERROR, ret);
 }
 
-TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
+TEST_F(
+  CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
   test_rcl_get_publishers_subscription_info_by_topic)
 {
   // This is implemented only in fastrtps currently.
@@ -338,8 +362,9 @@ TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
   // Get publishers info by topic
   rmw_topic_endpoint_info_array_t topic_endpoint_info_array_pub =
     rmw_get_zero_initialized_topic_endpoint_info_array();
-  ret = rcl_get_publishers_info_by_topic(&this->node,
-      &allocator, fqdn.c_str(), false, &topic_endpoint_info_array_pub);
+  ret = rcl_get_publishers_info_by_topic(
+    &this->node, &allocator, fqdn.c_str(), false,
+    &topic_endpoint_info_array_pub);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
   EXPECT_EQ(topic_endpoint_info_array_pub.count, 1u) << "Expected one publisher";
   rmw_topic_endpoint_info_t topic_endpoint_info_pub = topic_endpoint_info_array_pub.info_array[0];
@@ -350,8 +375,9 @@ TEST_F(CLASSNAME(TestInfoByTopicFixture, RMW_IMPLEMENTATION),
 
   rmw_topic_endpoint_info_array_t topic_endpoint_info_array_sub =
     rmw_get_zero_initialized_topic_endpoint_info_array();
-  ret = rcl_get_subscriptions_info_by_topic(&this->node,
-      &allocator, fqdn.c_str(), false, &topic_endpoint_info_array_sub);
+  ret = rcl_get_subscriptions_info_by_topic(
+    &this->node, &allocator, fqdn.c_str(), false,
+    &topic_endpoint_info_array_sub);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
   EXPECT_EQ(topic_endpoint_info_array_sub.count, 1u) << "Expected one subscription";
   rmw_topic_endpoint_info_t topic_endpoint_info_sub = topic_endpoint_info_array_sub.info_array[0];

--- a/rcl/test/rcl/test_init.cpp
+++ b/rcl/test/rcl/test_init.cpp
@@ -201,7 +201,8 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_init_and_shutdown
   ret = rcl_context_fini(&context);
   EXPECT_EQ(ret, RCL_RET_OK);
   context = rcl_get_zero_initialized_context();
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
   });
 }
@@ -224,7 +225,8 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_get_instance_id) 
   rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
   ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
   });
   {
@@ -235,7 +237,8 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_get_instance_id) 
   }
   // And it should be allocation free.
   uint64_t first_instance_id;
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     first_instance_id = rcl_context_get_instance_id(&context);
   });
   EXPECT_NE(0u, first_instance_id);

--- a/rcl/test/rcl/test_logging_rosout.cpp
+++ b/rcl/test/rcl/test_logging_rosout.cpp
@@ -32,15 +32,17 @@
 #endif
 
 #define EXPAND(x) x
-#define TEST_FIXTURE_P_RMW(test_fixture_name) CLASSNAME(test_fixture_name, \
-    RMW_IMPLEMENTATION)
+#define TEST_FIXTURE_P_RMW(test_fixture_name) CLASSNAME( \
+    test_fixture_name, RMW_IMPLEMENTATION)
 #define APPLY(macro, ...) EXPAND(macro(__VA_ARGS__))
 #define TEST_P_RMW(test_case_name, test_name) \
-  APPLY(TEST_P, \
-    CLASSNAME(test_case_name, RMW_IMPLEMENTATION), test_name)
+  APPLY( \
+    TEST_P, CLASSNAME(test_case_name, RMW_IMPLEMENTATION), test_name)
 #define INSTANTIATE_TEST_CASE_P_RMW(instance_name, test_case_name, ...) \
-  EXPAND(APPLY(INSTANTIATE_TEST_CASE_P, instance_name, \
-    CLASSNAME(test_case_name, RMW_IMPLEMENTATION), __VA_ARGS__))
+  EXPAND( \
+    APPLY( \
+      INSTANTIATE_TEST_CASE_P, instance_name, \
+      CLASSNAME(test_case_name, RMW_IMPLEMENTATION), __VA_ARGS__))
 
 struct TestParameters
 {
@@ -71,7 +73,8 @@ public:
     rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
     ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
     });
     this->context_ptr = new rcl_context_t;
@@ -137,7 +140,8 @@ wait_for_subscription_to_be_ready(
   rcl_ret_t ret =
     rcl_wait_set_init(&wait_set, 1, 0, 0, 0, 0, 0, context, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_wait_set_fini(&wait_set);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -188,7 +192,8 @@ get_parameters()
   /*
    * Test with enable(implicit) global rosout logs and enable node option of rosout.
    */
-  parameters.push_back({
+  parameters.push_back(
+  {
     0,
     nullptr,
     true,
@@ -198,7 +203,8 @@ get_parameters()
   /*
    * Test with enable(implicit) global rosout logs and disable node option of rosout.
    */
-  parameters.push_back({
+  parameters.push_back(
+  {
     0,
     nullptr,
     false,
@@ -208,7 +214,8 @@ get_parameters()
   /*
    * Test with enable(explicit) global rosout logs and enable node option of rosout.
    */
-  parameters.push_back({
+  parameters.push_back(
+  {
     s_argc,
     s_argv_enable_rosout,
     true,
@@ -218,7 +225,8 @@ get_parameters()
   /*
    * Test with enable(explicit) global rosout logs and disable node option of rosout.
    */
-  parameters.push_back({
+  parameters.push_back(
+  {
     s_argc,
     s_argv_enable_rosout,
     false,
@@ -228,7 +236,8 @@ get_parameters()
   /*
    * Test with disable global rosout logs and enable node option of rosout.
    */
-  parameters.push_back({
+  parameters.push_back(
+  {
     s_argc,
     s_argv_disable_rosout,
     true,
@@ -238,7 +247,8 @@ get_parameters()
   /*
    * Test with disable global rosout logs and disable node option of rosout.
    */
-  parameters.push_back({
+  parameters.push_back(
+  {
     s_argc,
     s_argv_disable_rosout,
     false,

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -90,7 +90,8 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
   ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
   });
   rcl_context_t invalid_context = rcl_get_zero_initialized_context();
@@ -115,20 +116,23 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
     // This is the normal check (not windows and windows if not opensplice)
     ASSERT_EQ(RCL_RET_OK, ret);
   }
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     osrf_testing_tools_cpp::memory_tools::disable_monitoring_in_all_threads();
     rcl_ret_t ret = rcl_node_fini(&invalid_node);
     EXPECT_EQ(RCL_RET_OK, ret);
   });
   ret = rcl_shutdown(&invalid_context);  // Shutdown to invalidate the node.
   ASSERT_EQ(RCL_RET_OK, ret);
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_context_fini(&invalid_context)) << rcl_get_error_string().str;
   });
   rcl_context_t context = rcl_get_zero_initialized_context();
   ret = rcl_init(0, nullptr, &init_options, &context);
   ASSERT_EQ(RCL_RET_OK, ret);
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     osrf_testing_tools_cpp::memory_tools::disable_monitoring_in_all_threads();
     ASSERT_EQ(RCL_RET_OK, rcl_shutdown(&context));
     ASSERT_EQ(RCL_RET_OK, rcl_context_fini(&context));
@@ -139,7 +143,8 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   rcl_node_t node = rcl_get_zero_initialized_node();
   ret = rcl_node_init(&node, name, namespace_, &context, &default_options);
   ASSERT_EQ(RCL_RET_OK, ret);
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     osrf_testing_tools_cpp::memory_tools::disable_monitoring_in_all_threads();
     rcl_ret_t ret = rcl_node_fini(&node);
     EXPECT_EQ(RCL_RET_OK, ret);
@@ -175,7 +180,8 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   actual_node_name = rcl_node_get_name(&invalid_node);
   EXPECT_STREQ(name, actual_node_name);
   rcl_reset_error();
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     actual_node_name = rcl_node_get_name(&node);
   });
   EXPECT_TRUE(actual_node_name ? true : false);
@@ -193,7 +199,8 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   actual_node_namespace = rcl_node_get_namespace(&invalid_node);
   EXPECT_STREQ(namespace_, actual_node_namespace);
   rcl_reset_error();
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     actual_node_namespace = rcl_node_get_namespace(&node);
   });
   EXPECT_STREQ(namespace_, actual_node_namespace);
@@ -208,7 +215,8 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   actual_fq_node_name = rcl_node_get_fully_qualified_name(&invalid_node);
   EXPECT_STREQ(fq_name, actual_fq_node_name);
   rcl_reset_error();
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     actual_fq_node_name = rcl_node_get_fully_qualified_name(&node);
   });
   EXPECT_STREQ(fq_name, actual_fq_node_name);
@@ -226,7 +234,8 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
     EXPECT_EQ("ns." + std::string(name), std::string(actual_node_logger_name));
   }
   rcl_reset_error();
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     actual_node_logger_name = rcl_node_get_logger_name(&node);
   });
   EXPECT_NE(actual_node_logger_name, nullptr);
@@ -248,7 +257,8 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
     EXPECT_EQ(default_options.domain_id, actual_options->domain_id);
   }
   rcl_reset_error();
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     actual_options = rcl_node_get_options(&node);
   });
   EXPECT_NE(nullptr, actual_options);
@@ -269,7 +279,8 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   ret = rcl_node_get_domain_id(&invalid_node, &actual_domain_id);
   EXPECT_EQ(RCL_RET_OK, ret);
   rcl_reset_error();
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     ret = rcl_node_get_domain_id(&node, &actual_domain_id);
   });
   EXPECT_EQ(RCL_RET_OK, ret);
@@ -288,7 +299,8 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   node_handle = rcl_node_get_rmw_handle(&invalid_node);
   EXPECT_NE(nullptr, node_handle);
   rcl_reset_error();
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     node_handle = rcl_node_get_rmw_handle(&node);
   });
   EXPECT_NE(nullptr, node_handle);
@@ -303,7 +315,8 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   instance_id = rcl_node_get_rcl_instance_id(&invalid_node);
   EXPECT_EQ(0u, instance_id);
   rcl_reset_error();
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     instance_id = rcl_node_get_rcl_instance_id(&node);
   });
   EXPECT_NE(0u, instance_id);
@@ -318,7 +331,8 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   graph_guard_condition = rcl_node_get_graph_guard_condition(&invalid_node);
   EXPECT_NE(nullptr, graph_guard_condition);
   rcl_reset_error();
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     graph_guard_condition = rcl_node_get_graph_guard_condition(&node);
   });
   EXPECT_NE(nullptr, graph_guard_condition);
@@ -342,12 +356,14 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_life_cycle)
   rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
   ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
   });
   ret = rcl_init(0, nullptr, &init_options, &context);
   ASSERT_EQ(RCL_RET_OK, ret);
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ASSERT_EQ(RCL_RET_OK, rcl_shutdown(&context));
     ASSERT_EQ(RCL_RET_OK, rcl_context_fini(&context));
   });
@@ -438,13 +454,15 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_name_restri
   rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
   ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
   });
   rcl_context_t context = rcl_get_zero_initialized_context();
   ret = rcl_init(0, nullptr, &init_options, &context);
   ASSERT_EQ(RCL_RET_OK, ret);
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ASSERT_EQ(RCL_RET_OK, rcl_shutdown(&context));
     ASSERT_EQ(RCL_RET_OK, rcl_context_fini(&context));
   });
@@ -504,13 +522,15 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_namespace_r
   rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
   ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
   });
   rcl_context_t context = rcl_get_zero_initialized_context();
   ret = rcl_init(0, nullptr, &init_options, &context);
   ASSERT_EQ(RCL_RET_OK, ret);
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ASSERT_EQ(RCL_RET_OK, rcl_shutdown(&context));
     ASSERT_EQ(RCL_RET_OK, rcl_context_fini(&context));
   });
@@ -608,13 +628,15 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_names) {
   rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
   ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
   });
   rcl_context_t context = rcl_get_zero_initialized_context();
   ret = rcl_init(0, nullptr, &init_options, &context);
   ASSERT_EQ(RCL_RET_OK, ret);
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ASSERT_EQ(RCL_RET_OK, rcl_shutdown(&context));
     ASSERT_EQ(RCL_RET_OK, rcl_context_fini(&context));
   });

--- a/rcl/test/rcl/test_publisher.cpp
+++ b/rcl/test/rcl/test_publisher.cpp
@@ -44,7 +44,8 @@ public:
       rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
       ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
       ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+      {
         EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
       });
       this->context_ptr = new rcl_context_t;
@@ -85,7 +86,8 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_nomin
   rcl_publisher_options_t publisher_options = rcl_publisher_get_default_options();
   ret = rcl_publisher_init(&publisher, this->node_ptr, ts, topic_name, &publisher_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_publisher_fini(&publisher, this->node_ptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -109,7 +111,8 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_nomin
   rcl_publisher_options_t publisher_options = rcl_publisher_get_default_options();
   ret = rcl_publisher_init(&publisher, this->node_ptr, ts, topic_name, &publisher_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_publisher_fini(&publisher, this->node_ptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -137,7 +140,8 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publishers_diff
   rcl_publisher_options_t publisher_options = rcl_publisher_get_default_options();
   ret = rcl_publisher_init(&publisher, this->node_ptr, ts_int, topic_name, &publisher_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_publisher_fini(&publisher, this->node_ptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -151,7 +155,8 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publishers_diff
   ret = rcl_publisher_init(
     &publisher_in_namespace, this->node_ptr, ts_string, topic_name, &publisher_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_publisher_fini(&publisher_in_namespace, this->node_ptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });

--- a/rcl/test/rcl/test_remap.cpp
+++ b/rcl/test/rcl/test_remap.cpp
@@ -431,8 +431,8 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), no_nodename_replacement)
   SCOPE_ARGS(global_arguments, "process_name");
 
   char * output = NULL;
-  ret = rcl_remap_node_name(NULL, &global_arguments, "NodeName", rcl_get_default_allocator(),
-      &output);
+  ret = rcl_remap_node_name(
+    NULL, &global_arguments, "NodeName", rcl_get_default_allocator(), &output);
   EXPECT_EQ(RCL_RET_OK, ret);
   EXPECT_EQ(NULL, output);
 }

--- a/rcl/test/rcl/test_security_directory.cpp
+++ b/rcl/test/rcl/test_security_directory.cpp
@@ -70,24 +70,28 @@ protected:
 
   void TearDown() final
   {
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       allocator.deallocate(root_path, allocator.state);
     });
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       allocator.deallocate(secure_root, allocator.state);
     });
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       allocator.deallocate(base_lookup_dir_fqn, allocator.state);
     });
   }
 
   void set_base_lookup_dir_fqn(const char * resource_dir, const char * resource_dir_name)
   {
-    base_lookup_dir_fqn = rcutils_join_path(resource_dir,
-        resource_dir_name, allocator);
+    base_lookup_dir_fqn = rcutils_join_path(
+      resource_dir, resource_dir_name, allocator);
     std::string putenv_input = ROS_SECURITY_ROOT_DIRECTORY_VAR_NAME "=";
     putenv_input += base_lookup_dir_fqn;
-    memcpy(g_envstring, putenv_input.c_str(),
+    memcpy(
+      g_envstring, putenv_input.c_str(),
       std::min(putenv_input.length(), sizeof(g_envstring) - 1));
     putenv_wrapper(g_envstring);
   }
@@ -99,17 +103,20 @@ protected:
 };
 
 TEST_F(TestGetSecureRoot, failureScenarios) {
-  ASSERT_EQ(rcl_get_secure_root(TEST_NODE_NAME, TEST_NODE_NAMESPACE, &allocator),
+  ASSERT_EQ(
+    rcl_get_secure_root(TEST_NODE_NAME, TEST_NODE_NAMESPACE, &allocator),
     (char *) NULL);
 
   putenv_wrapper(ROS_SECURITY_ROOT_DIRECTORY_VAR_NAME "=" TEST_RESOURCES_DIRECTORY);
 
   /* Security directory is set, but there's no matching directory */
   /// Wrong namespace
-  ASSERT_EQ(rcl_get_secure_root(TEST_NODE_NAME, "/some_other_namespace", &allocator),
+  ASSERT_EQ(
+    rcl_get_secure_root(TEST_NODE_NAME, "/some_other_namespace", &allocator),
     (char *) NULL);
   /// Wrong node name
-  ASSERT_EQ(rcl_get_secure_root("not_" TEST_NODE_NAME, TEST_NODE_NAMESPACE, &allocator),
+  ASSERT_EQ(
+    rcl_get_secure_root("not_" TEST_NODE_NAME, TEST_NODE_NAMESPACE, &allocator),
     (char *) NULL);
 }
 
@@ -126,7 +133,8 @@ TEST_F(TestGetSecureRoot, successScenarios_local_exactMatch) {
    */
   secure_root = rcl_get_secure_root(TEST_NODE_NAME, TEST_NODE_NAMESPACE, &allocator);
   std::string secure_root_str(secure_root);
-  ASSERT_STREQ(TEST_NODE_NAME,
+  ASSERT_STREQ(
+    TEST_NODE_NAME,
     secure_root_str.substr(secure_root_str.size() - (sizeof(TEST_NODE_NAME) - 1)).c_str());
 }
 
@@ -141,12 +149,12 @@ TEST_F(TestGetSecureRoot, successScenarios_local_prefixMatch) {
    * Root: ${CMAKE_BINARY_DIR}/tests/resources
    * Namespace: /test_security_directory
    * Node: dummy_node_and_some_suffix_added */
-  root_path = rcl_get_secure_root(TEST_NODE_NAME "_and_some_suffix_added",
-      TEST_NODE_NAMESPACE, &allocator);
+  root_path = rcl_get_secure_root(
+    TEST_NODE_NAME "_and_some_suffix_added", TEST_NODE_NAMESPACE, &allocator);
   ASSERT_STRNE(root_path, secure_root);
   putenv_wrapper(ROS_SECURITY_LOOKUP_TYPE_VAR_NAME "=MATCH_PREFIX");
-  root_path = rcl_get_secure_root(TEST_NODE_NAME "_and_some_suffix_added",
-      TEST_NODE_NAMESPACE, &allocator);
+  root_path = rcl_get_secure_root(
+    TEST_NODE_NAME "_and_some_suffix_added", TEST_NODE_NAMESPACE, &allocator);
   ASSERT_STREQ(root_path, secure_root);
 }
 
@@ -182,25 +190,26 @@ TEST_F(TestGetSecureRoot, successScenarios_root_prefixMatch) {
    * Root dir: ${CMAKE_BINARY_DIR}/tests/resources/test_security_directory
    * Namespace: /
    * Node: dummy_node_and_some_suffix_added */
-  root_path = rcl_get_secure_root(TEST_NODE_NAME "_and_some_suffix_added",
-      ROOT_NAMESPACE, &allocator);
+  root_path = rcl_get_secure_root(
+    TEST_NODE_NAME "_and_some_suffix_added", ROOT_NAMESPACE, &allocator);
   ASSERT_STREQ(root_path, secure_root);
 }
 
 TEST_F(TestGetSecureRoot, nodeSecurityDirectoryOverride_validDirectory) {
   /* Specify a valid directory */
   putenv_wrapper(ROS_SECURITY_NODE_DIRECTORY_VAR_NAME "=" TEST_RESOURCES_DIRECTORY);
-  root_path = rcl_get_secure_root("name shouldn't matter",
-      "namespace shouldn't matter", &allocator);
+  root_path = rcl_get_secure_root(
+    "name shouldn't matter", "namespace shouldn't matter", &allocator);
   ASSERT_STREQ(root_path, TEST_RESOURCES_DIRECTORY);
 }
 
-TEST_F(TestGetSecureRoot,
+TEST_F(
+  TestGetSecureRoot,
   nodeSecurityDirectoryOverride_validDirectory_overrideRootDirectoryAttempt) {
   /* Setting root dir has no effect */
   putenv_wrapper(ROS_SECURITY_NODE_DIRECTORY_VAR_NAME "=" TEST_RESOURCES_DIRECTORY);
-  root_path = rcl_get_secure_root("name shouldn't matter",
-      "namespace shouldn't matter", &allocator);
+  root_path = rcl_get_secure_root(
+    "name shouldn't matter", "namespace shouldn't matter", &allocator);
   putenv_wrapper(ROS_SECURITY_ROOT_DIRECTORY_VAR_NAME "=" TEST_RESOURCES_DIRECTORY);
   ASSERT_STREQ(root_path, TEST_RESOURCES_DIRECTORY);
 }
@@ -211,6 +220,7 @@ TEST_F(TestGetSecureRoot, nodeSecurityDirectoryOverride_invalidDirectory) {
   putenv_wrapper(
     ROS_SECURITY_NODE_DIRECTORY_VAR_NAME
     "=TheresN_oWayThi_sDirectory_Exists_hence_this_would_fail");
-  ASSERT_EQ(rcl_get_secure_root(TEST_NODE_NAME, TEST_NODE_NAMESPACE, &allocator),
+  ASSERT_EQ(
+    rcl_get_secure_root(TEST_NODE_NAME, TEST_NODE_NAMESPACE, &allocator),
     (char *) NULL);
 }

--- a/rcl/test/rcl/test_service.cpp
+++ b/rcl/test/rcl/test_service.cpp
@@ -46,7 +46,8 @@ public:
       rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
       ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
       ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+      {
         EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
       });
       this->context_ptr = new rcl_context_t;
@@ -87,7 +88,8 @@ wait_for_service_to_be_ready(
   rcl_ret_t ret =
     rcl_wait_set_init(&wait_set, 0, 0, 0, 0, 1, 0, context, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_wait_set_fini(&wait_set);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -147,7 +149,8 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_service_nominal) 
 
   // Check that the service name matches what we assigned.
   EXPECT_EQ(strcmp(rcl_service_get_service_name(&service), expected_topic), 0);
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_service_fini(&service, this->node_ptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -156,7 +159,8 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_service_nominal) 
   rcl_client_options_t client_options = rcl_client_get_default_options();
   ret = rcl_client_init(&client, this->node_ptr, ts, topic, &client_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_client_fini(&client, this->node_ptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -193,7 +197,8 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_service_nominal) 
     // Initialize a response.
     test_msgs__srv__BasicTypes_Response service_response;
     test_msgs__srv__BasicTypes_Response__init(&service_response);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       test_msgs__srv__BasicTypes_Response__fini(&service_response);
     });
 

--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -47,7 +47,8 @@ public:
       rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
       ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
       ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+      {
         EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
       });
       this->context_ptr = new rcl_context_t;
@@ -88,7 +89,8 @@ wait_for_subscription_to_be_ready(
   rcl_ret_t ret =
     rcl_wait_set_init(&wait_set, 1, 0, 0, 0, 0, 0, context, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_wait_set_fini(&wait_set);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -126,7 +128,8 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
   rcl_publisher_options_t publisher_options = rcl_publisher_get_default_options();
   ret = rcl_publisher_init(&publisher, this->node_ptr, ts, topic, &publisher_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_publisher_fini(&publisher, this->node_ptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -134,7 +137,8 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
   rcl_subscription_options_t subscription_options = rcl_subscription_get_default_options();
   ret = rcl_subscription_init(&subscription, this->node_ptr, ts, topic, &subscription_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_subscription_fini(&subscription, this->node_ptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -174,7 +178,8 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
   {
     test_msgs__msg__BasicTypes msg;
     test_msgs__msg__BasicTypes__init(&msg);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       test_msgs__msg__BasicTypes__fini(&msg);
     });
     ret = rcl_take(&subscription, &msg, nullptr, nullptr);
@@ -194,7 +199,8 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
   rcl_publisher_options_t publisher_options = rcl_publisher_get_default_options();
   ret = rcl_publisher_init(&publisher, this->node_ptr, ts, topic, &publisher_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_publisher_fini(&publisher, this->node_ptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -202,7 +208,8 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
   rcl_subscription_options_t subscription_options = rcl_subscription_get_default_options();
   ret = rcl_subscription_init(&subscription, this->node_ptr, ts, topic, &subscription_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_subscription_fini(&subscription, this->node_ptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -225,7 +232,8 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
   {
     test_msgs__msg__Strings msg;
     test_msgs__msg__Strings__init(&msg);
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       test_msgs__msg__Strings__fini(&msg);
     });
     ret = rcl_take(&subscription, &msg, nullptr, nullptr);

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -61,7 +61,8 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_ros_time_set_ove
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_ret_t retval = rcl_ros_clock_init(&ros_clock, &allocator);
   ASSERT_EQ(RCL_RET_OK, retval) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_ros_clock_fini(&ros_clock)) << rcl_get_error_string().str;
   });
 
@@ -85,7 +86,8 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_ros_time_set_ove
   ret = rcl_is_enabled_ros_time_override(&ros_clock, &is_enabled);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
   EXPECT_EQ(is_enabled, false);
-  EXPECT_NO_MEMORY_OPERATIONS({
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
     // Check for normal operation (not allowed to alloc).
     ret = rcl_clock_get_now(&ros_clock, &query_now);
   });
@@ -173,14 +175,16 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_init_for_clock_a
   rcl_clock_t source;
   ret = rcl_ros_clock_init(&source, &allocator);
   ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_ros_clock_fini(&source)) << rcl_get_error_string().str;
   });
 
   rcl_clock_t ros_clock;
   rcl_ret_t retval = rcl_ros_clock_init(&ros_clock, &allocator);
   ASSERT_EQ(retval, RCL_RET_OK) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_ros_clock_fini(&ros_clock)) << rcl_get_error_string().str;
   });
 }
@@ -189,7 +193,8 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_ros_clock_initially_
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_clock_t ros_clock;
   ASSERT_EQ(RCL_RET_OK, rcl_ros_clock_init(&ros_clock, &allocator)) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_clock_fini(&ros_clock)) << rcl_get_error_string().str;
   });
   ASSERT_EQ(RCL_RET_OK, rcl_enable_ros_time_override(&ros_clock)) << rcl_get_error_string().str;
@@ -207,7 +212,8 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), clock_validation) {
   rcl_ret_t ret;
   ret = rcl_ros_clock_init(&uninitialized, &allocator);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_ros_clock_fini(&uninitialized)) << rcl_get_error_string().str;
   });
 }
@@ -217,32 +223,37 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), default_clock_instanciation) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_ret_t retval = rcl_ros_clock_init(&ros_clock, &allocator);
   ASSERT_EQ(retval, RCL_RET_OK) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_ros_clock_fini(&ros_clock)) << rcl_get_error_string().str;
   });
   ASSERT_TRUE(rcl_clock_valid(&ros_clock));
 
   auto * steady_clock = static_cast<rcl_clock_t *>(
     allocator.zero_allocate(1, sizeof(rcl_clock_t), allocator.state));
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(steady_clock, allocator.state);
   });
 
   retval = rcl_steady_clock_init(steady_clock, &allocator);
   EXPECT_EQ(retval, RCL_RET_OK) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_steady_clock_fini(steady_clock)) << rcl_get_error_string().str;
   });
   ASSERT_TRUE(rcl_clock_valid(steady_clock));
 
   auto * system_clock = static_cast<rcl_clock_t *>(
     allocator.zero_allocate(1, sizeof(rcl_clock_t), allocator.state));
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(system_clock, allocator.state);
   });
   retval = rcl_system_clock_init(system_clock, &allocator);
   EXPECT_EQ(retval, RCL_RET_OK) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_system_clock_fini(system_clock)) << rcl_get_error_string().str;
   });
   ASSERT_TRUE(rcl_clock_valid(system_clock));
@@ -291,12 +302,14 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_difference) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   auto * ros_clock =
     static_cast<rcl_clock_t *>(allocator.allocate(sizeof(rcl_clock_t), allocator.state));
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(ros_clock, allocator.state);
   });
   rcl_ret_t retval = rcl_ros_clock_init(ros_clock, &allocator);
   ASSERT_EQ(retval, RCL_RET_OK) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_ros_clock_fini(ros_clock)) << rcl_get_error_string().str;
   });
   EXPECT_TRUE(ros_clock != nullptr);
@@ -326,12 +339,14 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_difference_signed) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   auto * ros_clock =
     static_cast<rcl_clock_t *>(allocator.allocate(sizeof(rcl_clock_t), allocator.state));
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(ros_clock, allocator.state);
   });
   rcl_ret_t retval = rcl_ros_clock_init(ros_clock, &allocator);
   ASSERT_EQ(retval, RCL_RET_OK) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_ros_clock_fini(ros_clock)) << rcl_get_error_string().str;
   });
 
@@ -407,12 +422,14 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_clock_change_callbacks) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   auto * ros_clock =
     static_cast<rcl_clock_t *>(allocator.allocate(sizeof(rcl_clock_t), allocator.state));
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(ros_clock, allocator.state);
   });
   rcl_ret_t retval = rcl_ros_clock_init(ros_clock, &allocator);
   ASSERT_EQ(retval, RCL_RET_OK) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_clock_fini(ros_clock));
   });
   rcl_time_point_value_t query_now;
@@ -424,7 +441,8 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_clock_change_callbacks) {
   threshold.on_clock_change = true;
   threshold.min_forward.nanoseconds = 0;
   threshold.min_backward.nanoseconds = 0;
-  ASSERT_EQ(RCL_RET_OK,
+  ASSERT_EQ(
+    RCL_RET_OK,
     rcl_clock_add_jump_callback(ros_clock, threshold, clock_callback, &time_jump)) <<
     rcl_get_error_string().str;
   reset_callback_triggers();
@@ -470,12 +488,14 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_forward_jump_callbacks) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   auto * ros_clock =
     static_cast<rcl_clock_t *>(allocator.allocate(sizeof(rcl_clock_t), allocator.state));
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(ros_clock, allocator.state);
   });
   rcl_ret_t retval = rcl_ros_clock_init(ros_clock, &allocator);
   ASSERT_EQ(retval, RCL_RET_OK) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_clock_fini(ros_clock));
   });
 
@@ -488,7 +508,8 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_forward_jump_callbacks) {
   threshold.on_clock_change = false;
   threshold.min_forward.nanoseconds = 1;
   threshold.min_backward.nanoseconds = 0;
-  ASSERT_EQ(RCL_RET_OK,
+  ASSERT_EQ(
+    RCL_RET_OK,
     rcl_clock_add_jump_callback(ros_clock, threshold, clock_callback, &time_jump)) <<
     rcl_get_error_string().str;
   reset_callback_triggers();
@@ -531,12 +552,14 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_backward_jump_callbacks) 
   rcl_allocator_t allocator = rcl_get_default_allocator();
   auto * ros_clock =
     static_cast<rcl_clock_t *>(allocator.allocate(sizeof(rcl_clock_t), allocator.state));
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(ros_clock, allocator.state);
   });
   rcl_ret_t retval = rcl_ros_clock_init(ros_clock, &allocator);
   ASSERT_EQ(retval, RCL_RET_OK) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_clock_fini(ros_clock));
   });
   rcl_ret_t ret;
@@ -548,7 +571,8 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_backward_jump_callbacks) 
   threshold.on_clock_change = false;
   threshold.min_forward.nanoseconds = 0;
   threshold.min_backward.nanoseconds = -1;
-  ASSERT_EQ(RCL_RET_OK,
+  ASSERT_EQ(
+    RCL_RET_OK,
     rcl_clock_add_jump_callback(ros_clock, threshold, clock_callback, &time_jump)) <<
     rcl_get_error_string().str;
   reset_callback_triggers();
@@ -591,12 +615,14 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_clock_add_jump_callback) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   auto * clock =
     static_cast<rcl_clock_t *>(allocator.allocate(sizeof(rcl_clock_t), allocator.state));
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(clock, allocator.state);
   });
   rcl_ret_t retval = rcl_ros_clock_init(clock, &allocator);
   ASSERT_EQ(RCL_RET_OK, retval) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_clock_fini(clock));
   });
 
@@ -627,12 +653,14 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_clock_remove_jump_callback) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   auto * clock =
     static_cast<rcl_clock_t *>(allocator.allocate(sizeof(rcl_clock_t), allocator.state));
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(clock, allocator.state);
   });
   rcl_ret_t retval = rcl_ros_clock_init(clock, &allocator);
   ASSERT_EQ(RCL_RET_OK, retval) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_clock_fini(clock));
   });
 
@@ -675,12 +703,14 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), add_remove_add_jump_callback) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   auto * clock =
     static_cast<rcl_clock_t *>(allocator.allocate(sizeof(rcl_clock_t), allocator.state));
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(clock, allocator.state);
   });
   rcl_ret_t retval = rcl_ros_clock_init(clock, &allocator);
   ASSERT_EQ(RCL_RET_OK, retval) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_clock_fini(clock));
   });
 

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -35,7 +35,8 @@ public:
       rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
       ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
       ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+      {
         EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
       });
       this->context_ptr = new rcl_context_t;
@@ -91,7 +92,8 @@ TEST_F(TestTimerFixture, test_two_timers) {
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   ret = rcl_wait_set_add_timer(&wait_set, &timer2, NULL);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_timer_fini(&timer);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     ret = rcl_timer_fini(&timer2);
@@ -147,7 +149,8 @@ TEST_F(TestTimerFixture, test_two_timers_ready_before_timeout) {
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   ret = rcl_wait_set_add_timer(&wait_set, &timer2, NULL);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_timer_fini(&timer);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     ret = rcl_timer_fini(&timer2);
@@ -197,7 +200,8 @@ TEST_F(TestTimerFixture, test_timer_not_ready) {
   ret = rcl_wait_set_add_timer(&wait_set, &timer, NULL);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_timer_fini(&timer);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     ret = rcl_wait_set_fini(&wait_set);
@@ -245,7 +249,8 @@ TEST_F(TestTimerFixture, test_canceled_timer) {
   ret = rcl_wait_set_add_timer(&wait_set, &timer, NULL);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_timer_fini(&timer);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     ret = rcl_wait_set_fini(&wait_set);
@@ -278,7 +283,8 @@ TEST_F(TestTimerFixture, test_rostime_time_until_next_call) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   ret = rcl_clock_init(RCL_ROS_TIME, &clock, &allocator);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_clock_fini(&clock)) << rcl_get_error_string().str;
   });
   ASSERT_EQ(RCL_RET_OK, rcl_enable_ros_time_override(&clock)) << rcl_get_error_string().str;
@@ -287,7 +293,8 @@ TEST_F(TestTimerFixture, test_rostime_time_until_next_call) {
   ret = rcl_timer_init(
     &timer, &clock, this->context_ptr, sec_5, nullptr, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_timer_fini(&timer)) << rcl_get_error_string().str;
   });
 
@@ -316,7 +323,8 @@ TEST_F(TestTimerFixture, test_system_time_to_ros_time) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   ret = rcl_clock_init(RCL_ROS_TIME, &clock, &allocator);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_clock_fini(&clock)) << rcl_get_error_string().str;
   });
 
@@ -324,7 +332,8 @@ TEST_F(TestTimerFixture, test_system_time_to_ros_time) {
   ret = rcl_timer_init(
     &timer, &clock, this->context_ptr, sec_5, nullptr, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_timer_fini(&timer)) << rcl_get_error_string().str;
   });
 
@@ -354,7 +363,8 @@ TEST_F(TestTimerFixture, test_ros_time_to_system_time) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   ret = rcl_clock_init(RCL_ROS_TIME, &clock, &allocator);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_clock_fini(&clock)) << rcl_get_error_string().str;
   });
 
@@ -365,7 +375,8 @@ TEST_F(TestTimerFixture, test_ros_time_to_system_time) {
   ret = rcl_timer_init(
     &timer, &clock, this->context_ptr, sec_5, nullptr, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_timer_fini(&timer)) << rcl_get_error_string().str;
   });
 
@@ -398,7 +409,8 @@ TEST_F(TestTimerFixture, test_ros_time_backwards_jump) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   ret = rcl_clock_init(RCL_ROS_TIME, &clock, &allocator);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_clock_fini(&clock)) << rcl_get_error_string().str;
   });
 
@@ -409,7 +421,8 @@ TEST_F(TestTimerFixture, test_ros_time_backwards_jump) {
   ret = rcl_timer_init(
     &timer, &clock, this->context_ptr, sec_5, nullptr, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_timer_fini(&timer)) << rcl_get_error_string().str;
   });
 
@@ -441,7 +454,8 @@ TEST_F(TestTimerFixture, test_ros_time_wakes_wait) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   ASSERT_EQ(RCL_RET_OK, rcl_clock_init(RCL_ROS_TIME, &clock, &allocator)) <<
     rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_clock_fini(&clock)) << rcl_get_error_string().str;
   });
   ASSERT_EQ(RCL_RET_OK, rcl_set_ros_time_override(&clock, sec_1)) << rcl_get_error_string().str;
@@ -451,7 +465,8 @@ TEST_F(TestTimerFixture, test_ros_time_wakes_wait) {
   ret = rcl_timer_init(
     &timer, &clock, this->context_ptr, sec_1, nullptr, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_timer_fini(&timer)) << rcl_get_error_string().str;
   });
 

--- a/rcl/test/rcl/test_wait.cpp
+++ b/rcl/test/rcl/test_wait.cpp
@@ -48,7 +48,8 @@ public:
     rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
     ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
     });
     this->context_ptr = new rcl_context_t;
@@ -131,7 +132,8 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), negative_timeout) {
   rcl_ret_t ret =
     rcl_wait_set_init(&wait_set, 0, 1, 1, 0, 0, 0, context_ptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ret = rcl_wait_set_fini(&wait_set);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -141,7 +143,8 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), negative_timeout) {
   ret = rcl_guard_condition_init(
     &guard_cond, this->context_ptr, rcl_guard_condition_get_default_options());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ret = rcl_guard_condition_fini(&guard_cond);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -151,7 +154,8 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), negative_timeout) {
   rcl_clock_t clock;
   rcl_allocator_t allocator = rcl_get_default_allocator();
   ret = rcl_clock_init(RCL_STEADY_TIME, &clock, &allocator);
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ret = rcl_clock_fini(&clock);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -161,7 +165,8 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), negative_timeout) {
   ret = rcl_timer_init(
     &timer, &clock, this->context_ptr, RCL_MS_TO_NS(10), nullptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ret = rcl_timer_fini(&timer);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -185,7 +190,8 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), zero_timeout) {
   rcl_ret_t ret =
     rcl_wait_set_init(&wait_set, 0, 1, 1, 0, 0, 0, context_ptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ret = rcl_wait_set_fini(&wait_set);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -195,7 +201,8 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), zero_timeout) {
   ret = rcl_guard_condition_init(
     &guard_cond, this->context_ptr, rcl_guard_condition_get_default_options());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ret = rcl_guard_condition_fini(&guard_cond);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -219,7 +226,8 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), zero_timeout_triggered
   rcl_ret_t ret =
     rcl_wait_set_init(&wait_set, 0, 1, 0, 0, 0, 0, context_ptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ret = rcl_wait_set_fini(&wait_set);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -228,7 +236,8 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), zero_timeout_triggered
   ret = rcl_guard_condition_init(
     &guard_cond, this->context_ptr, rcl_guard_condition_get_default_options());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ret = rcl_guard_condition_fini(&guard_cond);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -254,7 +263,8 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), canceled_timer) {
   rcl_ret_t ret =
     rcl_wait_set_init(&wait_set, 0, 1, 1, 0, 0, 0, context_ptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ret = rcl_wait_set_fini(&wait_set);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -264,7 +274,8 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), canceled_timer) {
   ret = rcl_guard_condition_init(
     &guard_cond, this->context_ptr, rcl_guard_condition_get_default_options());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ret = rcl_guard_condition_fini(&guard_cond);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -274,7 +285,8 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), canceled_timer) {
   rcl_clock_t clock;
   rcl_allocator_t allocator = rcl_get_default_allocator();
   ret = rcl_clock_init(RCL_STEADY_TIME, &clock, &allocator);
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ret = rcl_clock_fini(&clock);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -285,7 +297,8 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), canceled_timer) {
     &canceled_timer, &clock, this->context_ptr,
     RCL_MS_TO_NS(1), nullptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ret = rcl_timer_fini(&canceled_timer);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -311,7 +324,8 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), excess_capacity) {
   rcl_ret_t ret =
     rcl_wait_set_init(&wait_set, 42, 42, 42, 42, 42, 0, context_ptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ret = rcl_wait_set_fini(&wait_set);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -407,7 +421,8 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), multi_wait_set_threade
     test_set.thread_id = 0;
   }
   // Setup safe tear-down.
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     for (auto & test_set : test_sets) {
       rcl_ret_t ret = rcl_guard_condition_fini(&test_set.guard_condition);
       EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
@@ -460,7 +475,8 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), guard_condition) {
   rcl_ret_t ret =
     rcl_wait_set_init(&wait_set, 0, 1, 0, 0, 0, 0, context_ptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ret = rcl_wait_set_fini(&wait_set);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -468,7 +484,8 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), guard_condition) {
   ret = rcl_guard_condition_init(
     &guard_cond, this->context_ptr, rcl_guard_condition_get_default_options());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ret = rcl_guard_condition_fini(&guard_cond);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -509,7 +526,8 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), add_with_index) {
   rcl_ret_t ret = rcl_wait_set_init(
     &wait_set, 0, kNumEntities, 0, 0, 0, 0, context_ptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ret = rcl_wait_set_fini(&wait_set);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -523,7 +541,8 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), add_with_index) {
     ret = rcl_guard_condition_init(
       &guard_conditions[i], this->context_ptr, rcl_guard_condition_get_default_options());
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       ret = rcl_guard_condition_fini(&guard_conditions[i]);
       EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     });

--- a/rcl/test/test_namespace.cpp
+++ b/rcl/test/test_namespace.cpp
@@ -42,7 +42,8 @@ public:
       rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
       ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
       ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+      {
         EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
       });
       this->context_ptr = new rcl_context_t;
@@ -85,7 +86,8 @@ TEST_F(TestNamespaceFixture, test_client_server) {
   rcl_service_options_t service_options = rcl_service_get_default_options();
   ret = rcl_service_init(&service, this->node_ptr, ts, service_name, &service_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_service_fini(&service, this->node_ptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -95,7 +97,8 @@ TEST_F(TestNamespaceFixture, test_client_server) {
   ret = rcl_client_init(
     &unmatched_client, this->node_ptr, ts, unmatched_client_name, &unmatched_client_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_client_fini(&unmatched_client, this->node_ptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });
@@ -116,7 +119,8 @@ TEST_F(TestNamespaceFixture, test_client_server) {
   ret = rcl_client_init(
     &matched_client, this->node_ptr, ts, matched_client_name, &matched_client_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_client_fini(&matched_client, this->node_ptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   });

--- a/rcl_action/test/rcl_action/test_action_client.cpp
+++ b/rcl_action/test/rcl_action/test_action_client.cpp
@@ -32,7 +32,8 @@ protected:
       rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
       ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
       ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+      {
         EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
       });
       this->context = rcl_get_zero_initialized_context();

--- a/rcl_action/test/rcl_action/test_action_communication.cpp
+++ b/rcl_action/test/rcl_action/test_action_communication.cpp
@@ -43,7 +43,8 @@ protected:
     rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
     ret = rcl_init_options_init(&init_options, allocator);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
     });
     context = rcl_get_zero_initialized_context();
@@ -210,7 +211,8 @@ TEST_F(CLASSNAME(TestActionCommunication, RMW_IMPLEMENTATION), test_valid_goal_c
 
   // Check that the goal request was received correctly
   EXPECT_EQ(outgoing_goal_request.goal.order, incoming_goal_request.goal.order);
-  EXPECT_TRUE(uuidcmp(
+  EXPECT_TRUE(
+    uuidcmp(
       outgoing_goal_request.goal_id.uuid,
       incoming_goal_request.goal_id.uuid));
 
@@ -315,7 +317,8 @@ TEST_F(CLASSNAME(TestActionCommunication, RMW_IMPLEMENTATION), test_valid_cancel
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
 
   // Check that the cancel request was received correctly
-  EXPECT_TRUE(uuidcmp(
+  EXPECT_TRUE(
+    uuidcmp(
       outgoing_cancel_request.goal_info.goal_id.uuid,
       incoming_cancel_request.goal_info.goal_id.uuid));
   EXPECT_EQ(
@@ -326,7 +329,8 @@ TEST_F(CLASSNAME(TestActionCommunication, RMW_IMPLEMENTATION), test_valid_cancel
     incoming_cancel_request.goal_info.stamp.nanosec);
 
   // Initialize cancel request
-  ASSERT_TRUE(action_msgs__msg__GoalInfo__Sequence__init(
+  ASSERT_TRUE(
+    action_msgs__msg__GoalInfo__Sequence__init(
       &outgoing_cancel_response.goals_canceling, 2));
   init_test_uuid0(outgoing_cancel_response.goals_canceling.data[0].goal_id.uuid);
   outgoing_cancel_response.goals_canceling.data[0].stamp.sec = 102;
@@ -437,12 +441,14 @@ TEST_F(CLASSNAME(TestActionCommunication, RMW_IMPLEMENTATION), test_valid_result
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
 
   // Check that the result request was received correctly
-  EXPECT_TRUE(uuidcmp(
+  EXPECT_TRUE(
+    uuidcmp(
       outgoing_result_request.goal_id.uuid,
       incoming_result_request.goal_id.uuid));
 
   // Initialize result response
-  ASSERT_TRUE(rosidl_generator_c__int32__Sequence__init(
+  ASSERT_TRUE(
+    rosidl_generator_c__int32__Sequence__init(
       &outgoing_result_response.result.sequence, 4));
   outgoing_result_response.result.sequence.data[0] = 0;
   outgoing_result_response.result.sequence.data[1] = 1;
@@ -491,7 +497,8 @@ TEST_F(CLASSNAME(TestActionCommunication, RMW_IMPLEMENTATION), test_valid_result
   ASSERT_EQ(
     outgoing_result_response.result.sequence.size,
     incoming_result_response.result.sequence.size);
-  EXPECT_TRUE(!memcmp(
+  EXPECT_TRUE(
+    !memcmp(
       outgoing_result_response.result.sequence.data,
       incoming_result_response.result.sequence.data,
       outgoing_result_response.result.sequence.size));
@@ -585,7 +592,8 @@ TEST_F(CLASSNAME(TestActionCommunication, RMW_IMPLEMENTATION), test_valid_feedba
   test_msgs__action__Fibonacci_FeedbackMessage__init(&incoming_feedback);
 
   // Initialize feedback
-  ASSERT_TRUE(rosidl_generator_c__int32__Sequence__init(
+  ASSERT_TRUE(
+    rosidl_generator_c__int32__Sequence__init(
       &outgoing_feedback.feedback.sequence, 3));
   outgoing_feedback.feedback.sequence.data[0] = 0;
   outgoing_feedback.feedback.sequence.data[1] = 1;
@@ -624,11 +632,13 @@ TEST_F(CLASSNAME(TestActionCommunication, RMW_IMPLEMENTATION), test_valid_feedba
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
 
   // Check that feedback was received correctly
-  EXPECT_TRUE(uuidcmp(
+  EXPECT_TRUE(
+    uuidcmp(
       outgoing_feedback.goal_id.uuid,
       incoming_feedback.goal_id.uuid));
   ASSERT_EQ(outgoing_feedback.feedback.sequence.size, incoming_feedback.feedback.sequence.size);
-  EXPECT_TRUE(!memcmp(
+  EXPECT_TRUE(
+    !memcmp(
       outgoing_feedback.feedback.sequence.data,
       incoming_feedback.feedback.sequence.data,
       outgoing_feedback.feedback.sequence.size));
@@ -822,7 +832,8 @@ TEST_F(CLASSNAME(TestActionCommunication, RMW_IMPLEMENTATION), test_invalid_canc
   action_msgs__srv__CancelGoal_Response__init(&incoming_cancel_response);
 
   // Initialize cancel request
-  ASSERT_TRUE(action_msgs__msg__GoalInfo__Sequence__init(
+  ASSERT_TRUE(
+    action_msgs__msg__GoalInfo__Sequence__init(
       &outgoing_cancel_response.goals_canceling, 2));
   init_test_uuid0(outgoing_cancel_response.goals_canceling.data[0].goal_id.uuid);
   outgoing_cancel_response.goals_canceling.data[0].stamp.sec = 102;
@@ -940,7 +951,8 @@ TEST_F(CLASSNAME(TestActionCommunication, RMW_IMPLEMENTATION), test_invalid_resu
   test_msgs__action__Fibonacci_GetResult_Response__init(&incoming_result_response);
 
   // Initialize result response
-  ASSERT_TRUE(rosidl_generator_c__int32__Sequence__init(
+  ASSERT_TRUE(
+    rosidl_generator_c__int32__Sequence__init(
       &outgoing_result_response.result.sequence, 4));
   outgoing_result_response.result.sequence.data[0] = 0;
   outgoing_result_response.result.sequence.data[1] = 1;
@@ -1002,7 +1014,8 @@ TEST_F(CLASSNAME(TestActionCommunication, RMW_IMPLEMENTATION), test_invalid_feed
   test_msgs__action__Fibonacci_FeedbackMessage__init(&incoming_feedback);
 
   // Initialize feedback
-  ASSERT_TRUE(rosidl_generator_c__int32__Sequence__init(
+  ASSERT_TRUE(
+    rosidl_generator_c__int32__Sequence__init(
       &outgoing_feedback.feedback.sequence, 3));
   outgoing_feedback.feedback.sequence.data[0] = 0;
   outgoing_feedback.feedback.sequence.data[1] = 1;

--- a/rcl_action/test/rcl_action/test_action_interaction.cpp
+++ b/rcl_action/test/rcl_action/test_action_interaction.cpp
@@ -55,7 +55,8 @@ protected:
     rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
     ret = rcl_init_options_init(&init_options, allocator);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
     });
     context = rcl_get_zero_initialized_context();
@@ -244,7 +245,8 @@ TEST_F(CLASSNAME(TestActionClientServerInteraction, RMW_IMPLEMENTATION), test_in
 
   // Check that the goal request was received correctly
   EXPECT_EQ(this->outgoing_goal_request.goal.order, this->incoming_goal_request.goal.order);
-  EXPECT_TRUE(uuidcmp(
+  EXPECT_TRUE(
+    uuidcmp(
       this->outgoing_goal_request.goal_id.uuid,
       this->incoming_goal_request.goal_id.uuid));
 
@@ -304,7 +306,8 @@ TEST_F(CLASSNAME(TestActionClientServerInteraction, RMW_IMPLEMENTATION), test_in
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
 
   // Initialize feedback
-  ASSERT_TRUE(rosidl_generator_c__int32__Sequence__init(
+  ASSERT_TRUE(
+    rosidl_generator_c__int32__Sequence__init(
       &this->outgoing_feedback.feedback.sequence, 3));
   this->outgoing_feedback.feedback.sequence.data[0] = 0;
   this->outgoing_feedback.feedback.sequence.data[1] = 1;
@@ -346,13 +349,15 @@ TEST_F(CLASSNAME(TestActionClientServerInteraction, RMW_IMPLEMENTATION), test_in
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
 
   // Check that feedback was received correctly
-  EXPECT_TRUE(uuidcmp(
+  EXPECT_TRUE(
+    uuidcmp(
       this->outgoing_feedback.goal_id.uuid,
       this->incoming_feedback.goal_id.uuid));
   ASSERT_EQ(
     this->outgoing_feedback.feedback.sequence.size,
     this->incoming_feedback.feedback.sequence.size);
-  EXPECT_TRUE(!memcmp(
+  EXPECT_TRUE(
+    !memcmp(
       this->outgoing_feedback.feedback.sequence.data,
       this->incoming_feedback.feedback.sequence.data,
       this->outgoing_feedback.feedback.sequence.size));
@@ -386,12 +391,14 @@ TEST_F(CLASSNAME(TestActionClientServerInteraction, RMW_IMPLEMENTATION), test_in
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
 
   // Check that the result request was received correctly
-  EXPECT_TRUE(uuidcmp(
+  EXPECT_TRUE(
+    uuidcmp(
       this->outgoing_result_request.goal_id.uuid,
       this->incoming_result_request.goal_id.uuid));
 
   // Initialize result response
-  ASSERT_TRUE(rosidl_generator_c__int32__Sequence__init(
+  ASSERT_TRUE(
+    rosidl_generator_c__int32__Sequence__init(
       &this->outgoing_result_response.result.sequence, 4));
   this->outgoing_result_response.result.sequence.data[0] = 0;
   this->outgoing_result_response.result.sequence.data[1] = 1;
@@ -443,7 +450,8 @@ TEST_F(CLASSNAME(TestActionClientServerInteraction, RMW_IMPLEMENTATION), test_in
   ASSERT_EQ(
     this->outgoing_result_response.result.sequence.size,
     this->incoming_result_response.result.sequence.size);
-  EXPECT_TRUE(!memcmp(
+  EXPECT_TRUE(
+    !memcmp(
       this->outgoing_result_response.result.sequence.data,
       this->incoming_result_response.result.sequence.data,
       this->outgoing_result_response.result.sequence.size));
@@ -505,7 +513,8 @@ TEST_F(
 
   // Check that the goal request was received correctly
   EXPECT_EQ(this->outgoing_goal_request.goal.order, this->incoming_goal_request.goal.order);
-  EXPECT_TRUE(uuidcmp(
+  EXPECT_TRUE(
+    uuidcmp(
       this->outgoing_goal_request.goal_id.uuid,
       this->incoming_goal_request.goal_id.uuid));
 
@@ -565,7 +574,8 @@ TEST_F(
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
 
   // Initialize feedback
-  ASSERT_TRUE(rosidl_generator_c__int32__Sequence__init(
+  ASSERT_TRUE(
+    rosidl_generator_c__int32__Sequence__init(
       &this->outgoing_feedback.feedback.sequence, 3));
   this->outgoing_feedback.feedback.sequence.data[0] = 0;
   this->outgoing_feedback.feedback.sequence.data[1] = 1;
@@ -607,13 +617,15 @@ TEST_F(
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
 
   // Check that feedback was received correctly
-  EXPECT_TRUE(uuidcmp(
+  EXPECT_TRUE(
+    uuidcmp(
       this->outgoing_feedback.goal_id.uuid,
       this->incoming_feedback.goal_id.uuid));
   ASSERT_EQ(
     this->outgoing_feedback.feedback.sequence.size,
     this->incoming_feedback.feedback.sequence.size);
-  EXPECT_TRUE(!memcmp(
+  EXPECT_TRUE(
+    !memcmp(
       this->outgoing_feedback.feedback.sequence.data,
       this->incoming_feedback.feedback.sequence.data,
       this->outgoing_feedback.feedback.sequence.size));
@@ -647,12 +659,14 @@ TEST_F(
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
 
   // Check that the result request was received correctly
-  EXPECT_TRUE(uuidcmp(
+  EXPECT_TRUE(
+    uuidcmp(
       this->outgoing_result_request.goal_id.uuid,
       this->incoming_result_request.goal_id.uuid));
 
   // Initialize result response
-  ASSERT_TRUE(rosidl_generator_c__int32__Sequence__init(
+  ASSERT_TRUE(
+    rosidl_generator_c__int32__Sequence__init(
       &this->outgoing_result_response.result.sequence, 4));
   this->outgoing_result_response.result.sequence.data[0] = 0;
   this->outgoing_result_response.result.sequence.data[1] = 1;
@@ -699,7 +713,8 @@ TEST_F(
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
 
   // Check that the cancel request was received correctly
-  EXPECT_TRUE(uuidcmp(
+  EXPECT_TRUE(
+    uuidcmp(
       outgoing_cancel_request.goal_info.goal_id.uuid,
       incoming_cancel_request.goal_info.goal_id.uuid));
   EXPECT_EQ(
@@ -808,7 +823,8 @@ TEST_F(
   ASSERT_EQ(
     this->outgoing_result_response.result.sequence.size,
     this->incoming_result_response.result.sequence.size);
-  EXPECT_TRUE(!memcmp(
+  EXPECT_TRUE(
+    !memcmp(
       this->outgoing_result_response.result.sequence.data,
       this->incoming_result_response.result.sequence.data,
       this->outgoing_result_response.result.sequence.size));

--- a/rcl_action/test/rcl_action/test_action_server.cpp
+++ b/rcl_action/test/rcl_action/test_action_server.cpp
@@ -166,7 +166,8 @@ protected:
     rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
     ret = rcl_init_options_init(&init_options, allocator);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
     });
     context = rcl_get_zero_initialized_context();

--- a/rcl_action/test/rcl_action/test_graph.cpp
+++ b/rcl_action/test/rcl_action/test_graph.cpp
@@ -59,7 +59,8 @@ public:
     rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
     ret = rcl_init_options_init(&init_options, this->allocator);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
     });
     this->old_context = rcl_get_zero_initialized_context();
@@ -244,8 +245,9 @@ TEST_F(
 /**
  * Type define a get actions function.
  */
-typedef std::function<rcl_ret_t(const rcl_node_t *,
-    rcl_names_and_types_t *)> GetActionsFunc;
+typedef std::function<
+    rcl_ret_t(const rcl_node_t *, rcl_names_and_types_t *)
+> GetActionsFunc;
 
 /**
  * Extend the TestActionGraphFixture with a multi-node fixture for node discovery and node-graph
@@ -268,7 +270,8 @@ public:
     rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
     ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) <<
         rcl_get_error_string().str;
     });
@@ -283,22 +286,25 @@ public:
       &this->remote_node, this->remote_node_name, "", &this->remote_context, &node_options);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
-    action_func = std::bind(rcl_action_get_names_and_types,
-        std::placeholders::_1,
-        &this->allocator,
-        std::placeholders::_2);
-    clients_by_node_func = std::bind(rcl_action_get_client_names_and_types_by_node,
-        std::placeholders::_1,
-        &this->allocator,
-        this->remote_node_name,
-        "",
-        std::placeholders::_2);
-    servers_by_node_func = std::bind(rcl_action_get_server_names_and_types_by_node,
-        std::placeholders::_1,
-        &this->allocator,
-        this->remote_node_name,
-        "",
-        std::placeholders::_2);
+    action_func = std::bind(
+      rcl_action_get_names_and_types,
+      std::placeholders::_1,
+      &this->allocator,
+      std::placeholders::_2);
+    clients_by_node_func = std::bind(
+      rcl_action_get_client_names_and_types_by_node,
+      std::placeholders::_1,
+      &this->allocator,
+      this->remote_node_name,
+      "",
+      std::placeholders::_2);
+    servers_by_node_func = std::bind(
+      rcl_action_get_server_names_and_types_by_node,
+      std::placeholders::_1,
+      &this->allocator,
+      this->remote_node_name,
+      "",
+      std::placeholders::_2);
     WaitForAllNodesAlive();
   }
 
@@ -321,7 +327,8 @@ public:
     rcl_ret_t ret;
     rcutils_string_array_t node_names = rcutils_get_zero_initialized_string_array();
     rcutils_string_array_t node_namespaces = rcutils_get_zero_initialized_string_array();
-    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+    OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+    {
       ret = rcutils_string_array_fini(&node_names);
       ASSERT_EQ(RCUTILS_RET_OK, ret);
       ret = rcutils_string_array_fini(&node_namespaces);
@@ -379,7 +386,8 @@ TEST_F(TestActionGraphMultiNodeFixture, test_action_get_names_and_types) {
     client_action_name,
     &action_client_options);
   ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_action_client_fini(&action_client, &this->remote_node)) <<
       rcl_get_error_string().str;
   });
@@ -403,7 +411,8 @@ TEST_F(TestActionGraphMultiNodeFixture, test_action_get_names_and_types) {
   rcl_clock_t clock;
   ret = rcl_clock_init(RCL_STEADY_TIME, &clock, &this->allocator);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_clock_fini(&clock)) << rcl_get_error_string().str;
   });
   const char * server_action_name = "/test_action_get_names_and_types_server_action_name";
@@ -416,7 +425,8 @@ TEST_F(TestActionGraphMultiNodeFixture, test_action_get_names_and_types) {
     server_action_name,
     &action_server_options);
   ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_action_server_fini(&action_server, &this->remote_node)) <<
       rcl_get_error_string().str;
   });
@@ -452,7 +462,8 @@ TEST_F(TestActionGraphMultiNodeFixture, test_action_get_server_names_and_types_b
     this->action_name,
     &action_client_options);
   ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_action_client_fini(&action_client, &this->remote_node)) <<
       rcl_get_error_string().str;
   });
@@ -471,7 +482,8 @@ TEST_F(TestActionGraphMultiNodeFixture, test_action_get_server_names_and_types_b
   rcl_clock_t clock;
   ret = rcl_clock_init(RCL_STEADY_TIME, &clock, &this->allocator);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_clock_fini(&clock)) << rcl_get_error_string().str;
   });
   rcl_action_server_options_t action_server_options = rcl_action_server_get_default_options();
@@ -483,7 +495,8 @@ TEST_F(TestActionGraphMultiNodeFixture, test_action_get_server_names_and_types_b
     this->action_name,
     &action_server_options);
   ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_action_server_fini(&action_server, &this->remote_node)) <<
       rcl_get_error_string().str;
   });
@@ -510,7 +523,8 @@ TEST_F(TestActionGraphMultiNodeFixture, test_action_get_client_names_and_types_b
   rcl_clock_t clock;
   ret = rcl_clock_init(RCL_STEADY_TIME, &clock, &this->allocator);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_clock_fini(&clock)) << rcl_get_error_string().str;
   });
   rcl_action_server_options_t action_server_options = rcl_action_server_get_default_options();
@@ -522,7 +536,8 @@ TEST_F(TestActionGraphMultiNodeFixture, test_action_get_client_names_and_types_b
     this->action_name,
     &action_server_options);
   ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_action_server_fini(&action_server, &this->remote_node)) <<
       rcl_get_error_string().str;
   });
@@ -547,7 +562,8 @@ TEST_F(TestActionGraphMultiNodeFixture, test_action_get_client_names_and_types_b
     this->action_name,
     &action_client_options);
   ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     EXPECT_EQ(RCL_RET_OK, rcl_action_client_fini(&action_client, &this->remote_node)) <<
       rcl_get_error_string().str;
   });

--- a/rcl_lifecycle/test/test_default_state_machine.cpp
+++ b/rcl_lifecycle/test/test_default_state_machine.cpp
@@ -45,7 +45,8 @@ public:
       rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
       ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
       ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+      {
         EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
       });
       this->context_ptr = new rcl_context_t;
@@ -186,7 +187,8 @@ TEST_F(TestDefaultStateMachine, default_sequence) {
     lifecycle_msgs__msg__State__TRANSITION_STATE_SHUTTINGDOWN,
     lifecycle_msgs__msg__State__PRIMARY_STATE_FINALIZED);
 
-  EXPECT_EQ(RCL_RET_OK,
+  EXPECT_EQ(
+    RCL_RET_OK,
     rcl_lifecycle_state_machine_fini(&state_machine, this->node_ptr, this->allocator));
 }
 
@@ -253,7 +255,8 @@ TEST_F(TestDefaultStateMachine, wrong_default_sequence) {
 
       EXPECT_EQ(RCL_RET_ERROR, rcl_lifecycle_trigger_transition_by_id(&state_machine, *it, false));
       rcl_reset_error();
-      EXPECT_EQ(state_machine.current_state->id,
+      EXPECT_EQ(
+        state_machine.current_state->id,
         lifecycle_msgs__msg__State__TRANSITION_STATE_CONFIGURING);
     }
   }
@@ -273,7 +276,8 @@ TEST_F(TestDefaultStateMachine, wrong_default_sequence) {
       RCUTILS_LOG_INFO_NAMED(ROS_PACKAGE_NAME, "applying key %u", *it);
       EXPECT_EQ(RCL_RET_ERROR, rcl_lifecycle_trigger_transition_by_id(&state_machine, *it, false));
       rcl_reset_error();
-      EXPECT_EQ(state_machine.current_state->id,
+      EXPECT_EQ(
+        state_machine.current_state->id,
         lifecycle_msgs__msg__State__PRIMARY_STATE_INACTIVE);
     }
   }
@@ -292,7 +296,8 @@ TEST_F(TestDefaultStateMachine, wrong_default_sequence) {
 
       EXPECT_EQ(RCL_RET_ERROR, rcl_lifecycle_trigger_transition_by_id(&state_machine, *it, false));
       rcl_reset_error();
-      EXPECT_EQ(state_machine.current_state->id,
+      EXPECT_EQ(
+        state_machine.current_state->id,
         lifecycle_msgs__msg__State__TRANSITION_STATE_ACTIVATING);
     }
   }
@@ -311,7 +316,8 @@ TEST_F(TestDefaultStateMachine, wrong_default_sequence) {
 
       EXPECT_EQ(RCL_RET_ERROR, rcl_lifecycle_trigger_transition_by_id(&state_machine, *it, false));
       rcl_reset_error();
-      EXPECT_EQ(state_machine.current_state->id,
+      EXPECT_EQ(
+        state_machine.current_state->id,
         lifecycle_msgs__msg__State__PRIMARY_STATE_ACTIVE);
     }
   }
@@ -330,7 +336,8 @@ TEST_F(TestDefaultStateMachine, wrong_default_sequence) {
 
       EXPECT_EQ(RCL_RET_ERROR, rcl_lifecycle_trigger_transition_by_id(&state_machine, *it, false));
       rcl_reset_error();
-      EXPECT_EQ(state_machine.current_state->id,
+      EXPECT_EQ(
+        state_machine.current_state->id,
         lifecycle_msgs__msg__State__TRANSITION_STATE_DEACTIVATING);
     }
   }
@@ -355,7 +362,8 @@ TEST_F(TestDefaultStateMachine, wrong_default_sequence) {
 
       EXPECT_EQ(RCL_RET_ERROR, rcl_lifecycle_trigger_transition_by_id(&state_machine, *it, false));
       rcl_reset_error();
-      EXPECT_EQ(state_machine.current_state->id,
+      EXPECT_EQ(
+        state_machine.current_state->id,
         lifecycle_msgs__msg__State__TRANSITION_STATE_CLEANINGUP);
     }
   }
@@ -380,7 +388,8 @@ TEST_F(TestDefaultStateMachine, wrong_default_sequence) {
 
       EXPECT_EQ(RCL_RET_ERROR, rcl_lifecycle_trigger_transition_by_id(&state_machine, *it, false));
       rcl_reset_error();
-      EXPECT_EQ(state_machine.current_state->id,
+      EXPECT_EQ(
+        state_machine.current_state->id,
         lifecycle_msgs__msg__State__TRANSITION_STATE_SHUTTINGDOWN);
     }
   }
@@ -395,12 +404,14 @@ TEST_F(TestDefaultStateMachine, wrong_default_sequence) {
     for (auto it = transition_ids.begin(); it != transition_ids.end(); ++it) {
       EXPECT_EQ(RCL_RET_ERROR, rcl_lifecycle_trigger_transition_by_id(&state_machine, *it, false));
       rcl_reset_error();
-      EXPECT_EQ(state_machine.current_state->id,
+      EXPECT_EQ(
+        state_machine.current_state->id,
         lifecycle_msgs__msg__State__PRIMARY_STATE_FINALIZED);
     }
   }
 
-  EXPECT_EQ(RCL_RET_OK,
+  EXPECT_EQ(
+    RCL_RET_OK,
     rcl_lifecycle_state_machine_fini(&state_machine, this->node_ptr, this->allocator));
 }
 
@@ -473,7 +484,8 @@ TEST_F(TestDefaultStateMachine, default_in_a_loop) {
     lifecycle_msgs__msg__State__TRANSITION_STATE_SHUTTINGDOWN,
     lifecycle_msgs__msg__State__PRIMARY_STATE_FINALIZED);
 
-  EXPECT_EQ(RCL_RET_OK,
+  EXPECT_EQ(
+    RCL_RET_OK,
     rcl_lifecycle_state_machine_fini(&state_machine, this->node_ptr, this->allocator));
 }
 
@@ -589,7 +601,8 @@ TEST_F(TestDefaultStateMachine, default_sequence_failure) {
     lifecycle_msgs__msg__State__TRANSITION_STATE_SHUTTINGDOWN,
     lifecycle_msgs__msg__State__PRIMARY_STATE_FINALIZED);
 
-  EXPECT_EQ(RCL_RET_OK,
+  EXPECT_EQ(
+    RCL_RET_OK,
     rcl_lifecycle_state_machine_fini(&state_machine, this->node_ptr, this->allocator));
 }
 
@@ -736,7 +749,8 @@ TEST_F(TestDefaultStateMachine, default_sequence_error_resolved) {
     lifecycle_msgs__msg__State__TRANSITION_STATE_ERRORPROCESSING,
     lifecycle_msgs__msg__State__PRIMARY_STATE_UNCONFIGURED);
 
-  EXPECT_EQ(RCL_RET_OK,
+  EXPECT_EQ(
+    RCL_RET_OK,
     rcl_lifecycle_state_machine_fini(&state_machine, this->node_ptr, this->allocator));
 }
 
@@ -767,7 +781,8 @@ TEST_F(TestDefaultStateMachine, default_sequence_error_unresolved) {
       lifecycle_msgs__msg__State__TRANSITION_STATE_ERRORPROCESSING,
       lifecycle_msgs__msg__State__PRIMARY_STATE_FINALIZED);
 
-    EXPECT_EQ(RCL_RET_OK,
+    EXPECT_EQ(
+      RCL_RET_OK,
       rcl_lifecycle_state_machine_fini(&state_machine, this->node_ptr, this->allocator));
   }
 
@@ -807,7 +822,8 @@ TEST_F(TestDefaultStateMachine, default_sequence_error_unresolved) {
       lifecycle_msgs__msg__State__TRANSITION_STATE_ERRORPROCESSING,
       lifecycle_msgs__msg__State__PRIMARY_STATE_FINALIZED);
 
-    EXPECT_EQ(RCL_RET_OK,
+    EXPECT_EQ(
+      RCL_RET_OK,
       rcl_lifecycle_state_machine_fini(&state_machine, this->node_ptr, this->allocator));
   }
 }

--- a/rcl_lifecycle/test/test_multiple_instances.cpp
+++ b/rcl_lifecycle/test/test_multiple_instances.cpp
@@ -43,7 +43,8 @@ public:
       rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
       ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
       ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+      OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+      {
         EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
       });
       this->context_ptr = new rcl_context_t;

--- a/rcl_yaml_param_parser/src/parser.c
+++ b/rcl_yaml_param_parser/src/parser.c
@@ -791,7 +791,8 @@ void rcl_yaml_node_struct_print(
               printf(": ");
               for (size_t i = 0; i < param_var->bool_array_value->size; i++) {
                 if (param_var->bool_array_value->values) {
-                  printf("%s, ",
+                  printf(
+                    "%s, ",
                     (param_var->bool_array_value->values[i]) ? "true" : "false");
                 }
               }
@@ -951,8 +952,9 @@ static rcutils_ret_t add_val_to_string_arr(
     val_array->data[0U] = value;
   } else {
     /// Increase the array size by one and add the new value
-    val_array->data = allocator.reallocate(val_array->data,
-        ((val_array->size + 1U) * sizeof(char *)), allocator.state);
+    val_array->data = allocator.reallocate(
+      val_array->data,
+      ((val_array->size + 1U) * sizeof(char *)), allocator.state);
     if (NULL == val_array->data) {
       RCUTILS_SAFE_FWRITE_TO_STDERR("Error allocating mem");
       return RCUTILS_RET_BAD_ALLOC;
@@ -1370,8 +1372,9 @@ static rcutils_ret_t parse_key(
             ret = RCUTILS_RET_ERROR;
             break;
           }
-          ret = replace_ns(ns_tracker, parameter_ns, (ns_tracker->num_parameter_ns + 1U),
-              NS_TYPE_PARAM, allocator);
+          ret = replace_ns(
+            ns_tracker, parameter_ns, (ns_tracker->num_parameter_ns + 1U),
+            NS_TYPE_PARAM, allocator);
           if (RCUTILS_RET_OK != ret) {
             RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
               "Internal error replacing namespace at line %d", line_num);

--- a/rcl_yaml_param_parser/test/test_parse_yaml.cpp
+++ b/rcl_yaml_param_parser/test/test_parse_yaml.cpp
@@ -31,18 +31,21 @@ TEST(test_parser, correct_syntax) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   char * test_path = rcutils_join_path(cur_dir, "test", allocator);
   ASSERT_TRUE(NULL != test_path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(test_path, allocator.state);
   });
   char * path = rcutils_join_path(test_path, "correct_config.yaml", allocator);
   ASSERT_TRUE(NULL != path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(path, allocator.state);
   });
   ASSERT_TRUE(rcutils_exists(path)) << "No test YAML file found at " << path;
   rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
   ASSERT_TRUE(NULL != params_hdl) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_yaml_node_struct_fini(params_hdl);
   });
   bool res = rcl_parse_yaml_file(path, params_hdl);
@@ -50,7 +53,8 @@ TEST(test_parser, correct_syntax) {
 
   char * another_path = rcutils_join_path(test_path, "overlay.yaml", allocator);
   ASSERT_TRUE(NULL != another_path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(another_path, allocator.state);
   });
   ASSERT_TRUE(rcutils_exists(another_path)) << "No test YAML file found at " << another_path;
@@ -59,7 +63,8 @@ TEST(test_parser, correct_syntax) {
 
   rcl_params_t * copy_of_params_hdl = rcl_yaml_node_struct_copy(params_hdl);
   ASSERT_TRUE(NULL != copy_of_params_hdl) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_yaml_node_struct_fini(copy_of_params_hdl);
   });
 
@@ -189,18 +194,21 @@ TEST(test_file_parser, string_array_with_quoted_number) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   char * test_path = rcutils_join_path(cur_dir, "test", allocator);
   ASSERT_TRUE(NULL != test_path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(test_path, allocator.state);
   });
   char * path = rcutils_join_path(test_path, "string_array_with_quoted_number.yaml", allocator);
   ASSERT_TRUE(NULL != path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(path, allocator.state);
   });
   ASSERT_TRUE(rcutils_exists(path)) << "No test YAML file found at " << path;
   rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
   ASSERT_TRUE(NULL != params_hdl) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_yaml_node_struct_fini(params_hdl);
   });
   bool res = rcl_parse_yaml_file(path, params_hdl);
@@ -227,18 +235,21 @@ TEST(test_file_parser, multi_ns_correct_syntax) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   char * test_path = rcutils_join_path(cur_dir, "test", allocator);
   ASSERT_TRUE(NULL != test_path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(test_path, allocator.state);
   });
   char * path = rcutils_join_path(test_path, "multi_ns_correct.yaml", allocator);
   ASSERT_TRUE(NULL != path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(path, allocator.state);
   });
   ASSERT_TRUE(rcutils_exists(path)) << "No test YAML file found at " << path;
   rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
   ASSERT_TRUE(NULL != params_hdl) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_yaml_node_struct_fini(params_hdl);
   });
   bool res = rcl_parse_yaml_file(path, params_hdl);
@@ -252,18 +263,21 @@ TEST(test_file_parser, root_ns) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   char * test_path = rcutils_join_path(cur_dir, "test", allocator);
   ASSERT_TRUE(NULL != test_path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(test_path, allocator.state);
   });
   char * path = rcutils_join_path(test_path, "root_ns.yaml", allocator);
   ASSERT_TRUE(NULL != path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(path, allocator.state);
   });
   ASSERT_TRUE(rcutils_exists(path)) << "No test YAML file found at " << path;
   rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
   ASSERT_TRUE(NULL != params_hdl) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_yaml_node_struct_fini(params_hdl);
   });
   bool res = rcl_parse_yaml_file(path, params_hdl);
@@ -281,12 +295,14 @@ TEST(test_file_parser, seq_map1) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   char * test_path = rcutils_join_path(cur_dir, "test", allocator);
   ASSERT_TRUE(NULL != test_path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(test_path, allocator.state);
   });
   char * path = rcutils_join_path(test_path, "seq_map1.yaml", allocator);
   ASSERT_TRUE(NULL != path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(path, allocator.state);
   });
   ASSERT_TRUE(rcutils_exists(path)) << "No test YAML file found at " << path;
@@ -303,12 +319,14 @@ TEST(test_file_parser, seq_map2) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   char * test_path = rcutils_join_path(cur_dir, "test", allocator);
   ASSERT_TRUE(NULL != test_path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(test_path, allocator.state);
   });
   char * path = rcutils_join_path(test_path, "seq_map2.yaml", allocator);
   ASSERT_TRUE(NULL != path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(path, allocator.state);
   });
   ASSERT_TRUE(rcutils_exists(path)) << "No test YAML file found at " << path;
@@ -325,12 +343,14 @@ TEST(test_file_parser, params_with_no_node) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   char * test_path = rcutils_join_path(cur_dir, "test", allocator);
   ASSERT_TRUE(NULL != test_path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(test_path, allocator.state);
   });
   char * path = rcutils_join_path(test_path, "params_with_no_node.yaml", allocator);
   ASSERT_TRUE(NULL != path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(path, allocator.state);
   });
   ASSERT_TRUE(rcutils_exists(path)) << "No test YAML file found at " << path;
@@ -347,12 +367,14 @@ TEST(test_file_parser, no_alias_support) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   char * test_path = rcutils_join_path(cur_dir, "test", allocator);
   ASSERT_TRUE(NULL != test_path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(test_path, allocator.state);
   });
   char * path = rcutils_join_path(test_path, "no_alias_support.yaml", allocator);
   ASSERT_TRUE(NULL != path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(path, allocator.state);
   });
   ASSERT_TRUE(rcutils_exists(path)) << "No test YAML file found at " << path;
@@ -369,12 +391,14 @@ TEST(test_file_parser, empty_string) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   char * test_path = rcutils_join_path(cur_dir, "test", allocator);
   ASSERT_TRUE(NULL != test_path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(test_path, allocator.state);
   });
   char * path = rcutils_join_path(test_path, "empty_string.yaml", allocator);
   ASSERT_TRUE(NULL != path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(path, allocator.state);
   });
   ASSERT_TRUE(rcutils_exists(path)) << "No test YAML file found at " << path;
@@ -391,12 +415,14 @@ TEST(test_file_parser, no_value1) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   char * test_path = rcutils_join_path(cur_dir, "test", allocator);
   ASSERT_TRUE(NULL != test_path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(test_path, allocator.state);
   });
   char * path = rcutils_join_path(test_path, "no_value1.yaml", allocator);
   ASSERT_TRUE(NULL != path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(path, allocator.state);
   });
   ASSERT_TRUE(rcutils_exists(path)) << "No test YAML file found at " << path;
@@ -413,12 +439,14 @@ TEST(test_file_parser, indented_ns) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   char * test_path = rcutils_join_path(cur_dir, "test", allocator);
   ASSERT_TRUE(NULL != test_path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(test_path, allocator.state);
   });
   char * path = rcutils_join_path(test_path, "indented_name_space.yaml", allocator);
   ASSERT_TRUE(NULL != path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(path, allocator.state);
   });
   ASSERT_TRUE(rcutils_exists(path)) << "No test YAML file found at " << path;
@@ -436,12 +464,14 @@ TEST(test_file_parser, maximum_number_parameters) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   char * test_path = rcutils_join_path(cur_dir, "test", allocator);
   ASSERT_TRUE(NULL != test_path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(test_path, allocator.state);
   });
   char * path = rcutils_join_path(test_path, "max_num_params.yaml", allocator);
   ASSERT_TRUE(NULL != path) << rcutils_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     allocator.deallocate(path, allocator.state);
   });
   ASSERT_TRUE(rcutils_exists(path)) << "No test YAML file found at " << path;


### PR DESCRIPTION
Style update to match the ROS 2 development guide and pass with the updated linter configuration from ament/ament_lint#210.