### PR TITLE
Expose rcl default logging output handler

### DIFF
--- a/rcl/include/rcl/logging.h
+++ b/rcl/include/rcl/logging.h
@@ -21,11 +21,14 @@
 #include "rcl/types.h"
 #include "rcl/visibility_control.h"
 
+#include "rcutils/logging.h"
+
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
+typedef rcutils_logging_output_handler_t rcl_logging_output_handler_t;
 
 /// Configure the logging system.
 /**
@@ -52,6 +55,34 @@ rcl_ret_t
 rcl_logging_configure(
   const rcl_arguments_t * global_args,
   const rcl_allocator_t * allocator);
+
+/// Configure the logging system with the provided output handler.
+/**
+ * Similar to rcl_logging_configure, but it uses the provided output handler.
+ * \sa rcl_logging_configure
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param global_args The global arguments for the system
+ * \param allocator Used to allocate memory used by the logging system
+ * \param output_handler Output handler to be installed
+ * \return `RCL_RET_OK` if successful, or
+ * \return `RCL_RET_BAD_ALLOC` if allocating memory failed, or
+ * \return `RCL_RET_ERR` if a general error occurs
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_logging_configure_with_output_handler(
+  const rcl_arguments_t * global_args,
+  const rcl_allocator_t * allocator,
+  rcl_logging_output_handler_t output_handler);
 
 /**
  * This function should be called to tear down the logging setup by the configure function.
@@ -89,6 +120,31 @@ rcl_ret_t rcl_logging_fini();
 RCL_PUBLIC
 RCL_WARN_UNUSED
 bool rcl_logging_rosout_enabled();
+
+/// Default output handler used by rcl.
+/**
+ * This function can be wrapped in a language specific client library,
+ * adding the necessary mutual exclusion protection there, and then used
+ * by calling `rcl_logging_configure_with_output_handler` instead of
+ * `rcl_logging_configure`.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | Yes
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \return `TRUE` if logging rosout is enabled, or
+ * \return `FALSE` if logging rosout is disabled.
+ */
+RCL_PUBLIC
+void
+rcl_logging_multiple_output_handler(
+  const rcutils_log_location_t * location,
+  int severity, const char * name, rcutils_time_point_value_t timestamp,
+  const char * format, va_list * args);
 
 #ifdef __cplusplus
 }

--- a/rcl/include/rcl/logging.h
+++ b/rcl/include/rcl/logging.h
@@ -124,8 +124,8 @@ bool rcl_logging_rosout_enabled();
 /// Default output handler used by rcl.
 /**
  * This function can be wrapped in a language specific client library,
- * adding the necessary mutual exclusion protection there, and then used
- * by calling `rcl_logging_configure_with_output_handler` instead of
+ * adding the necessary mutual exclusion protection there, and then use
+ * `rcl_logging_configure_with_output_handler` instead of
  * `rcl_logging_configure`.
  *
  * <hr>
@@ -135,9 +135,6 @@ bool rcl_logging_rosout_enabled();
  * Thread-Safe        | Yes
  * Uses Atomics       | No
  * Lock-Free          | Yes
- *
- * \return `TRUE` if logging rosout is enabled, or
- * \return `FALSE` if logging rosout is disabled.
  */
 RCL_PUBLIC
 void


### PR DESCRIPTION
This will be need to be able to address https://github.com/ros2/rclcpp/issues/1042.

I've tried out the demos without doing changes in `rclcpp`/`rclpy`, and logging continues working well with this change.