### PR TITLE
Fix test_count_matched memory leaks reported by asan #567

### DIFF
--- a/rcl/test/rcl/test_count_matched.cpp
+++ b/rcl/test/rcl/test_count_matched.cpp
@@ -186,6 +186,14 @@ TEST_F(CLASSNAME(TestCountFixture, RMW_IMPLEMENTATION), test_count_matched_funct
 
   check_state(wait_set_ptr, nullptr, &sub, graph_guard_condition, -1, 0, 9);
   check_state(wait_set_ptr, nullptr, &sub2, graph_guard_condition, -1, 0, 9);
+
+  ret = rcl_subscription_fini(&sub, this->node_ptr);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
+
+  ret = rcl_subscription_fini(&sub2, this->node_ptr);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
 }
 
 TEST_F(
@@ -240,6 +248,14 @@ TEST_F(
   // Even multiple subscribers should not match
   check_state(wait_set_ptr, &pub, &sub, graph_guard_condition, 0, 0, 9);
   check_state(wait_set_ptr, &pub, &sub2, graph_guard_condition, 0, 0, 9);
+
+  ret = rcl_subscription_fini(&sub, this->node_ptr);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
+
+  ret = rcl_subscription_fini(&sub2, this->node_ptr);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
 
   ret = rcl_publisher_fini(&pub, this->node_ptr);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;

--- a/rcl/test/rcl/test_count_matched.cpp
+++ b/rcl/test/rcl/test_count_matched.cpp
@@ -114,6 +114,8 @@ public:
     *this->context_ptr = rcl_get_zero_initialized_context();
     ret = rcl_init(0, nullptr, &init_options, this->context_ptr);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+    ret = rcl_init_options_fini(&init_options);
+    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     this->node_ptr = new rcl_node_t;
     *this->node_ptr = rcl_get_zero_initialized_node();
     const char * name = "test_count_node";


### PR DESCRIPTION
This is for #469

- asan report for f532a444d693ba6853f90fb40952c0df34ae33bf

```
#0 0x7ff90124bb50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
#1 0x7ff90096e885 in __default_allocate /ros2_asan/src/ros2/rcutils/src/allocator.c:35
#2 0x7ff900f1dd69 in rcl_subscription_init /ros2_asan/src/ros2/rcl/rcl/src/rcl/subscription.c:154
#3 0x55daa28490da in TestCountFixture__rmw_fastrtps_cpp_test_count_matched_functions_mismatched_qos_Test::TestBody() /ros2_asan/src/ros2/rcl/rcl/test/rcl/test_count_matched.cpp:234
```

- asan report for e9e4025cac17063671274f5d5ae3800e3c6f7022

```
#0 0x7ff90124bb50 in __interceptor_malloc (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xdeb50)
#1 0x7ff90096e885 in __default_allocate /ros2_asan/src/ros2/rcutils/src/allocator.c:35
#2 0x7ff900f0304a in rcl_init_options_init /ros2_asan/src/ros2/rcl/rcl/src/rcl/init_options.c:45
#3 0x55daa284a8d6 in TestCountFixture__rmw_fastrtps_cpp::SetUp() (/ros2_asan/build-asan/rcl/test/test_count_matched__rmw_fastrtps_cpp+0x2a8d6)
#4 0x55daa28c454f in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) /ros2_asan/install-asan/gtest_vendor/src/g
test_vendor/./src/gtest.cc:2447
```


