### PR TITLE
Add tests for time.c and timer.c for rcl package

### DIFF
--- a/rcl/test/rcl/allocator_testing_utils.h
+++ b/rcl/test/rcl/allocator_testing_utils.h
@@ -1,0 +1,94 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCL__ALLOCATOR_TESTING_UTILS_H_
+#define RCL__ALLOCATOR_TESTING_UTILS_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stddef.h>
+
+#include "rcutils/allocator.h"
+
+typedef struct __failing_allocator_state
+{
+  bool is_failing;
+} __failing_allocator_state;
+
+void *
+failing_malloc(size_t size, void * state)
+{
+  if (((__failing_allocator_state *)state)->is_failing) {
+    return nullptr;
+  }
+  return rcutils_get_default_allocator().allocate(size, rcutils_get_default_allocator().state);
+}
+
+void *
+failing_realloc(void * pointer, size_t size, void * state)
+{
+  if (((__failing_allocator_state *)state)->is_failing) {
+    return nullptr;
+  }
+  return rcutils_get_default_allocator().reallocate(
+    pointer, size, rcutils_get_default_allocator().state);
+}
+
+void
+failing_free(void * pointer, void * state)
+{
+  if (((__failing_allocator_state *)state)->is_failing) {
+    return;
+  }
+  rcutils_get_default_allocator().deallocate(pointer, rcutils_get_default_allocator().state);
+}
+
+void *
+failing_calloc(size_t number_of_elements, size_t size_of_element, void * state)
+{
+  if (((__failing_allocator_state *)state)->is_failing) {
+    return nullptr;
+  }
+  return rcutils_get_default_allocator().zero_allocate(
+    number_of_elements, size_of_element, rcutils_get_default_allocator().state);
+}
+
+static inline rcutils_allocator_t
+get_failing_allocator(void)
+{
+  static __failing_allocator_state state;
+  state.is_failing = true;
+  auto failing_allocator = rcutils_get_default_allocator();
+  failing_allocator.allocate = failing_malloc;
+  failing_allocator.deallocate = failing_free;
+  failing_allocator.reallocate = failing_realloc;
+  failing_allocator.zero_allocate = failing_calloc;
+  failing_allocator.state = &state;
+  return failing_allocator;
+}
+
+static inline void
+set_failing_allocator_is_failing(rcutils_allocator_t & failing_allocator, bool state)
+{
+  ((__failing_allocator_state *)failing_allocator.state)->is_failing = state;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RCL__ALLOCATOR_TESTING_UTILS_H_

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -509,6 +509,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_fail_set_jump_callbacks) 
   rcl_clock_t fail_clock;
   rcl_time_jump_t time_jump;
   rcl_jump_threshold_t threshold;
+  threshold.on_clock_change = NULL;
   threshold.min_forward.nanoseconds = -1;
   threshold.min_backward.nanoseconds = 0;
 
@@ -790,8 +791,9 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), fail_override) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   bool result;
   rcl_time_point_value_t set_point = 1000000000ull;
-  ASSERT_EQ(RCL_RET_OK, rcl_clock_init(
-    RCL_CLOCK_UNINITIALIZED, &ros_clock, &allocator))  << rcl_get_error_string().str;
+  ASSERT_EQ(
+    RCL_RET_OK, rcl_clock_init(
+      RCL_CLOCK_UNINITIALIZED, &ros_clock, &allocator)) << rcl_get_error_string().str;
 
   EXPECT_EQ(RCL_RET_ERROR, rcl_enable_ros_time_override(&ros_clock));
   EXPECT_EQ(RCL_RET_ERROR, rcl_disable_ros_time_override(&ros_clock));

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -513,7 +513,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_fail_set_jump_callbacks) 
   rcl_ret_t ret = rcl_clock_init(RCL_CLOCK_UNINITIALIZED, &fail_clock, &allocator);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
-  threshold.on_clock_change = NULL;
+  threshold.on_clock_change = false;
   threshold.min_forward.nanoseconds = -1;
   threshold.min_backward.nanoseconds = 0;
 

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -269,7 +269,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), specific_clock_instantiation) {
       "Expected time source of type RCL_CLOCK_UNINITIALIZED";
     EXPECT_TRUE(rcutils_allocator_is_valid(&(uninitialized_clock.allocator)));
     ret = rcl_clock_fini(&uninitialized_clock);
-    EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT) << rcl_get_error_string().str;
+    EXPECT_EQ(ret, RCL_RET_ERROR) << rcl_get_error_string().str;
     rcl_reset_error();
     EXPECT_EQ(
       rcl_ros_clock_fini(&uninitialized_clock), RCL_RET_ERROR) << rcl_get_error_string().str;

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -269,7 +269,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), specific_clock_instantiation) {
       "Expected time source of type RCL_CLOCK_UNINITIALIZED";
     EXPECT_TRUE(rcutils_allocator_is_valid(&(uninitialized_clock.allocator)));
     ret = rcl_clock_fini(&uninitialized_clock);
-    EXPECT_EQ(ret, RCL_RET_ERROR) << rcl_get_error_string().str;
+    EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT) << rcl_get_error_string().str;
     rcl_reset_error();
     EXPECT_EQ(
       rcl_ros_clock_fini(&uninitialized_clock), RCL_RET_ERROR) << rcl_get_error_string().str;

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -506,9 +506,13 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_clock_change_callbacks) {
 }
 
 TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_fail_set_jump_callbacks) {
+  rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_clock_t fail_clock;
   rcl_time_jump_t time_jump;
   rcl_jump_threshold_t threshold;
+  rcl_ret_t ret = rcl_clock_init(RCL_CLOCK_UNINITIALIZED, &fail_clock, &allocator);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
   threshold.on_clock_change = NULL;
   threshold.min_forward.nanoseconds = -1;
   threshold.min_backward.nanoseconds = 0;

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -560,68 +560,22 @@ TEST_F(TestPreInitTimer, test_timer_get_allocator) {
   EXPECT_EQ(NULL, rcl_timer_get_allocator(nullptr));
 }
 
-TEST_F(TestTimerFixture, test_timer_clock) {
-  rcl_ret_t ret;
-
+TEST_F(TestPreInitTimer, test_timer_clock) {
   rcl_clock_t * clock_impl;
-  rcl_clock_t clock;
-  rcl_allocator_t allocator = rcl_get_default_allocator();
-  rcl_timer_t timer = rcl_get_zero_initialized_timer();
-
-  ret = rcl_clock_init(RCL_STEADY_TIME, &clock, &allocator);
-  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-
-  ret = rcl_timer_init(
-    &timer, &clock, this->context_ptr, RCL_MS_TO_NS(5), nullptr, rcl_get_default_allocator());
-  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-
   EXPECT_EQ(RCL_RET_OK, rcl_timer_clock(&timer, &clock_impl));
   EXPECT_EQ(clock_impl, &clock);
 }
 
-static uint8_t times_called = 0;
-static void callback_function(rcl_timer_t * timer, int64_t last_call)
-{
-  (void) timer;
-  (void) last_call;
-  times_called++;
-}
-static rcl_timer_callback_t timer_callback_test = &callback_function;
-
-TEST_F(TestTimerFixture, test_timer_call) {
-  rcl_ret_t ret;
-  rcl_clock_t clock;
-  rcl_allocator_t allocator = rcl_get_default_allocator();
-  rcl_timer_t timer = rcl_get_zero_initialized_timer();
+TEST_F(TestPreInitTimer, test_timer_call) {
   int64_t next_call_start, next_call_end;
   int64_t old_period = 0;
 
-  ASSERT_EQ(
-    RCL_RET_OK,
-    rcl_clock_init(RCL_ROS_TIME, &clock, &allocator)) << rcl_get_error_string().str;
-
-  ret = rcl_timer_init(
-    &timer, &clock, this->context_ptr, RCL_S_TO_NS(1), timer_callback_test,
-    rcl_get_default_allocator());
-  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
-  {
-    ret = rcl_clock_fini(&clock);
-    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    rcl_ret_t ret = rcl_timer_fini(&timer);
-    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  });
-
   EXPECT_EQ(RCL_RET_OK, rcl_timer_get_time_until_next_call(&timer, &next_call_start));
-  ret = rcl_timer_call(&timer);
-  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ASSERT_EQ(RCL_RET_OK, rcl_timer_call(&timer)) << rcl_get_error_string().str;
   EXPECT_EQ(times_called, 1);
 
-  ret = rcl_timer_call(&timer);
-  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  ret = rcl_timer_call(&timer);
-  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ASSERT_EQ(RCL_RET_OK, rcl_timer_call(&timer)) << rcl_get_error_string().str;
+  ASSERT_EQ(RCL_RET_OK, rcl_timer_call(&timer)) << rcl_get_error_string().str;
   EXPECT_EQ(times_called, 3);
   EXPECT_EQ(RCL_RET_OK, rcl_timer_get_time_until_next_call(&timer, &next_call_end));
   EXPECT_GT(next_call_end, next_call_start);
@@ -629,8 +583,7 @@ TEST_F(TestTimerFixture, test_timer_call) {
   next_call_start = next_call_end;
   ASSERT_EQ(RCL_RET_OK, rcl_timer_exchange_period(&timer, 0, &old_period));
   EXPECT_EQ(RCL_S_TO_NS(1), old_period);
-  ret = rcl_timer_call(&timer);
-  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ASSERT_EQ(RCL_RET_OK, rcl_timer_call(&timer)) << rcl_get_error_string().str;
   EXPECT_EQ(times_called, 4);
   EXPECT_EQ(RCL_RET_OK, rcl_timer_get_time_until_next_call(&timer, &next_call_end));
   EXPECT_GT(next_call_start, next_call_end);
@@ -640,28 +593,6 @@ TEST_F(TestTimerFixture, test_timer_call) {
   EXPECT_EQ(times_called, 4);
 }
 
-TEST_F(TestTimerFixture, test_get_callback) {
-  rcl_ret_t ret;
-  rcl_clock_t clock;
-  rcl_allocator_t allocator = rcl_get_default_allocator();
-  rcl_timer_t timer = rcl_get_zero_initialized_timer();
-
-  ASSERT_EQ(
-    RCL_RET_OK,
-    rcl_clock_init(RCL_ROS_TIME, &clock, &allocator)) << rcl_get_error_string().str;
-
-  ret = rcl_timer_init(
-    &timer, &clock, this->context_ptr, RCL_S_TO_NS(1), timer_callback_test,
-    rcl_get_default_allocator());
-  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
-  {
-    ret = rcl_clock_fini(&clock);
-    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    rcl_ret_t ret = rcl_timer_fini(&timer);
-    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  });
-
+TEST_F(TestPreInitTimer, test_get_callback) {
   ASSERT_EQ(timer_callback_test, rcl_timer_get_callback(&timer)) << rcl_get_error_string().str;
 }

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -682,3 +682,11 @@ TEST_F(TestPreInitTimer, test_timer_get_period) {
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_timer_get_period(nullptr, &period));
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_timer_get_period(&timer, nullptr));
 }
+
+TEST_F(TestPreInitTimer, test_time_since_last_call) {
+  rcl_time_point_value_t time_sice_next_call_start, time_sice_next_call_end;
+
+  ASSERT_EQ(RCL_RET_OK, rcl_timer_get_time_since_last_call(&timer, &time_sice_next_call_start));
+  ASSERT_EQ(RCL_RET_OK, rcl_timer_get_time_since_last_call(&timer, &time_sice_next_call_end));
+  EXPECT_GT(time_sice_next_call_end, time_sice_next_call_start);
+}

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -673,3 +673,12 @@ TEST_F(TestPreInitTimer, test_invalid_init_fini) {
 
   EXPECT_EQ(RCL_RET_OK, rcl_timer_fini(nullptr));
 }
+
+TEST_F(TestPreInitTimer, test_timer_get_period) {
+  int64_t period;
+  ASSERT_EQ(RCL_RET_OK, rcl_timer_get_period(&timer, &period));
+  EXPECT_EQ(RCL_S_TO_NS(1), period);
+
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_timer_get_period(nullptr, &period));
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_timer_get_period(&timer, nullptr));
+}

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -649,3 +649,7 @@ TEST_F(TestPreInitTimer, test_timer_exchange_callback) {
   ASSERT_EQ(RCL_RET_OK, rcl_timer_call(&timer)) << rcl_get_error_string().str;
   EXPECT_EQ(times_called, 0);
 }
+
+TEST_F(TestPreInitTimer, test_invalid_get_guard) {
+  ASSERT_EQ(NULL, rcl_timer_get_guard_condition(nullptr));
+}

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -576,18 +576,6 @@ TEST_F(TestPreInitTimer, test_timer_clock) {
 }
 
 TEST_F(TestPreInitTimer, test_timer_call) {
-  /*
-    TODO: Use better names for next_call_start and next_call_end (?)
-
-    API does not expose the explicit time for the next call of the timer,
-    but provides time missing before/after next call.
-    I'm using this to compare the time difference between consecutive calls, to see if
-    the next_time variable is updated properly.
-    Comparing next_call_start and next_call_end is the same as
-    comparing missing_time_next_call1 vs missing_time_next_call2
-
-    Open to suggestions before merging
-   */
   int64_t next_call_start, next_call_end;
   int64_t old_period = 0;
   times_called = 0;

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -559,3 +559,22 @@ TEST_F(TestPreInitTimer, test_timer_get_allocator) {
 
   EXPECT_EQ(NULL, rcl_timer_get_allocator(nullptr));
 }
+
+TEST_F(TestTimerFixture, test_timer_clock) {
+  rcl_ret_t ret;
+
+  rcl_clock_t * clock_impl;
+  rcl_clock_t clock;
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  rcl_timer_t timer = rcl_get_zero_initialized_timer();
+
+  ret = rcl_clock_init(RCL_STEADY_TIME, &clock, &allocator);
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  ret = rcl_timer_init(
+    &timer, &clock, this->context_ptr, RCL_MS_TO_NS(5), nullptr, rcl_get_default_allocator());
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+  EXPECT_EQ(RCL_RET_OK, rcl_timer_clock(&timer, &clock_impl));
+  EXPECT_EQ(clock_impl, &clock);
+}

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -72,6 +72,12 @@ static void callback_function(rcl_timer_t * timer, int64_t last_call)
   (void) last_call;
   times_called++;
 }
+static void callback_function_changed(rcl_timer_t * timer, int64_t last_call)
+{
+  (void) timer;
+  (void) last_call;
+  times_called--;
+}
 
 class TestPreInitTimer : public TestTimerFixture
 {
@@ -80,6 +86,7 @@ public:
   rcl_allocator_t allocator;
   rcl_timer_t timer;
   rcl_timer_callback_t timer_callback_test = &callback_function;
+  rcl_timer_callback_t timer_callback_changed = &callback_function_changed;
 
   void SetUp() override
   {
@@ -629,4 +636,16 @@ TEST_F(TestPreInitTimer, test_timer_reset) {
   ASSERT_EQ(RCL_RET_OK, rcl_timer_reset(&timer));
   EXPECT_EQ(RCL_RET_OK, rcl_timer_call(&timer)) << rcl_get_error_string().str;
   EXPECT_EQ(times_called, 3);
+}
+
+TEST_F(TestPreInitTimer, test_timer_exchange_callback) {
+  times_called = 0;
+  ASSERT_EQ(RCL_RET_OK, rcl_timer_call(&timer)) << rcl_get_error_string().str;
+  EXPECT_EQ(times_called, 1);
+  ASSERT_EQ(
+    timer_callback_test, rcl_timer_exchange_callback(
+      &timer, timer_callback_changed)) << rcl_get_error_string().str;
+
+  ASSERT_EQ(RCL_RET_OK, rcl_timer_call(&timer)) << rcl_get_error_string().str;
+  EXPECT_EQ(times_called, 0);
 }

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -570,13 +570,14 @@ TEST_F(TestPreInitTimer, test_timer_get_allocator) {
 }
 
 TEST_F(TestPreInitTimer, test_timer_clock) {
-  rcl_clock_t * clock_impl;
+  rcl_clock_t * clock_impl = nullptr;
   EXPECT_EQ(RCL_RET_OK, rcl_timer_clock(&timer, &clock_impl)) << rcl_get_error_string().str;
   EXPECT_EQ(clock_impl, &clock);
 }
 
 TEST_F(TestPreInitTimer, test_timer_call) {
-  int64_t next_call_start, next_call_end;
+  int64_t next_call_start = 0;
+  int64_t next_call_end = 0;
   int64_t old_period = 0;
   times_called = 0;
 
@@ -608,7 +609,8 @@ TEST_F(TestPreInitTimer, test_get_callback) {
 }
 
 TEST_F(TestPreInitTimer, test_timer_reset) {
-  int64_t next_call_start, next_call_end;
+  int64_t next_call_start = 0;
+  int64_t next_call_end = 0;
   times_called = 0;
 
   ASSERT_EQ(RCL_RET_OK, rcl_timer_call(&timer)) << rcl_get_error_string().str;
@@ -646,14 +648,13 @@ TEST_F(TestPreInitTimer, test_invalid_get_guard) {
 
 TEST_F(TestPreInitTimer, test_invalid_init_fini) {
   rcl_allocator_t bad_allocator = get_failing_allocator();
-  rcl_timer_t timer_fail;
+  rcl_timer_t timer_fail = rcl_get_zero_initialized_timer();
 
   EXPECT_EQ(
     RCL_RET_ALREADY_INIT, rcl_timer_init(
       &timer, &clock, this->context_ptr, 500, nullptr,
       rcl_get_default_allocator())) << rcl_get_error_string().str;
 
-  timer_fail = rcl_get_zero_initialized_timer();
   ASSERT_EQ(
     RCL_RET_BAD_ALLOC, rcl_timer_init(
       &timer_fail, &clock, this->context_ptr, RCL_S_TO_NS(1), timer_callback_test,
@@ -663,7 +664,7 @@ TEST_F(TestPreInitTimer, test_invalid_init_fini) {
 }
 
 TEST_F(TestPreInitTimer, test_timer_get_period) {
-  int64_t period;
+  int64_t period = 0;
   ASSERT_EQ(RCL_RET_OK, rcl_timer_get_period(&timer, &period));
   EXPECT_EQ(RCL_S_TO_NS(1), period);
 
@@ -672,7 +673,8 @@ TEST_F(TestPreInitTimer, test_timer_get_period) {
 }
 
 TEST_F(TestPreInitTimer, test_time_since_last_call) {
-  rcl_time_point_value_t time_sice_next_call_start, time_sice_next_call_end;
+  rcl_time_point_value_t time_sice_next_call_start = 0u;
+  rcl_time_point_value_t time_sice_next_call_end = 0u;
 
   ASSERT_EQ(RCL_RET_OK, rcl_timer_get_time_since_last_call(&timer, &time_sice_next_call_start));
   ASSERT_EQ(RCL_RET_OK, rcl_timer_get_time_since_last_call(&timer, &time_sice_next_call_end));


### PR DESCRIPTION
This is part of the effort to bring core ROS2 packages to level quality 1. Originally meant to be a complete PR with tests for all the submodules, now will be divided in various PR for faster reviewing.

Combined with #610 will provide tests for all the functions in `timer.h` and `time.h`.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>