### PR TITLE
Reduce the internal timeouts

### DIFF
--- a/rcl/test/rcl/client_fixture.cpp
+++ b/rcl/test/rcl/client_fixture.cpp
@@ -179,7 +179,7 @@ int main(int argc, char ** argv)
     });
 
     // Wait until server is available
-    if (!wait_for_server_to_be_available(&node, &client, 1000, 100)) {
+    if (!wait_for_server_to_be_available(&node, &client, 10, 100)) {
       RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME, "Server never became available");
       return -1;
     }
@@ -214,7 +214,7 @@ int main(int argc, char ** argv)
     memset(&client_response, 0, sizeof(test_msgs__srv__BasicTypes_Response));
     test_msgs__srv__BasicTypes_Response__init(&client_response);
 
-    if (!wait_for_client_to_be_ready(&client, &context, 1000, 100)) {
+    if (!wait_for_client_to_be_ready(&client, &context, 10, 100)) {
       RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME, "Client never became ready");
       return -1;
     }

--- a/rcl/test/rcl/service_fixture.cpp
+++ b/rcl/test/rcl/service_fixture.cpp
@@ -164,7 +164,7 @@ int main(int argc, char ** argv)
 
     // Block until a client request comes in.
 
-    if (!wait_for_service_to_be_ready(&service, &context, 1000, 100)) {
+    if (!wait_for_service_to_be_ready(&service, &context, 10, 100)) {
       RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME, "Service never became ready");
       return -1;
     }


### PR DESCRIPTION
Debugging #611 these timeouts were so long that the overall test timeout was being triggered before these internal timeouts were triggered.

1000 retries at 100ms -> 10 seconds each. I cut it down to 1 second for each to establish the connection.

Reducing these helps narrow down the focus on where things are actually failing. 
