### PR TITLE
[rcl_action] changed build_depend and build_depend_export dependencies to depend

### DIFF
--- a/rcl_action/package.xml
+++ b/rcl_action/package.xml
@@ -9,17 +9,11 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
-  <build_depend>action_msgs</build_depend>
-  <build_depend>rcl</build_depend>
-  <build_depend>rcutils</build_depend>
-  <build_depend>rmw</build_depend>
-  <build_depend>rosidl_generator_c</build_depend>
-
-  <build_export_depend>action_msgs</build_export_depend>
-  <build_export_depend>rcl</build_export_depend>
-  <build_export_depend>rcutils</build_export_depend>
-  <build_export_depend>rmw</build_export_depend>
-  <build_export_depend>rosidl_generator_c</build_export_depend>
+  <depend>action_msgs</depend>
+  <depend>rcl</depend>
+  <depend>rcutils</depend>
+  <depend>rmw</depend>
+  <depend>rosidl_generator_c</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
changed the following `<build_depend>` and `<build_depend_export>` to `<depend>`
 - action_msgs
 - rcl
 - rcutils
 - rmw
 - rosidl_generator_c