### PR TITLE
Ensure rcl_publisher_init() fails safely.

### DIFF
--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -198,6 +198,7 @@ rcl_publisher_init(
 fail:
   if (publisher->impl) {
     allocator->deallocate(publisher->impl, allocator->state);
+    publisher->impl = NULL;
   }
 
   ret = fail_ret;


### PR DESCRIPTION
Precisely what the title says.