### PR TITLE
QD Security Vulnerability Declaration: REP 2006

### DIFF
--- a/rcl/QUALITY_DECLARATION.md
+++ b/rcl/QUALITY_DECLARATION.md
@@ -203,7 +203,7 @@ It is **Quality Level 4**, see its [Quality Declaration document](https://gitlab
 
 ### Vulnerability Disclosure Policy [7.i]
 
-`rcl` does not have a Vulnerability Disclosure Policy.
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).
 
 # Current status Summary
 

--- a/rcl_action/QUALITY_DECLARATION.md
+++ b/rcl_action/QUALITY_DECLARATION.md
@@ -167,4 +167,4 @@ Currently nightly results can be seen here:
 
 ## Vulnerability Disclosure Policy [7.i]
 
-This package does not yet have a Vulnerability Disclosure Policy.
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rcl_lifecycle/QUALITY_DECLARATION.md
+++ b/rcl_lifecycle/QUALITY_DECLARATION.md
@@ -166,4 +166,4 @@ Currently nightly results can be seen here:
 
 ## Vulnerability Disclosure Policy [7.i]
 
-This package does not yet have a Vulnerability Disclosure Policy.
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).

--- a/rcl_yaml_param_parser/QUALITY_DECLARATION.md
+++ b/rcl_yaml_param_parser/QUALITY_DECLARATION.md
@@ -150,4 +150,4 @@ Currently nightly results can be seen here:
 
 ## Vulnerability Disclosure Policy [7.i]
 
-This package does not yet have a Vulnerability Disclosure Policy.
+This package conforms to the Vulnerability Disclosure Policy in [REP-2006](https://www.ros.org/reps/rep-2006.html).


### PR DESCRIPTION
This PR adds a link to REP-2006 (the Security Vulnerability Declaration) to the Quality Declaration for this repository.

Connects to ros2/ros2#924.