### PR TITLE
Change naming style for private functions

### DIFF
--- a/rcl/src/rcl/time.c
+++ b/rcl/src/rcl/time.c
@@ -32,7 +32,7 @@ typedef struct rcl_ros_clock_storage_t
 
 // Implementation only
 rcl_ret_t
-rcl_get_steady_time(void * data, rcl_time_point_value_t * current_time)
+_rcl_get_steady_time(void * data, rcl_time_point_value_t * current_time)
 {
   (void)data;  // unused
   return rcutils_steady_time_now(current_time);
@@ -40,7 +40,7 @@ rcl_get_steady_time(void * data, rcl_time_point_value_t * current_time)
 
 // Implementation only
 rcl_ret_t
-rcl_get_system_time(void * data, rcl_time_point_value_t * current_time)
+_rcl_get_system_time(void * data, rcl_time_point_value_t * current_time)
 {
   (void)data;  // unused
   return rcutils_system_time_now(current_time);
@@ -48,7 +48,7 @@ rcl_get_system_time(void * data, rcl_time_point_value_t * current_time)
 
 // Internal method for zeroing values on init, assumes clock is valid
 void
-rcl_init_generic_clock(rcl_clock_t * clock)
+_rcl_init_generic_clock(rcl_clock_t * clock)
 {
   clock->type = RCL_CLOCK_UNINITIALIZED;
   clock->jump_callbacks = NULL;
@@ -60,11 +60,11 @@ rcl_init_generic_clock(rcl_clock_t * clock)
 // The function used to get the current ros time.
 // This is in the implementation only
 rcl_ret_t
-rcl_get_ros_time(void * data, rcl_time_point_value_t * current_time)
+_rcl_get_ros_time(void * data, rcl_time_point_value_t * current_time)
 {
   rcl_ros_clock_storage_t * t = (rcl_ros_clock_storage_t *)data;
   if (!t->active) {
-    return rcl_get_system_time(data, current_time);
+    return _rcl_get_system_time(data, current_time);
   }
   *current_time = rcutils_atomic_load_uint64_t(&(t->current_time));
   return RCL_RET_OK;
@@ -91,7 +91,7 @@ rcl_clock_init(
   switch (clock_type) {
     case RCL_CLOCK_UNINITIALIZED:
       RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT);
-      rcl_init_generic_clock(clock);
+      _rcl_init_generic_clock(clock);
       return RCL_RET_OK;
     case RCL_ROS_TIME:
       return rcl_ros_clock_init(clock, allocator);
@@ -144,13 +144,13 @@ rcl_ros_clock_init(
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(allocator, RCL_RET_INVALID_ARGUMENT);
-  rcl_init_generic_clock(clock);
+  _rcl_init_generic_clock(clock);
   clock->data = allocator->allocate(sizeof(rcl_ros_clock_storage_t), allocator->state);
   rcl_ros_clock_storage_t * storage = (rcl_ros_clock_storage_t *)clock->data;
   // 0 is a special value meaning time has not been set
   atomic_init(&(storage->current_time), 0);
   storage->active = false;
-  clock->get_now = rcl_get_ros_time;
+  clock->get_now = _rcl_get_ros_time;
   clock->type = RCL_ROS_TIME;
   clock->allocator = *allocator;
   return RCL_RET_OK;
@@ -181,8 +181,8 @@ rcl_steady_clock_init(
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(allocator, RCL_RET_INVALID_ARGUMENT);
-  rcl_init_generic_clock(clock);
-  clock->get_now = rcl_get_steady_time;
+  _rcl_init_generic_clock(clock);
+  clock->get_now = _rcl_get_steady_time;
   clock->type = RCL_STEADY_TIME;
   clock->allocator = *allocator;
   return RCL_RET_OK;
@@ -208,8 +208,8 @@ rcl_system_clock_init(
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(allocator, RCL_RET_INVALID_ARGUMENT);
-  rcl_init_generic_clock(clock);
-  clock->get_now = rcl_get_system_time;
+  _rcl_init_generic_clock(clock);
+  clock->get_now = _rcl_get_system_time;
   clock->type = RCL_SYSTEM_TIME;
   clock->allocator = *allocator;
   return RCL_RET_OK;
@@ -363,7 +363,7 @@ rcl_set_ros_time_override(
   if (storage->active) {
     time_jump.clock_change = RCL_ROS_TIME_NO_CHANGE;
     rcl_time_point_value_t current_time;
-    rcl_ret_t ret = rcl_get_ros_time(storage, &current_time);
+    rcl_ret_t ret = _rcl_get_ros_time(storage, &current_time);
     if (RCL_RET_OK != ret) {
       return ret;
     }


### PR DESCRIPTION
To keep consistency with other functions only available in this method, added "_" prefix on functions only available to this module.

Edit: Removed underscore from functions internal to the module and added the `static` keyword.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>