### PR TITLE
Add sleep before getting publisher info.

### DIFF
--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -109,7 +109,7 @@ function(test_target_function)
     set(AMENT_GTEST_ARGS TIMEOUT 120)
   endif()
   rcl_add_custom_gtest(test_info_by_topic${target_suffix}
-    SRCS rcl/test_info_by_topic.cpp
+    SRCS rcl/test_info_by_topic.cpp rcl/wait_for_entity_helpers.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME}

--- a/rcl/test/rcl/test_info_by_topic.cpp
+++ b/rcl/test/rcl/test_info_by_topic.cpp
@@ -18,8 +18,10 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <memory>
 #include <string>
+#include <thread>
 
 #include "rcl/error_handling.h"
 #include "rcl/graph.h"
@@ -357,6 +359,7 @@ TEST_F(
     &subscription_options);
   ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
   const std::string fqdn = std::string("/") + this->topic_name;
+  std::this_thread::sleep_for(std::chrono::milliseconds(250));
   // Get publishers info by topic
   rmw_topic_endpoint_info_array_t topic_endpoint_info_array_pub =
     rmw_get_zero_initialized_topic_endpoint_info_array();

--- a/rcl/test/rcl/test_info_by_topic.cpp
+++ b/rcl/test/rcl/test_info_by_topic.cpp
@@ -362,31 +362,6 @@ TEST_F(
   ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
   const std::string fqdn = std::string("/") + this->topic_name;
   ASSERT_TRUE(wait_for_established_subscription(&publisher, 10, 100));
-  //size_t max_tries = 10;
-  //size_t iteration = 0;
-  //size_t publisher_count = 0;
-  //do {
-  //      	ret = rcl_count_publishers(&this->node, fqdn.c_str(), &publisher_count);
-  //      	if (publisher_count >= 1) {
-  //      		break;
-  //      	}
-  //      	++iteration;
-  //      	std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  //} while (iteration < max_tries || publisher_count < 1);
-  //      ASSERT_EQ(publisher_count, 1u) << "Unexpected publisher count";
-  //max_tries = 10;
-  //iteration = 0;
-  //size_t subscriber_count = 0;
-  //do {
-  //      	ret = rcl_count_subscribers(&this->node, fqdn.c_str(), &subscriber_count);
-  //      	if (subscriber_count >= 1) {
-  //      		break;
-  //      	}
-  //      	++iteration;
-  //      	std::this_thread::sleep_for(std::chrono::milliseconds(100));
-  //} while (iteration < max_tries);
-  //      ASSERT_EQ(subscriber_count, 1u) << "Unexpected subscriber count";
-  //ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
   ASSERT_TRUE(wait_for_subscription_to_be_ready(&subscription, &this->context, 10, 100));
   // Get publishers info by topic
   rmw_topic_endpoint_info_array_t topic_endpoint_info_array_pub =

--- a/rcl/test/rcl/test_info_by_topic.cpp
+++ b/rcl/test/rcl/test_info_by_topic.cpp
@@ -35,6 +35,8 @@
 
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 
+#include "wait_for_entity_helpers.hpp"
+
 #ifdef RMW_IMPLEMENTATION
 # define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
 # define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
@@ -359,7 +361,33 @@ TEST_F(
     &subscription_options);
   ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
   const std::string fqdn = std::string("/") + this->topic_name;
-  std::this_thread::sleep_for(std::chrono::milliseconds(250));
+  ASSERT_TRUE(wait_for_established_subscription(&publisher, 10, 100));
+  //size_t max_tries = 10;
+  //size_t iteration = 0;
+  //size_t publisher_count = 0;
+  //do {
+  //      	ret = rcl_count_publishers(&this->node, fqdn.c_str(), &publisher_count);
+  //      	if (publisher_count >= 1) {
+  //      		break;
+  //      	}
+  //      	++iteration;
+  //      	std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  //} while (iteration < max_tries || publisher_count < 1);
+  //      ASSERT_EQ(publisher_count, 1u) << "Unexpected publisher count";
+  //max_tries = 10;
+  //iteration = 0;
+  //size_t subscriber_count = 0;
+  //do {
+  //      	ret = rcl_count_subscribers(&this->node, fqdn.c_str(), &subscriber_count);
+  //      	if (subscriber_count >= 1) {
+  //      		break;
+  //      	}
+  //      	++iteration;
+  //      	std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  //} while (iteration < max_tries);
+  //      ASSERT_EQ(subscriber_count, 1u) << "Unexpected subscriber count";
+  //ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+  ASSERT_TRUE(wait_for_subscription_to_be_ready(&subscription, &this->context, 10, 100));
   // Get publishers info by topic
   rmw_topic_endpoint_info_array_t topic_endpoint_info_array_pub =
     rmw_get_zero_initialized_topic_endpoint_info_array();


### PR DESCRIPTION
This test appears to be timing/load sensitive. I can reproduce
intermittent failures locally when stressing my host and the more stress
the faster the reproduction. Since adding the sleep I have not seen any
failures to find the expected publisher info locally.

This seems to resolve unreliable test failures such as [this one](https://ci.ros2.org/job/nightly_linux-aarch64_repeated/1185/testReport/projectroot/test/test_info_by_topic__rmw_cyclonedds_cpp/). There still appear to be occasional segfaults when using rmw_fastrtps_cpp or rmw_fastrtps_dynamic_cpp which I don't think are related.