### PR TITLE
Add check rcl_node_options_copy invalid out

### DIFF
--- a/rcl/src/rcl/node_options.c
+++ b/rcl/src/rcl/node_options.c
@@ -50,6 +50,10 @@ rcl_node_options_copy(
     RCL_SET_ERROR_MSG("Attempted to copy options into itself");
     return RCL_RET_INVALID_ARGUMENT;
   }
+  if (NULL != options_out->arguments.impl) {
+    RCL_SET_ERROR_MSG("Options out must be zero initialized");
+    return RCL_RET_INVALID_ARGUMENT;
+  }
   options_out->domain_id = options->domain_id;
   options_out->allocator = options->allocator;
   options_out->use_global_arguments = options->use_global_arguments;
@@ -57,8 +61,6 @@ rcl_node_options_copy(
   if (NULL != options->arguments.impl) {
     rcl_ret_t ret = rcl_arguments_copy(&(options->arguments), &(options_out->arguments));
     return ret;
-  } else {
-    options_out->arguments.impl = NULL;
   }
   return RCL_RET_OK;
 }

--- a/rcl/src/rcl/node_options.c
+++ b/rcl/src/rcl/node_options.c
@@ -57,6 +57,8 @@ rcl_node_options_copy(
   if (NULL != options->arguments.impl) {
     rcl_ret_t ret = rcl_arguments_copy(&(options->arguments), &(options_out->arguments));
     return ret;
+  } else {
+    options_out->arguments.impl = NULL;
   }
   return RCL_RET_OK;
 }

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -798,6 +798,5 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_options) {
 TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_options_fail) {
   rcl_node_options_t not_ini_options;
   rcl_node_options_t default_options = rcl_node_get_default_options();
-  EXPECT_EQ(RCL_RET_OK, rcl_node_options_copy(&default_options, &not_ini_options));
-  EXPECT_EQ(RCL_RET_OK, rcl_node_options_fini(&not_ini_options));
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_node_options_copy(&default_options, &not_ini_options));
 }

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -792,3 +792,12 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_options) {
   // EXPECT_EQ(RCL_RET_OK, rcl_node_options_copy(&default_options, &not_ini_options));
   // EXPECT_EQ(RCL_RET_OK, rcl_node_options_fini(&not_ini_options)); <-- code fails, returns -11
 }
+
+/* Tests special case node_options
+ */
+TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_options_fail) {
+  rcl_node_options_t not_ini_options;
+  rcl_node_options_t default_options = rcl_node_get_default_options();
+  EXPECT_EQ(RCL_RET_OK, rcl_node_options_copy(&default_options, &not_ini_options));
+  EXPECT_EQ(RCL_RET_OK, rcl_node_options_fini(&not_ini_options));
+}

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -784,13 +784,6 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_options) {
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_node_options_fini(nullptr));
   EXPECT_EQ(RCL_RET_OK, rcl_node_options_fini(&default_options));
   EXPECT_EQ(RCL_RET_OK, rcl_node_options_fini(&not_ini_options));
-
-  // (TODO: blast545) will be fixed with: https://github.com/ros2/rcl/pull/671
-  // This causes the test suite to fail:
-  // rcl_node_options_t default_options = rcl_node_get_default_options();
-  // rcl_node_options_t not_ini_options;
-  // EXPECT_EQ(RCL_RET_OK, rcl_node_options_copy(&default_options, &not_ini_options));
-  // EXPECT_EQ(RCL_RET_OK, rcl_node_options_fini(&not_ini_options)); <-- code fails, returns -11
 }
 
 /* Tests special case node_options

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -789,7 +789,13 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_options) {
 /* Tests special case node_options
  */
 TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_options_fail) {
-  rcl_node_options_t not_ini_options;
+  rcl_node_options_t prev_ini_options = rcl_node_get_default_options();
+  const char * argv[] = {"--ros-args"};
+  int argc = sizeof(argv) / sizeof(const char *);
+  EXPECT_EQ(
+    RCL_RET_OK,
+    rcl_parse_arguments(argc, argv, rcl_get_default_allocator(), &prev_ini_options.arguments));
+
   rcl_node_options_t default_options = rcl_node_get_default_options();
-  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_node_options_copy(&default_options, &not_ini_options));
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_node_options_copy(&default_options, &prev_ini_options));
 }


### PR DESCRIPTION
Found this scenario when adding tests for `rcl`, the attached test code in this PR causes a not handled exception when trying to call `rcl_node_options_fini` for `not_ini_options`.

I consider this a bug because `rcl_node_options_copy` seems to be a valid way to initialize `rcl_node_options_t` objects.

EDIT: Adding a check and changing the test to reflect that expected usage does not manage receiving a not initialized `rcl_node_options_t` object.