### PR TITLE
Fix std::string construction

### DIFF
--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -556,7 +556,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
       ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
       ASSERT_EQ(
         std::string(test_string),
-        std::string(*msg_loaned->string_value.data, msg_loaned->string_value.size));
+        std::string(msg_loaned->string_value.data, msg_loaned->string_value.size));
     } else {
       ret = rcl_take(&subscription, &msg, nullptr, nullptr);
       ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;


### PR DESCRIPTION
This pull request aims to fix [a warning seen on nightly Windows builds](https://ci.ros2.org/view/nightly/job/nightly_win_rel/1533/msbuild/category.63474818/). This was first observed when running CI for [ros2/launch#408](https://github.com/ros2/launch/pull/408#issuecomment-620162001). 

I also believe that this is what the test author actually meant to do.

CI up to `rcl`:
- Windows [![Build Status](https://ci.ros2.org/job/ci_windows/10402/badge/icon)](https://ci.ros2.org/job/ci_windows/10402/) 