### PR TITLE
Fix conversions between rmw_localhost_only_t and bool

### DIFF
--- a/rcl/src/rcl/init.c
+++ b/rcl/src/rcl/init.c
@@ -162,10 +162,6 @@ rcl_init(
       fail_ret = ret;
       goto fail;
     }
-  } else if (RMW_LOCALHOST_ONLY_DISABLED == *localhost_only) {
-    // If the user sets the rmw init option to RMW_LOCALHOST_ONLY_DISABLED
-    // manually, save the boolean variable as 0
-    *localhost_only = 0;
   }
 
   if (context->global_arguments.impl->enclave) {

--- a/rcl/src/rcl/init.c
+++ b/rcl/src/rcl/init.c
@@ -162,6 +162,10 @@ rcl_init(
       fail_ret = ret;
       goto fail;
     }
+  } else if (RMW_LOCALHOST_ONLY_DISABLED == *localhost_only) {
+    // If the user sets the rmw init option to RMW_LOCALHOST_ONLY_DISABLED
+    // manually, save the boolean variable as 0
+    *localhost_only = 0;
   }
 
   if (context->global_arguments.impl->enclave) {

--- a/rcl/src/rcl/localhost.c
+++ b/rcl/src/rcl/localhost.c
@@ -41,9 +41,9 @@ rcl_get_localhost_only(rmw_localhost_only_t * localhost_only)
       get_env_error_str);
     return RCL_RET_ERROR;
   }
-  *localhost_only = ros_local_host_env_val != NULL &&
+  *localhost_only = (ros_local_host_env_val != NULL &&
     strcmp(
-    ros_local_host_env_val,
-    "1") == 0 ? RMW_LOCALHOST_ONLY_ENABLED : RMW_LOCALHOST_ONLY_DISABLED;
+      ros_local_host_env_val,
+      "1") == 0) ? RMW_LOCALHOST_ONLY_ENABLED : RMW_LOCALHOST_ONLY_DISABLED;
   return RCL_RET_OK;
 }

--- a/rcl/src/rcl/localhost.c
+++ b/rcl/src/rcl/localhost.c
@@ -41,6 +41,9 @@ rcl_get_localhost_only(rmw_localhost_only_t * localhost_only)
       get_env_error_str);
     return RCL_RET_ERROR;
   }
-  *localhost_only = ros_local_host_env_val != NULL && strcmp(ros_local_host_env_val, "1") == 0;
+  *localhost_only = ros_local_host_env_val != NULL &&
+    strcmp(
+    ros_local_host_env_val,
+    "1") == 0 ? RMW_LOCALHOST_ONLY_ENABLED : RMW_LOCALHOST_ONLY_DISABLED;
   return RCL_RET_OK;
 }

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -263,11 +263,7 @@ rcl_node_init(
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Using domain ID of '%zu'", domain_id);
   node->impl->actual_domain_id = domain_id;
 
-  if (RMW_LOCALHOST_ONLY_DEFAULT == localhost_only) {
-    if (RMW_RET_OK != rcl_get_localhost_only(&localhost_only)) {
-      goto fail;
-    }
-  }
+  localhost_only = *(&context->impl->init_options.impl->rmw_init_options.localhost_only);
 
   node->impl->rmw_node_handle = rmw_create_node(
     &(node->context->impl->rmw_context),

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -267,7 +267,8 @@ rcl_node_init(
 
   node->impl->rmw_node_handle = rmw_create_node(
     &(node->context->impl->rmw_context),
-    name, local_namespace_, domain_id, localhost_only);
+    name, local_namespace_, domain_id,
+    localhost_only == RMW_LOCALHOST_ONLY_ENABLED);
 
   RCL_CHECK_FOR_NULL_WITH_MSG(
     node->impl->rmw_node_handle, rmw_get_error_string().str, goto fail);

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -263,7 +263,7 @@ rcl_node_init(
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Using domain ID of '%zu'", domain_id);
   node->impl->actual_domain_id = domain_id;
 
-  localhost_only = *(&context->impl->init_options.impl->rmw_init_options.localhost_only);
+  localhost_only = context->impl->init_options.impl->rmw_init_options.localhost_only;
 
   node->impl->rmw_node_handle = rmw_create_node(
     &(node->context->impl->rmw_context),


### PR DESCRIPTION
When initializing a node, the current code tries to load the localhost_only variable from the environment variable. This PR takes the value already parsed from the initialized context passed to the node.

Also fixes wrong result conversion with the `rcl_get_localhost_only` function.