### PR TITLE
Documentation rcl_pub/etc_fini() must come before rcl_node_fini()

### DIFF
--- a/rcl/include/rcl/client.h
+++ b/rcl/include/rcl/client.h
@@ -174,7 +174,7 @@ rcl_client_init(
  * Lock-Free          | Yes
  *
  * \param[inout] client handle to the client to be finalized
- * \param[in] node handle to the node used to create the client
+ * \param[in] node a valid (not finalized) handle to the node used to create the client
  * \return `RCL_RET_OK` if client was finalized successfully, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
  * \return `RCL_RET_NODE_INVALID` if the node is invalid, or

--- a/rcl/include/rcl/node.h
+++ b/rcl/include/rcl/node.h
@@ -153,8 +153,13 @@ rcl_node_init(
  * Destroys any automatically created infrastructure and deallocates memory.
  * After calling, the rcl_node_t can be safely deallocated.
  *
- * Any middleware primitives created by the user, e.g. publishers, services, etc.,
- * are invalid after deinitialization.
+ * All middleware primitives created by the user, e.g. publishers, services, etc,
+ * which were created from this node must be finalized using their respective
+ * `rcl_*_fini()` functions before this is called.
+ * \sa rcl_publisher_fini()
+ * \sa rcl_subscription_fini()
+ * \sa rcl_client_fini()
+ * \sa rcl_service_fini()
  *
  * <hr>
  * Attribute          | Adherence

--- a/rcl/include/rcl/publisher.h
+++ b/rcl/include/rcl/publisher.h
@@ -172,7 +172,7 @@ rcl_publisher_init(
  * Lock-Free          | Yes
  *
  * \param[inout] publisher handle to the publisher to be finalized
- * \param[in] node handle to the node used to create the publisher
+ * \param[in] node a valid (not finalized) handle to the node used to create the publisher
  * \return `RCL_RET_OK` if publisher was finalized successfully, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
  * \return `RCL_RET_PUBLISHER_INVALID` if the publisher is invalid, or

--- a/rcl/include/rcl/service.h
+++ b/rcl/include/rcl/service.h
@@ -173,7 +173,7 @@ rcl_service_init(
  * Lock-Free          | Yes
  *
  * \param[inout] service handle to the service to be deinitialized
- * \param[in] node handle to the node used to create the service
+ * \param[in] node a valid (not finalized) handle to the node used to create the service
  * \return `RCL_RET_OK` if service was deinitialized successfully, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
  * \return `RCL_RET_SERVICE_INVALID` if the service is invalid, or

--- a/rcl/include/rcl/subscription.h
+++ b/rcl/include/rcl/subscription.h
@@ -175,7 +175,7 @@ rcl_subscription_init(
  * Lock-Free          | Yes
  *
  * \param[inout] subscription handle to the subscription to be deinitialized
- * \param[in] node handle to the node used to create the subscription
+ * \param[in] node a valid (not finalized) handle to the node used to create the subscription
  * \return `RCL_RET_OK` if subscription was deinitialized successfully, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
  * \return `RCL_RET_SUBSCRIPTION_INVALID` if the subscription is invalid, or


### PR DESCRIPTION
Context https://github.com/ros2/rcl/issues/585#issuecomment-616760593

In short, this documents that the client library using `rcl` must ensure entities created from nodes are finalized before the node itself is finalized.