### PR TITLE
transition start and goal states can be null

### DIFF
--- a/rcl_lifecycle/src/rcl_lifecycle.c
+++ b/rcl_lifecycle/src/rcl_lifecycle.c
@@ -132,16 +132,6 @@ rcl_lifecycle_transition_init(
     return RCL_RET_ERROR;
   }
 
-  if (!start) {
-    RCL_SET_ERROR_MSG("start state pointer is null\n");
-    return RCL_RET_ERROR;
-  }
-
-  if (!goal) {
-    RCL_SET_ERROR_MSG("goal state pointer is null\n");
-    return RCL_RET_ERROR;
-  }
-
   transition->start = start;
   transition->goal = goal;
 

--- a/rcl_lifecycle/test/test_rcl_lifecycle.cpp
+++ b/rcl_lifecycle/test/test_rcl_lifecycle.cpp
@@ -133,12 +133,12 @@ TEST(TestRclLifecycle, lifecycle_transition) {
 
   ret = rcl_lifecycle_transition_init(
     &transition, expected_id, &expected_label[0], nullptr, nullptr, &allocator);
-  EXPECT_EQ(ret, RCL_RET_ERROR);
+  EXPECT_EQ(ret, RCL_RET_OK);
   rcutils_reset_error();
 
   ret = rcl_lifecycle_transition_init(
     &transition, expected_id, &expected_label[0], start, nullptr, &allocator);
-  EXPECT_EQ(ret, RCL_RET_ERROR);
+  EXPECT_EQ(ret, RCL_RET_OK);
   rcutils_reset_error();
 
   rcl_allocator_t bad_allocator = rcl_get_default_allocator();


### PR DESCRIPTION
The lifecycle transitions can be _lazy_ initialized, meaning that the start and goal state can be null at the time of initialization: https://github.com/ros2/rclcpp/blob/87bb9f9758dce239d37256ae91d58ce6325f405b/rclcpp_lifecycle/src/transition.cpp#L155-L156

This should fix the regression stated in here; https://github.com/ros2/rcl/pull/649#issuecomment-634723857