### PR TITLE
warn about unused return value for set_logger_level

### DIFF
--- a/rcl/include/rcl/logging_external_interface.h
+++ b/rcl/include/rcl/logging_external_interface.h
@@ -19,6 +19,10 @@
 #include "rcl/types.h"
 #include "rcl/visibility_control.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /// Initialize the external logging library.
 /**
  * \param[in] config_file The location of a config file that the external
@@ -78,6 +82,11 @@ rcl_logging_external_log(int severity, const char * name, const char * msg);
  * \return RCL_RET_ERROR if an unspecified error occurs.
  */
 RCL_PUBLIC
+RCL_WARN_UNUSED
 rcl_ret_t rcl_logging_external_set_logger_level(const char * name, int level);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif  // RCL__LOGGING_EXTERNAL_INTERFACE_H_

--- a/rcl/include/rcl/macros.h
+++ b/rcl/include/rcl/macros.h
@@ -23,7 +23,7 @@ extern "C"
 /// Ignored return values of functions with this macro will emit a warning.
 #define RCL_WARN_UNUSED RCUTILS_WARN_UNUSED
 
-#define RCL_UNUSED(x) RCUTILS_UNUSED(x)
+#define RCL_UNUSED(x) (void)(x)
 
 #ifdef __cplusplus
 }

--- a/rcl/include/rcl/macros.h
+++ b/rcl/include/rcl/macros.h
@@ -20,14 +20,10 @@ extern "C"
 {
 #endif
 
-#ifndef _WIN32
 /// Ignored return values of functions with this macro will emit a warning.
-# define RCL_WARN_UNUSED __attribute__((warn_unused_result))
-#else
-# define RCL_WARN_UNUSED _Check_return_
-#endif
+#define RCL_WARN_UNUSED RCUTILS_WARN_UNUSED
 
-#define RCL_UNUSED(x) (void)(x)
+#define RCL_UNUSED(x) RCUTILS_UNUSED(x)
 
 #ifdef __cplusplus
 }

--- a/rcl/src/rcl/logging.c
+++ b/rcl/src/rcl/logging.c
@@ -95,7 +95,13 @@ rcl_logging_configure(const rcl_arguments_t * global_args, const rcl_allocator_t
   if (g_rcl_logging_ext_lib_enabled) {
     status = rcl_logging_external_initialize(config_file, g_logging_allocator);
     if (RCL_RET_OK == status) {
-      rcl_logging_external_set_logger_level(NULL, default_level);
+      // TODO(dirk-thomas) the return value should be typed and compared to
+      // constants instead of zero
+      int logging_status = rcl_logging_external_set_logger_level(
+        NULL, default_level);
+      if (logging_status != 0) {
+        status = RCL_RET_ERROR;
+      }
       g_rcl_logging_out_handlers[g_rcl_logging_num_out_handlers++] =
         rcl_logging_ext_lib_output_handler;
     }


### PR DESCRIPTION
Redo of dropped #650. Fixes #651.