### PR TITLE
remove tinydir_vendor dependency

### DIFF
--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -10,7 +10,6 @@ find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rmw_implementation REQUIRED)
 find_package(rosidl_generator_c REQUIRED)
-find_package(tinydir_vendor REQUIRED)
 find_package(tracetools REQUIRED)
 
 include_directories(include)
@@ -74,7 +73,6 @@ ament_target_dependencies(${PROJECT_NAME}
   "rcutils"
   "rosidl_generator_c"
   ${RCL_LOGGING_IMPL}
-  "tinydir_vendor"
   "tracetools"
 )
 

--- a/rcl/package.xml
+++ b/rcl/package.xml
@@ -19,7 +19,6 @@
   <depend>rcutils</depend>
   <depend>rmw_implementation</depend>
   <depend>rosidl_generator_c</depend>
-  <depend>tinydir_vendor</depend>
   <depend>tracetools</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>


### PR DESCRIPTION
@ivanpauno I believe https://github.com/ros2/rcl/pull/515 allowed us to remove this dependency completely right ?