### PR TITLE
Save allocator for RCL_CLOCK_UNINITIALIZED clock.

### DIFF
--- a/rcl/src/rcl/time.c
+++ b/rcl/src/rcl/time.c
@@ -158,7 +158,6 @@ rcl_ros_clock_init(
   storage->active = false;
   clock->get_now = rcl_get_ros_time;
   clock->type = RCL_ROS_TIME;
-  clock->allocator = *allocator;
   return RCL_RET_OK;
 }
 
@@ -190,7 +189,6 @@ rcl_steady_clock_init(
   rcl_init_generic_clock(clock, allocator);
   clock->get_now = rcl_get_steady_time;
   clock->type = RCL_STEADY_TIME;
-  clock->allocator = *allocator;
   return RCL_RET_OK;
 }
 
@@ -217,7 +215,6 @@ rcl_system_clock_init(
   rcl_init_generic_clock(clock, allocator);
   clock->get_now = rcl_get_system_time;
   clock->type = RCL_SYSTEM_TIME;
-  clock->allocator = *allocator;
   return RCL_RET_OK;
 }
 

--- a/rcl/src/rcl/time.c
+++ b/rcl/src/rcl/time.c
@@ -48,13 +48,14 @@ rcl_get_system_time(void * data, rcl_time_point_value_t * current_time)
 
 // Internal method for zeroing values on init, assumes clock is valid
 static void
-rcl_init_generic_clock(rcl_clock_t * clock)
+rcl_init_generic_clock(rcl_clock_t * clock, rcl_allocator_t * allocator)
 {
   clock->type = RCL_CLOCK_UNINITIALIZED;
   clock->jump_callbacks = NULL;
   clock->num_jump_callbacks = 0u;
   clock->get_now = NULL;
   clock->data = NULL;
+  clock->allocator = *allocator;
 }
 
 // The function used to get the current ros time.
@@ -91,7 +92,7 @@ rcl_clock_init(
   switch (clock_type) {
     case RCL_CLOCK_UNINITIALIZED:
       RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT);
-      rcl_init_generic_clock(clock);
+      rcl_init_generic_clock(clock, allocator);
       return RCL_RET_OK;
     case RCL_ROS_TIME:
       return rcl_ros_clock_init(clock, allocator);
@@ -144,7 +145,7 @@ rcl_ros_clock_init(
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(allocator, RCL_RET_INVALID_ARGUMENT);
-  rcl_init_generic_clock(clock);
+  rcl_init_generic_clock(clock, allocator);
   clock->data = allocator->allocate(sizeof(rcl_ros_clock_storage_t), allocator->state);
   if (NULL == clock->data) {
     RCL_SET_ERROR_MSG("allocating memory failed");
@@ -186,7 +187,7 @@ rcl_steady_clock_init(
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(allocator, RCL_RET_INVALID_ARGUMENT);
-  rcl_init_generic_clock(clock);
+  rcl_init_generic_clock(clock, allocator);
   clock->get_now = rcl_get_steady_time;
   clock->type = RCL_STEADY_TIME;
   clock->allocator = *allocator;
@@ -213,7 +214,7 @@ rcl_system_clock_init(
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(clock, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(allocator, RCL_RET_INVALID_ARGUMENT);
-  rcl_init_generic_clock(clock);
+  rcl_init_generic_clock(clock, allocator);
   clock->get_now = rcl_get_system_time;
   clock->type = RCL_SYSTEM_TIME;
   clock->allocator = *allocator;

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -263,11 +263,22 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), specific_clock_instantiation) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   {
     rcl_clock_t uninitialized_clock;
-    rcl_ret_t ret = rcl_clock_init(
-      RCL_CLOCK_UNINITIALIZED, &uninitialized_clock, &allocator);
+    rcl_ret_t ret = rcl_clock_init(RCL_CLOCK_UNINITIALIZED, &uninitialized_clock, &allocator);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
     EXPECT_EQ(uninitialized_clock.type, RCL_CLOCK_UNINITIALIZED) <<
       "Expected time source of type RCL_CLOCK_UNINITIALIZED";
+    ret = rcl_clock_fini(&uninitialized_clock);
+    EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT) << rcl_get_error_string().str;
+    rcl_reset_error();
+    EXPECT_EQ(
+      rcl_ros_clock_fini(&uninitialized_clock), RCL_RET_ERROR) << rcl_get_error_string().str;
+    rcl_reset_error();
+    EXPECT_EQ(
+      rcl_steady_clock_fini(&uninitialized_clock), RCL_RET_ERROR) << rcl_get_error_string().str;
+    rcl_reset_error();
+    EXPECT_EQ(
+      rcl_system_clock_fini(&uninitialized_clock), RCL_RET_ERROR) << rcl_get_error_string().str;
+    rcl_reset_error();
   }
   {
     rcl_clock_t ros_clock;
@@ -295,6 +306,12 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), specific_clock_instantiation) {
       "Expected time source of type RCL_STEADY_TIME";
     ret = rcl_clock_fini(&steady_clock);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+  }
+  {
+    rcl_clock_t fail_clock;
+    rcl_clock_type_t undefined_type = (rcl_clock_type_t) 130;
+    rcl_ret_t ret = rcl_clock_init(undefined_type, &fail_clock, &allocator);
+    EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT) << rcl_get_error_string().str;
   }
 }
 

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -267,9 +267,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), specific_clock_instantiation) {
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
     EXPECT_EQ(uninitialized_clock.type, RCL_CLOCK_UNINITIALIZED) <<
       "Expected time source of type RCL_CLOCK_UNINITIALIZED";
-    ret = rcl_clock_fini(&uninitialized_clock);
-    EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT) << rcl_get_error_string().str;
-    rcl_reset_error();
+    EXPECT_TRUE(rcutils_allocator_is_valid(&(uninitialized_clock.allocator)));
   }
   {
     rcl_clock_t ros_clock;

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -270,15 +270,6 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), specific_clock_instantiation) {
     ret = rcl_clock_fini(&uninitialized_clock);
     EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT) << rcl_get_error_string().str;
     rcl_reset_error();
-    EXPECT_EQ(
-      rcl_ros_clock_fini(&uninitialized_clock), RCL_RET_ERROR) << rcl_get_error_string().str;
-    rcl_reset_error();
-    EXPECT_EQ(
-      rcl_steady_clock_fini(&uninitialized_clock), RCL_RET_ERROR) << rcl_get_error_string().str;
-    rcl_reset_error();
-    EXPECT_EQ(
-      rcl_system_clock_fini(&uninitialized_clock), RCL_RET_ERROR) << rcl_get_error_string().str;
-    rcl_reset_error();
   }
   {
     rcl_clock_t ros_clock;
@@ -306,12 +297,6 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), specific_clock_instantiation) {
       "Expected time source of type RCL_STEADY_TIME";
     ret = rcl_clock_fini(&steady_clock);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
-  }
-  {
-    rcl_clock_t fail_clock;
-    rcl_clock_type_t undefined_type = (rcl_clock_type_t) 130;
-    rcl_ret_t ret = rcl_clock_init(undefined_type, &fail_clock, &allocator);
-    EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT) << rcl_get_error_string().str;
   }
 }
 


### PR DESCRIPTION
Allocator is passed in `rcl_clock_init` call with type `RCL_CLOCK_UNINITIALIZED`, seems reasonable to save it as it is done with the other types. This will match the expected behavior of `rcl_clock_fini` returning `RCL_RET_INVALID_ARGUMENT` for this type of clocks instead of `RCL_RET_ERROR` due to the allocator check.