### PR TITLE
[Eloquent] Don't check history depth if RMW_QOS_POLICY_HISTORY_KEEP_ALL (#595)

### DIFF
--- a/rcl/test/rcl/test_get_actual_qos.cpp
+++ b/rcl/test/rcl/test_get_actual_qos.cpp
@@ -167,9 +167,9 @@ TEST_P_RMW(TestPublisherGetActualQoS, test_publisher_get_qos_settings)
   EXPECT_EQ(
     qos->history,
     parameters.qos_expected.history);
-  EXPECT_EQ(
-    qos->depth,
-    parameters.qos_expected.depth);
+  if (parameters.qos_expected.history == RMW_QOS_POLICY_HISTORY_KEEP_LAST) {
+    EXPECT_EQ(qos->depth, parameters.qos_expected.depth);
+  }
   EXPECT_EQ(
     qos->reliability,
     parameters.qos_expected.reliability);
@@ -222,9 +222,9 @@ TEST_P_RMW(TestSubscriptionGetActualQoS, test_subscription_get_qos_settings)
   EXPECT_EQ(
     qos->history,
     parameters.qos_expected.history);
-  EXPECT_EQ(
-    qos->depth,
-    parameters.qos_expected.depth);
+  if (parameters.qos_expected.history == RMW_QOS_POLICY_HISTORY_KEEP_LAST) {
+    EXPECT_EQ(qos->depth, parameters.qos_expected.depth);
+  }
   EXPECT_EQ(
     qos->reliability,
     parameters.qos_expected.reliability);


### PR DESCRIPTION
Backport of #593

Signed-off-by: Dan Rose <dan@digilabs.io>
