### PR TITLE
Guard against returning NULL or empty node names

### DIFF
--- a/rcl/include/rcl/graph.h
+++ b/rcl/include/rcl/graph.h
@@ -406,7 +406,6 @@ rcl_names_and_types_fini(rcl_names_and_types_t * names_and_types);
  *
  * The `node_names` parameter must be allocated and zero initialized.
  * `node_names` is the output for this function, and contains allocated memory.
- * Note that entries in the array might contain `NULL` values.
  * Use rcutils_get_zero_initialized_string_array() for initializing an empty
  * rcutils_string_array_t struct.
  * This `node_names` struct should therefore be passed to rcutils_string_array_fini()

--- a/rcl/include/rcl/graph.h
+++ b/rcl/include/rcl/graph.h
@@ -444,6 +444,8 @@ rcl_names_and_types_fini(rcl_names_and_types_t * names_and_types);
  * \return #RCL_RET_OK if the query was successful, or
  * \return #RCL_RET_BAD_ALLOC if an error occurred while allocating memory, or
  * \return #RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or
+ * \return #RCL_RET_NODE_INVALID_NAME if a node with an invalid name is detected, or
+ * \return #RCL_RET_NODE_INVALID_NAMESPACE if a node with an invalid namespace is detected, or
  * \return #RCL_RET_ERROR if an unspecified error occurs.
  */
 RCL_PUBLIC

--- a/rcl/src/rcl/graph.c
+++ b/rcl/src/rcl/graph.c
@@ -350,18 +350,18 @@ rcl_get_node_names(
   for (size_t i = 0u; i < node_names->size; ++i) {
     if (!node_names->data[i]) {
       RCL_SET_ERROR_MSG("NULL node name returned by the RMW layer");
-      return RCL_RET_ERROR;
+      return RCL_RET_NODE_INVALID_NAME;
     }
     if (!strcmp(node_names->data[i], "")) {
       RCL_SET_ERROR_MSG("empty node name returned by the RMW layer");
-      return RCL_RET_ERROR;
+      return RCL_RET_NODE_INVALID_NAME;
     }
   }
   // Check that none of the node namespaces are NULL
   for (size_t i = 0u; i < node_namespaces->size; ++i) {
     if (!node_namespaces->data[i]) {
       RCL_SET_ERROR_MSG("NULL node namespace returned by the RMW layer");
-      return RCL_RET_ERROR;
+      return RCL_RET_NODE_INVALID_NAMESPACE;
     }
   }
   return RCL_RET_OK;

--- a/rcl/src/rcl/graph.c
+++ b/rcl/src/rcl/graph.c
@@ -348,8 +348,12 @@ rcl_get_node_names(
 
   // Check that none of the node names are NULL or empty
   for (size_t i = 0u; i < node_names->size; ++i) {
-    if (!node_names->data[i] || !strcmp(node_names->data[i], "")) {
-      RCL_SET_ERROR_MSG("NULL or empty node name returned by the RMW layer");
+    if (!node_names->data[i]) {
+      RCL_SET_ERROR_MSG("NULL node name returned by the RMW layer");
+      return RCL_RET_ERROR;
+    }
+    if (!strcmp(node_names->data[i], "")) {
+      RCL_SET_ERROR_MSG("empty node name returned by the RMW layer");
       return RCL_RET_ERROR;
     }
   }

--- a/rcl/src/rcl/graph.c
+++ b/rcl/src/rcl/graph.c
@@ -358,7 +358,7 @@ rcl_get_node_names(
     }
   }
   // Check that none of the node namespaces are NULL
-  for (size_t i = 0u; i < node_names->size; ++i) {
+  for (size_t i = 0u; i < node_namespaces->size; ++i) {
     if (!node_namespaces->data[i]) {
       RCL_SET_ERROR_MSG("NULL node namespace returned by the RMW layer");
       return RCL_RET_ERROR;

--- a/rcl/src/rcl/graph.c
+++ b/rcl/src/rcl/graph.c
@@ -357,6 +357,13 @@ rcl_get_node_names(
       return RCL_RET_ERROR;
     }
   }
+  // Check that none of the node namespaces are NULL
+  for (size_t i = 0u; i < node_names->size; ++i) {
+    if (!node_namespaces->data[i]) {
+      RCL_SET_ERROR_MSG("NULL node namespace returned by the RMW layer");
+      return RCL_RET_ERROR;
+    }
+  }
   return RCL_RET_OK;
 }
 

--- a/rcl/src/rcl/graph.c
+++ b/rcl/src/rcl/graph.c
@@ -341,7 +341,19 @@ rcl_get_node_names(
     rcl_node_get_rmw_handle(node),
     node_names,
     node_namespaces);
-  return rcl_convert_rmw_ret_to_rcl_ret(rmw_ret);
+
+  if (RMW_RET_OK != rmw_ret) {
+    return rcl_convert_rmw_ret_to_rcl_ret(rmw_ret);
+  }
+
+  // Check that none of the node names are NULL or empty
+  for (size_t i = 0u; i < node_names->size; ++i) {
+    if (!node_names->data[i] || !strcmp(node_names->data[i], "")) {
+      RCL_SET_ERROR_MSG("NULL or empty node name returned by the RMW layer");
+      return RCL_RET_ERROR;
+    }
+  }
+  return RCL_RET_OK;
 }
 
 rcl_ret_t


### PR DESCRIPTION
Return an error instead.

I think this is the last task to wrap up https://github.com/ros2/ros2/issues/489.

Specifically, this is addressing https://github.com/ros2/ros2/issues/489#issuecomment-411581806
Reverting https://github.com/ros2/rcl/pull/214.
