### PR TITLE
Added rcl_lifecycle Doxyfile

### DIFF
--- a/rcl_lifecycle/Doxyfile
+++ b/rcl_lifecycle/Doxyfile
@@ -16,18 +16,14 @@ GENERATE_LATEX         = NO
 ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES
-PREDEFINED             += RCL_PUBLIC=
-PREDEFINED             += RCL_WARN_UNUSED=
-
-# Uncomment to generate internal documentation.
-#ENABLED_SECTIONS       = INTERNAL
-#INPUT                  += ./src/rcl/arguments.c
+PREDEFINED             += RCL_LIFECYCLE_PUBLIC=
 
 # Tag files that do not exist will produce a warning and cross-project linking will not work.
 TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
 # Consider changing "latest" to the version you want to reference (e.g. beta1 or 1.0.0)
-TAGFILES += "../../../../doxygen_tag_files/rcl.tag=http://docs.ros2.org//api/rcl/"
-TAGFILES += "../../../../doxygen_tag_files/rmw.tag=http://docs.ros2.org//api/rmw/"
-TAGFILES += "../../../../doxygen_tag_files/rcutils.tag=http://docs.ros2.org//api/rcutils/"
+TAGFILES += "../../../../doxygen_tag_files/rcl.tag=http://docs.ros2.org/latest/api/rcl/"
+TAGFILES += "../../../../doxygen_tag_files/rmw.tag=http://docs.ros2.org/latest/api/rmw/"
+TAGFILES += "../../../../doxygen_tag_files/rcutils.tag=http://docs.ros2.org/latest/api/rcutils/"
+TAGFILES += "../../../../doxygen_tag_files/rosidl_runtime_c.tag=http://docs.ros2.org/latest/api/rosidl_runtime_c/"
 # Uncomment to generate tag files for cross-project linking.
 GENERATE_TAGFILE = "../../../../doxygen_tag_files/rcl_lifecycle.tag"

--- a/rcl_lifecycle/Doxyfile
+++ b/rcl_lifecycle/Doxyfile
@@ -1,0 +1,33 @@
+# All settings not listed here will use the Doxygen default values.
+
+PROJECT_NAME           = "rcl_lifecycle"
+PROJECT_NUMBER         = master
+PROJECT_BRIEF          = "C API providing common functionality for ROS lifecycle."
+
+INPUT                  = ./include
+RECURSIVE              = YES
+OUTPUT_DIRECTORY       = doc_output
+
+EXTRACT_ALL            = YES
+SORT_MEMBER_DOCS       = NO
+
+GENERATE_LATEX         = NO
+
+ENABLE_PREPROCESSING   = YES
+MACRO_EXPANSION        = YES
+EXPAND_ONLY_PREDEF     = YES
+PREDEFINED             += RCL_PUBLIC=
+PREDEFINED             += RCL_WARN_UNUSED=
+
+# Uncomment to generate internal documentation.
+#ENABLED_SECTIONS       = INTERNAL
+#INPUT                  += ./src/rcl/arguments.c
+
+# Tag files that do not exist will produce a warning and cross-project linking will not work.
+TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
+# Consider changing "latest" to the version you want to reference (e.g. beta1 or 1.0.0)
+TAGFILES += "../../../../doxygen_tag_files/rcl.tag=http://docs.ros2.org//api/rcl/"
+TAGFILES += "../../../../doxygen_tag_files/rmw.tag=http://docs.ros2.org//api/rmw/"
+TAGFILES += "../../../../doxygen_tag_files/rcutils.tag=http://docs.ros2.org//api/rcutils/"
+# Uncomment to generate tag files for cross-project linking.
+GENERATE_TAGFILE = "../../../../doxygen_tag_files/rcl_lifecycle.tag"


### PR DESCRIPTION
Added Doxyfile to `rcl_lifecycle` in the process of reaching Quality Level 1.

In the repo [docs.ros2.org](https://github.com/ros2/docs.ros2.org/) branch `gen_doc`. The [documentation](https://github.com/ros2/docs.ros2.org/blob/doc_gen/Makefile#L9) of `rcl_lifecycle` is trying to be build but there is no Doxyfile.

Signed-off-by: ahcorde <ahcorde@gmail.com>