### PR TITLE
Fix security directory lookup for '/' security contexts

### DIFF
--- a/rcl/src/rcl/security.c
+++ b/rcl/src/rcl/security.c
@@ -111,16 +111,16 @@ char * exact_match_lookup(
 {
   // Perform an exact match for the context name in directory <root dir>.
   char * secure_root = NULL;
+  char * contexts_dir = NULL;
+  contexts_dir = rcutils_join_path(ros_secure_root_env, "contexts", *allocator);
   // "/" case when root namespace is explicitly passed in
   if (0 == strcmp(name, "/")) {
-    secure_root = rcutils_strdup(ros_secure_root_env, *allocator);
+    secure_root = contexts_dir;
   } else {
     char * relative_path = NULL;
-    char * contexts_dir = NULL;
     // Get native path, ignore the leading forward slash
     // TODO(ros2team): remove the hard-coded length, use the length of the root namespace instead
     relative_path = rcutils_to_native_path(name + 1, *allocator);
-    contexts_dir = rcutils_join_path(ros_secure_root_env, "contexts", *allocator);
     secure_root = rcutils_join_path(contexts_dir, relative_path, *allocator);
     allocator->deallocate(relative_path, allocator->state);
     allocator->deallocate(contexts_dir, allocator->state);

--- a/rcl/test/rcl/test_security.cpp
+++ b/rcl/test/rcl/test_security.cpp
@@ -134,6 +134,18 @@ TEST_F(TestGetSecureRoot, failureScenarios) {
   rcl_reset_error();
 }
 
+TEST_F(TestGetSecureRoot, successScenarios_local_root_security_context) {
+  putenv_wrapper(
+    ROS_SECURITY_ROOT_DIRECTORY_VAR_NAME "="
+    TEST_RESOURCES_DIRECTORY TEST_SECURITY_DIRECTORY_RESOURCES_DIR_NAME);
+
+  secure_root = rcl_get_secure_root("/", &allocator);
+  ASSERT_NE(nullptr, secure_root);
+  ASSERT_STREQ(
+    TEST_RESOURCES_DIRECTORY TEST_SECURITY_DIRECTORY_RESOURCES_DIR_NAME PATH_SEPARATOR "contexts",
+    secure_root);
+}
+
 TEST_F(TestGetSecureRoot, successScenarios_local_exactMatch) {
   putenv_wrapper(
     ROS_SECURITY_ROOT_DIRECTORY_VAR_NAME "="


### PR DESCRIPTION
Follow-up of https://github.com/ros2/rcl/pull/607.
It wasn't working correctly for the root security context: '/'.

Added test covering this corner case.