### PR TITLE
Add visibility to rcl_timer_get_allocator

### DIFF
--- a/rcl/include/rcl/timer.h
+++ b/rcl/include/rcl/timer.h
@@ -566,6 +566,8 @@ rcl_timer_reset(rcl_timer_t * timer);
  * \param[inout] timer handle to the timer object
  * \return pointer to the allocator, or `NULL` if an error occurred
  */
+RCL_PUBLIC
+RCL_WARN_UNUSED
 const rcl_allocator_t *
 rcl_timer_get_allocator(const rcl_timer_t * timer);
 

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -72,7 +72,6 @@ static void callback_function(rcl_timer_t * timer, int64_t last_call)
   (void) last_call;
   times_called++;
 }
-static rcl_timer_callback_t timer_callback_test = &callback_function;
 
 class TestPreInitTimer : public TestTimerFixture
 {
@@ -80,6 +79,7 @@ public:
   rcl_clock_t clock;
   rcl_allocator_t allocator;
   rcl_timer_t timer;
+  rcl_timer_callback_t timer_callback_test = &callback_function;
 
   void SetUp() override
   {
@@ -554,8 +554,7 @@ TEST_F(TestTimerFixture, test_ros_time_wakes_wait) {
 }
 
 TEST_F(TestPreInitTimer, test_timer_get_allocator) {
-  const rcl_allocator_t * allocator_returned;
-  allocator_returned = rcl_timer_get_allocator(&timer);
+  const rcl_allocator_t * allocator_returned = rcl_timer_get_allocator(&timer);
   EXPECT_TRUE(rcutils_allocator_is_valid(allocator_returned));
 
   EXPECT_EQ(NULL, rcl_timer_get_allocator(nullptr));

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -552,3 +552,11 @@ TEST_F(TestTimerFixture, test_ros_time_wakes_wait) {
   EXPECT_TRUE(timer_was_ready);
   EXPECT_LT(finish - start, std::chrono::milliseconds(100));
 }
+
+TEST_F(TestPreInitTimer, test_timer_get_allocator) {
+  const rcl_allocator_t * allocator_returned;
+  allocator_returned = rcl_timer_get_allocator(&timer);
+  EXPECT_TRUE(rcutils_allocator_is_valid(allocator_returned));
+
+  EXPECT_EQ(NULL, rcl_timer_get_allocator(nullptr));
+}


### PR DESCRIPTION
Added RCL_PUBLIC macro to be able of using `rcl_timer_get_allocator` outside the timer module. 

Also added tests to check the proper usage of this function.