### PR TITLE
Fix alloc-dealloc-mismatch(new->free) in test_info_by_topic (#469)

### DIFF
--- a/rcl/test/rcl/test_info_by_topic.cpp
+++ b/rcl/test/rcl/test_info_by_topic.cpp
@@ -286,7 +286,7 @@ TEST_F(
   this->topic_endpoint_info_array.info_array = new rmw_topic_endpoint_info_t();
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
   {
-    free(this->topic_endpoint_info_array.info_array);
+    delete this->topic_endpoint_info_array.info_array;
   });
   rcl_allocator_t allocator = rcl_get_default_allocator();
   const auto ret = rcl_get_publishers_info_by_topic(
@@ -308,7 +308,7 @@ TEST_F(
   this->topic_endpoint_info_array.info_array = new rmw_topic_endpoint_info_t();
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
   {
-    free(this->topic_endpoint_info_array.info_array);
+    delete this->topic_endpoint_info_array.info_array;
   });
   rcl_allocator_t allocator = rcl_get_default_allocator();
   const auto ret = rcl_get_subscriptions_info_by_topic(


### PR DESCRIPTION
This is for #469.

- asan report for d3aa89a974052f92d5c81a9c3b203a77e0b654fb.
  There is the same message at test_info_by_topic.cpp:285.

```
==8995==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new vs free) on 0x60d0000050b0
#0 0x7f5348d207b8 in __interceptor_free (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xde7b8)
#1 0x55f772752542 in operator() /ros2_asan/src/ros2/rcl/rcl/test/rcl/test_info_by_topic.cpp:267
#2 0x55f772757e27 in ~ScopeExit /ros2_asan/install-asan/osrf_testing_tools_cpp/share/osrf_testing_tools_cpp/cmake/../../../include/osrf_testing_tools_cpp/scope_exit.hpp:30
#3 0x55f772752a24 in TestInfoByTopicFixture__rmw_fastrtps_cpp_test_rcl_get_publishers_info_by_topic_invalid_participants_Test::TestBody() /ros2_asan/src/ros2/rcl/rcl/test/rcl/test_info_by_topic.cpp:267
```
