### PR TITLE
Add preemption to rcl_action

### DIFF
--- a/rcl_action/include/rcl_action/types.h
+++ b/rcl_action/include/rcl_action/types.h
@@ -91,7 +91,8 @@ typedef int8_t rcl_action_goal_state_t;
 #define GOAL_STATE_SUCCEEDED action_msgs__msg__GoalStatus__STATUS_SUCCEEDED
 #define GOAL_STATE_CANCELED action_msgs__msg__GoalStatus__STATUS_CANCELED
 #define GOAL_STATE_ABORTED action_msgs__msg__GoalStatus__STATUS_ABORTED
-#define GOAL_STATE_NUM_STATES 7
+#define GOAL_STATE_PREEMPTED action_msgs__msg__GoalStatus__STATUS_PREEMPTED
+#define GOAL_STATE_NUM_STATES 8
 
 /// User friendly error messages for invalid trasntions
 // Description variables in types.c should be changed if enum values change
@@ -105,6 +106,7 @@ typedef enum rcl_action_goal_event_t
   GOAL_EVENT_CANCEL_GOAL,
   GOAL_EVENT_SUCCEED,
   GOAL_EVENT_ABORT,
+  GOAL_EVENT_PREEMPT,
   GOAL_EVENT_CANCELED,
   GOAL_EVENT_NUM_EVENTS
 } rcl_action_goal_event_t;

--- a/rcl_action/src/rcl_action/goal_state_machine.c
+++ b/rcl_action/src/rcl_action/goal_state_machine.c
@@ -68,6 +68,17 @@ _abort_event_handler(rcl_action_goal_state_t state, rcl_action_goal_event_t even
 }
 
 rcl_action_goal_state_t
+_preempt_event_handler(rcl_action_goal_state_t state, rcl_action_goal_event_t event)
+{
+  assert(GOAL_STATE_EXECUTING == state || GOAL_STATE_CANCELING == state);
+  assert(GOAL_EVENT_PREEMPT == event);
+  // Avoid unused warnings, but keep asserts for debug purposes
+  (void)state;
+  (void)event;
+  return GOAL_STATE_PREEMPTED;
+}
+
+rcl_action_goal_state_t
 _canceled_event_handler(rcl_action_goal_state_t state, rcl_action_goal_event_t event)
 {
   assert(GOAL_STATE_CANCELING == state);
@@ -89,10 +100,12 @@ static rcl_action_goal_event_handler
     [GOAL_EVENT_CANCEL_GOAL] = _cancel_goal_event_handler,
     [GOAL_EVENT_SUCCEED] = _succeed_event_handler,
     [GOAL_EVENT_ABORT] = _abort_event_handler,
+    [GOAL_EVENT_PREEMPT] = _preempt_event_handler,
   },
   [GOAL_STATE_CANCELING] = {
     [GOAL_EVENT_SUCCEED] = _succeed_event_handler,
     [GOAL_EVENT_ABORT] = _abort_event_handler,
+    [GOAL_EVENT_PREEMPT] = _preempt_event_handler,
     [GOAL_EVENT_CANCELED] = _canceled_event_handler,
   },
 };

--- a/rcl_action/src/rcl_action/types.c
+++ b/rcl_action/src/rcl_action/types.c
@@ -134,10 +134,10 @@ rcl_action_cancel_response_fini(rcl_action_cancel_response_t * cancel_response)
 
 /// Values should be changed if enum values change
 const char * goal_state_descriptions[] =
-{"UNKNOWN", "ACCEPTED", "EXECUTING", "CANCELING", "SUCCEEDED", "CANCELED", "ABORTED"};
+{"UNKNOWN", "ACCEPTED", "EXECUTING", "CANCELING", "SUCCEEDED", "CANCELED", "ABORTED", "PREEMPTED"};
 
 const char * goal_event_descriptions[] =
-{"EXECUTE", "CANCEL_GOAL", "SUCCEED", "ABORT", "CANCELED", "NUM_EVENTS"};
+{"EXECUTE", "CANCEL_GOAL", "SUCCEED", "ABORT", "PREEMPT", "CANCELED", "NUM_EVENTS"};
 
 #ifdef __cplusplus
 }

--- a/rcl_action/test/rcl_action/test_goal_handle.cpp
+++ b/rcl_action/test/rcl_action/test_goal_handle.cpp
@@ -174,7 +174,7 @@ using EventStateActiveCancelableTuple =
   std::tuple<rcl_action_goal_event_t, rcl_action_goal_state_t, bool, bool>;
 using StateTransitionSequence = std::vector<EventStateActiveCancelableTuple>;
 const std::vector<std::string> event_strs = {
-  "EXECUTE", "CANCEL_GOAL", "SUCCEED", "ABORT", "CANCELED"};
+  "EXECUTE", "CANCEL_GOAL", "SUCCEED", "ABORT", "PREEMPT", "CANCELED"};
 
 class TestGoalHandleStateTransitionSequence
   : public ::testing::TestWithParam<StateTransitionSequence>
@@ -294,11 +294,20 @@ const StateTransitionSequence valid_state_transition_sequences[] = {
   },
   {
     std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_EXECUTING, true, true),
+    std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_CANCELING, true, false),
+    std::make_tuple(GOAL_EVENT_PREEMPT, GOAL_STATE_PREEMPTED, false, false),
+  },
+  {
+    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_EXECUTING, true, true),
     std::make_tuple(GOAL_EVENT_SUCCEED, GOAL_STATE_SUCCEEDED, false, false),
   },
   {
     std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_EXECUTING, true, true),
     std::make_tuple(GOAL_EVENT_ABORT, GOAL_STATE_ABORTED, false, false),
+  },
+  {
+    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_EXECUTING, true, true),
+    std::make_tuple(GOAL_EVENT_PREEMPT, GOAL_STATE_PREEMPTED, false, false),
   },
   {
     std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_CANCELING, true, false),
@@ -307,6 +316,10 @@ const StateTransitionSequence valid_state_transition_sequences[] = {
   {
     std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_CANCELING, true, false),
     std::make_tuple(GOAL_EVENT_ABORT, GOAL_STATE_ABORTED, false, false),
+  },
+  {
+    std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_CANCELING, true, false),
+    std::make_tuple(GOAL_EVENT_PREEMPT, GOAL_STATE_PREEMPTED, false, false),
   },
   // This is an odd case, but valid nonetheless
   {
@@ -344,6 +357,9 @@ const StateTransitionSequence invalid_state_transition_sequences[] = {
   },
   {
     std::make_tuple(GOAL_EVENT_ABORT, GOAL_STATE_UNKNOWN, false, false),
+  },
+  {
+    std::make_tuple(GOAL_EVENT_PREEMPT, GOAL_STATE_UNKNOWN, false, false),
   },
 };
 

--- a/rcl_action/test/rcl_action/test_goal_state_machine.cpp
+++ b/rcl_action/test/rcl_action/test_goal_state_machine.cpp
@@ -39,6 +39,10 @@ TEST(TestGoalStateMachine, test_valid_transitions)
     GOAL_EVENT_ABORT);
   EXPECT_EQ(GOAL_STATE_ABORTED, state);
   state = rcl_action_transition_goal_state(
+    GOAL_STATE_EXECUTING,
+    GOAL_EVENT_PREEMPT);
+  EXPECT_EQ(GOAL_STATE_PREEMPTED, state);
+  state = rcl_action_transition_goal_state(
     GOAL_STATE_CANCELING,
     GOAL_EVENT_CANCELED);
   EXPECT_EQ(GOAL_STATE_CANCELED, state);
@@ -46,6 +50,10 @@ TEST(TestGoalStateMachine, test_valid_transitions)
     GOAL_STATE_CANCELING,
     GOAL_EVENT_ABORT);
   EXPECT_EQ(GOAL_STATE_ABORTED, state);
+  state = rcl_action_transition_goal_state(
+    GOAL_STATE_CANCELING,
+    GOAL_EVENT_PREEMPT);
+  EXPECT_EQ(GOAL_STATE_PREEMPTED, state);
 }
 
 TEST(TestGoalStateMachine, test_invalid_transitions)
@@ -58,6 +66,10 @@ TEST(TestGoalStateMachine, test_invalid_transitions)
   state = rcl_action_transition_goal_state(
     GOAL_STATE_ACCEPTED,
     GOAL_EVENT_ABORT);
+  EXPECT_EQ(GOAL_STATE_UNKNOWN, state);
+  state = rcl_action_transition_goal_state(
+    GOAL_STATE_ACCEPTED,
+    GOAL_EVENT_PREEMPT);
   EXPECT_EQ(GOAL_STATE_UNKNOWN, state);
   state = rcl_action_transition_goal_state(
     GOAL_STATE_ACCEPTED,
@@ -103,6 +115,10 @@ TEST(TestGoalStateMachine, test_invalid_transitions)
   EXPECT_EQ(GOAL_STATE_UNKNOWN, state);
   state = rcl_action_transition_goal_state(
     GOAL_STATE_SUCCEEDED,
+    GOAL_EVENT_PREEMPT);
+  EXPECT_EQ(GOAL_STATE_UNKNOWN, state);
+  state = rcl_action_transition_goal_state(
+    GOAL_STATE_SUCCEEDED,
     GOAL_EVENT_CANCELED);
   EXPECT_EQ(GOAL_STATE_UNKNOWN, state);
 
@@ -125,6 +141,36 @@ TEST(TestGoalStateMachine, test_invalid_transitions)
   EXPECT_EQ(GOAL_STATE_UNKNOWN, state);
   state = rcl_action_transition_goal_state(
     GOAL_STATE_ABORTED,
+    GOAL_EVENT_PREEMPT);
+  EXPECT_EQ(GOAL_STATE_UNKNOWN, state);
+  state = rcl_action_transition_goal_state(
+    GOAL_STATE_ABORTED,
+    GOAL_EVENT_CANCELED);
+  EXPECT_EQ(GOAL_STATE_UNKNOWN, state);
+
+  // Invalid from PREEMPTED
+  state = rcl_action_transition_goal_state(
+    GOAL_STATE_PREEMPTED,
+    GOAL_EVENT_EXECUTE);
+  EXPECT_EQ(GOAL_STATE_UNKNOWN, state);
+  state = rcl_action_transition_goal_state(
+    GOAL_STATE_PREEMPTED,
+    GOAL_EVENT_CANCEL_GOAL);
+  EXPECT_EQ(GOAL_STATE_UNKNOWN, state);
+  state = rcl_action_transition_goal_state(
+    GOAL_STATE_PREEMPTED,
+    GOAL_EVENT_SUCCEED);
+  EXPECT_EQ(GOAL_STATE_UNKNOWN, state);
+  state = rcl_action_transition_goal_state(
+    GOAL_STATE_PREEMPTED,
+    GOAL_EVENT_ABORT);
+  EXPECT_EQ(GOAL_STATE_UNKNOWN, state);
+  state = rcl_action_transition_goal_state(
+    GOAL_STATE_PREEMPTED,
+    GOAL_EVENT_PREEMPT);
+  EXPECT_EQ(GOAL_STATE_UNKNOWN, state);
+  state = rcl_action_transition_goal_state(
+    GOAL_STATE_PREEMPTED,
     GOAL_EVENT_CANCELED);
   EXPECT_EQ(GOAL_STATE_UNKNOWN, state);
 
@@ -144,6 +190,10 @@ TEST(TestGoalStateMachine, test_invalid_transitions)
   state = rcl_action_transition_goal_state(
     GOAL_STATE_CANCELED,
     GOAL_EVENT_ABORT);
+  EXPECT_EQ(GOAL_STATE_UNKNOWN, state);
+  state = rcl_action_transition_goal_state(
+    GOAL_STATE_CANCELED,
+    GOAL_EVENT_PREEMPT);
   EXPECT_EQ(GOAL_STATE_UNKNOWN, state);
   state = rcl_action_transition_goal_state(
     GOAL_STATE_CANCELED,


### PR DESCRIPTION
Signed-off-by: Sarthak Mittal <sarthakmittal2608@gmail.com>

Adds terminal state `PREEMPTED` to goal state machine in order to differentiate between a goal aborted due to genuine abort logic and goal aborted by the server due to preemption.

Based on the discussions in the following ticket: https://github.com/ros2/design/issues/284
Depends on: https://github.com/ros2/rcl_interfaces/pull/105

![RCLActionDesign](https://user-images.githubusercontent.com/22402940/84405678-1a685000-ac26-11ea-99d4-a7d2619d0c7f.png)