### PR TITLE
Update docstring for rcl_*_event_init() functions

### DIFF
--- a/rcl/include/rcl/event.h
+++ b/rcl/include/rcl/event.h
@@ -70,6 +70,7 @@ rcl_get_zero_initialized_event(void);
  * \param[in] event_type to listen for
  * \return `RCL_RET_OK` if the rcl_event_t is filled, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
+ * \return `RCL_RET_UNSUPPORTED` if event_type is not supported, or
  * \return `RCL_RET_ERROR` if an unspecified error occurs.
  */
 RCL_PUBLIC
@@ -89,6 +90,7 @@ rcl_publisher_event_init(
  * \param[in] event_type to listen for
  * \return `RCL_RET_OK` if the rcl_event_t is filled, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
+ * \return `RCL_RET_UNSUPPORTED` if event_type is not supported, or
  * \return `RCL_RET_ERROR` if an unspecified error occurs.
  */
 RCL_PUBLIC


### PR DESCRIPTION
Related to https://github.com/ros2/ros2/issues/822

The `rcl_publisher_event_init()` and `rcl_subscription_event_init()` functions can now return the `RCL_RET_UNSUPPORTED` error code to indicate that the `event_type` that was passed in is unsupported by the underlying middleware.