### PR TITLE
[backport dashing] Don't check history depth if RMW_QOS_POLICY_HISTORY_KEEP_ALL

### DIFF
--- a/rcl/test/rcl/test_get_actual_qos.cpp
+++ b/rcl/test/rcl/test_get_actual_qos.cpp
@@ -133,9 +133,9 @@ TEST_P_RMW(TestGetActualQoS, test_publisher_get_qos_settings) {
   EXPECT_EQ(
     qos->history,
     parameters.qos_expected.history);
-  EXPECT_EQ(
-    qos->depth,
-    parameters.qos_expected.depth);
+  if (parameters.qos_expected.history == RMW_QOS_POLICY_HISTORY_KEEP_LAST) {
+    EXPECT_EQ(qos->depth, parameters.qos_expected.depth);
+  }
   EXPECT_EQ(
     qos->reliability,
     parameters.qos_expected.reliability);


### PR DESCRIPTION
Backport of #593
Fixes CI issue http://build.ros2.org/user/rotu/my-views/view/CycloneDDS/job/Dci__nightly-cyclonedds_ubuntu_bionic_amd64/lastCompletedBuild/testReport/rcl/TestWithDifferentQoSSettings_TestGetActualQoS__rmw_cyclonedds_cpp/test_publisher_get_qos_settings_publisher_non_default_qos__publisher_non_default_qos______________________/
Signed-off-by: Dan Rose <dan@digilabs.io>
