### PR TITLE
Address unused parameter warnings

### DIFF
--- a/rcl_action/src/rcl_action/goal_state_machine.c
+++ b/rcl_action/src/rcl_action/goal_state_machine.c
@@ -28,6 +28,9 @@ _execute_event_handler(rcl_action_goal_state_t state, rcl_action_goal_event_t ev
 {
   assert(GOAL_STATE_ACCEPTED == state);
   assert(GOAL_EVENT_EXECUTE == event);
+  // Avoid unused warnings, but keep asserts for debug purposes
+  (void)state;
+  (void)event;
   return GOAL_STATE_EXECUTING;
 }
 
@@ -36,6 +39,9 @@ _cancel_goal_event_handler(rcl_action_goal_state_t state, rcl_action_goal_event_
 {
   assert(GOAL_STATE_ACCEPTED == state || GOAL_STATE_EXECUTING == state);
   assert(GOAL_EVENT_CANCEL_GOAL == event);
+  // Avoid unused warnings, but keep asserts for debug purposes
+  (void)state;
+  (void)event;
   return GOAL_STATE_CANCELING;
 }
 
@@ -44,6 +50,9 @@ _succeed_event_handler(rcl_action_goal_state_t state, rcl_action_goal_event_t ev
 {
   assert(GOAL_STATE_EXECUTING == state || GOAL_STATE_CANCELING == state);
   assert(GOAL_EVENT_SUCCEED == event);
+  // Avoid unused warnings, but keep asserts for debug purposes
+  (void)state;
+  (void)event;
   return GOAL_STATE_SUCCEEDED;
 }
 
@@ -52,6 +61,9 @@ _abort_event_handler(rcl_action_goal_state_t state, rcl_action_goal_event_t even
 {
   assert(GOAL_STATE_EXECUTING == state || GOAL_STATE_CANCELING == state);
   assert(GOAL_EVENT_ABORT == event);
+  // Avoid unused warnings, but keep asserts for debug purposes
+  (void)state;
+  (void)event;
   return GOAL_STATE_ABORTED;
 }
 
@@ -60,6 +72,9 @@ _canceled_event_handler(rcl_action_goal_state_t state, rcl_action_goal_event_t e
 {
   assert(GOAL_STATE_CANCELING == state);
   assert(GOAL_EVENT_CANCELED == event);
+  // Avoid unused warnings, but keep asserts for debug purposes
+  (void)state;
+  (void)event;
   return GOAL_STATE_CANCELED;
 }
 


### PR DESCRIPTION
Removing the if statements in #663 caused unused parameter warnings in release mode. This adds in no-ops to remove the warnings.

Example failure:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10941)](http://ci.ros2.org/job/ci_linux/10941/)

Fixed issue, built in release mode
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10943)](http://ci.ros2.org/job/ci_linux/10943/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6288)](http://ci.ros2.org/job/ci_linux-aarch64/6288/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8911)](http://ci.ros2.org/job/ci_osx/8911/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10845)](http://ci.ros2.org/job/ci_windows/10845/)

Debug mode:
* Linux [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux)](https://ci.ros2.org/job/ci_linux/)