### PR TITLE
Fix test_publisher memory leaks reported by asan

### DIFF
--- a/rcl/test/rcl/test_publisher.cpp
+++ b/rcl/test/rcl/test_publisher.cpp
@@ -173,6 +173,7 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publishers_diff
   test_msgs__msg__Strings__init(&msg_string);
   ASSERT_TRUE(rosidl_runtime_c__String__assign(&msg_string.string_value, "testing"));
   ret = rcl_publish(&publisher_in_namespace, &msg_string, nullptr);
+  test_msgs__msg__Strings__fini(&msg_string);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 }
 

--- a/rcl/test/rcl/test_publisher.cpp
+++ b/rcl/test/rcl/test_publisher.cpp
@@ -202,6 +202,8 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_init_
   ret = rcl_publisher_init(&publisher, this->node_ptr, ts, topic_name, &default_publisher_options);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   EXPECT_TRUE(rcl_publisher_is_valid(&publisher));
+  ret = rcl_publisher_fini(&publisher, this->node_ptr);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   rcl_reset_error();
 
   // Try passing null for publisher in init.
@@ -213,6 +215,8 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_init_
   publisher = rcl_get_zero_initialized_publisher();
   ret = rcl_publisher_init(&publisher, nullptr, ts, topic_name, &default_publisher_options);
   EXPECT_EQ(RCL_RET_NODE_INVALID, ret) << rcl_get_error_string().str;
+  ret = rcl_publisher_fini(&publisher, this->node_ptr);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   rcl_reset_error();
 
   // Try passing an invalid (uninitialized) node in init.
@@ -220,6 +224,8 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_init_
   rcl_node_t invalid_node = rcl_get_zero_initialized_node();
   ret = rcl_publisher_init(&publisher, &invalid_node, ts, topic_name, &default_publisher_options);
   EXPECT_EQ(RCL_RET_NODE_INVALID, ret) << rcl_get_error_string().str;
+  ret = rcl_publisher_fini(&publisher, this->node_ptr);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   rcl_reset_error();
 
   // Try passing null for the type support in init.
@@ -227,18 +233,24 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_init_
   ret = rcl_publisher_init(
     &publisher, this->node_ptr, nullptr, topic_name, &default_publisher_options);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string().str;
+  ret = rcl_publisher_fini(&publisher, this->node_ptr);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   rcl_reset_error();
 
   // Try passing null for the topic name in init.
   publisher = rcl_get_zero_initialized_publisher();
   ret = rcl_publisher_init(&publisher, this->node_ptr, ts, nullptr, &default_publisher_options);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string().str;
+  ret = rcl_publisher_fini(&publisher, this->node_ptr);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   rcl_reset_error();
 
   // Try passing null for the options in init.
   publisher = rcl_get_zero_initialized_publisher();
   ret = rcl_publisher_init(&publisher, this->node_ptr, ts, topic_name, nullptr);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string().str;
+  ret = rcl_publisher_fini(&publisher, this->node_ptr);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   rcl_reset_error();
 
   // Try passing options with an invalid allocate in allocator with init.
@@ -249,6 +261,8 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_init_
   ret = rcl_publisher_init(
     &publisher, this->node_ptr, ts, topic_name, &publisher_options_with_invalid_allocator);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string().str;
+  ret = rcl_publisher_fini(&publisher, this->node_ptr);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   rcl_reset_error();
 
   // Try passing options with an invalid deallocate in allocator with init.
@@ -258,6 +272,8 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_publisher_init_
   ret = rcl_publisher_init(
     &publisher, this->node_ptr, ts, topic_name, &publisher_options_with_invalid_allocator);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string().str;
+  ret = rcl_publisher_fini(&publisher, this->node_ptr);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   rcl_reset_error();
 
   // An allocator with an invalid realloc will probably work (so we will not test it).


### PR DESCRIPTION
This is for #469.
I solved all asan reports for this function.

Asan report for 9435ea96a11df6c0e6a7ab5588c8da9f3f29d003.

```
#0 0x7f86c687ef40 in realloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdef40)
#1 0x7f86c5d91f75 in rosidl_generator_c__String__assignn /ros2_asan/src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:85
#2 0x7f86c5d920af in rosidl_generator_c__String__assign /ros2_asan/src/ros2/rosidl/rosidl_generator_c/src/string_functions.c:101
#3 0x7f86c5950976 in test_msgs__msg__Strings__init /ros2_asan/build-asan/test_msgs/rosidl_generator_c/test_msgs/msg/strings__functions.c:55
#4 0x55a4966b51c5 in TestPublisherFixture__rmw_fastrtps_cpp_test_publishers_different_types_Test::TestBody() /ros2_asan/src/ros2/rcl/rcl/test/rcl/test_publisher.cpp:168
```

Asan report for 64a24b554a510c8f6617476134d9069c7b0959f

```
#0 0x7f9b28596b50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
#1 0x7f9b27cb9885 in __default_allocate /ros2_asan/src/ros2/rcutils/src/allocator.c:35
#2 0x7f9b2825d73e in rcl_publisher_init /ros2_asan/src/ros2/rcl/rcl/src/rcl/publisher.c:158
#3 0x5593b9d89aa0 in TestPublisherFixture__rmw_fastrtps_cpp_test_publisher_init_fini_Test::TestBody() /ros2_asan/src/ros2/rcl/rcl/test/rcl/test_publisher.cpp:196
```

