### PR TITLE
Improve rcl timer test coverage.

### DIFF
--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -50,17 +50,21 @@ function(test_target_function)
     AMENT_DEPENDENCIES ${rmw_implementation}
   )
 
-  set(timer_test_timeout 60)
+  # TODO(hidmic): re-enable timer tests against RTI Connext once
+  #               https://github.com/ros2/rcl/issues/687 is resolved
+  set(AMENT_GTEST_ARGS "")
   if(rmw_implementation STREQUAL "rmw_connext_cpp")
-    set(timer_test_timeout 90)  # Bump timeout for RTI Connext
+    message(STATUS "Skipping test_timer${target_suffix} test.")
+    set(AMENT_GTEST_ARGS "SKIP_TEST")
   endif()
+
   rcl_add_custom_gtest(test_timer${target_suffix}
     SRCS rcl/test_timer.cpp
     ENV ${rmw_implementation_env_var}
-    TIMEOUT ${timer_test_timeout}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
     AMENT_DEPENDENCIES ${rmw_implementation}
+    ${AMENT_GTEST_ARGS}
   )
 
   rcl_add_custom_gtest(test_context${target_suffix}

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -50,6 +50,19 @@ function(test_target_function)
     AMENT_DEPENDENCIES ${rmw_implementation}
   )
 
+  set(timer_test_timeout 60)
+  if(rmw_implementation STREQUAL "rmw_connext_cpp")
+    set(timer_test_timeout 90)  # Bump timeout for RTI Connext
+  endif()
+  rcl_add_custom_gtest(test_timer${target_suffix}
+    SRCS rcl/test_timer.cpp
+    ENV ${rmw_implementation_env_var}
+    TIMEOUT ${timer_test_timeout}
+    APPEND_LIBRARY_DIRS ${extra_lib_dirs}
+    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
+    AMENT_DEPENDENCIES ${rmw_implementation}
+  )
+
   rcl_add_custom_gtest(test_context${target_suffix}
     SRCS rcl/test_context.cpp
     ENV ${rmw_implementation_env_var} ${memory_tools_ld_preload_env_var}
@@ -348,13 +361,6 @@ rcl_add_custom_gtest(test_expand_topic_name
   SRCS rcl/test_expand_topic_name.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
   LIBRARIES ${PROJECT_NAME}
-)
-
-rcl_add_custom_gtest(test_timer${target_suffix}
-  SRCS rcl/test_timer.cpp
-  APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME}
-  AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
 )
 
 rcl_add_custom_gtest(test_security

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -183,7 +183,7 @@ TEST_F(TestTimerFixture, test_two_timers_ready_before_timeout) {
   rcl_timer_t timer2 = rcl_get_zero_initialized_timer();
 
   ret = rcl_timer_init(
-    &timer, &clock, this->context_ptr, RCL_MS_TO_NS(50), nullptr, rcl_get_default_allocator());
+    &timer, &clock, this->context_ptr, RCL_MS_TO_NS(10), nullptr, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
   ret = rcl_timer_init(
@@ -288,7 +288,7 @@ TEST_F(TestTimerFixture, test_timer_overrun) {
 
   rcl_timer_t timer = rcl_get_zero_initialized_timer();
   ret = rcl_timer_init(
-    &timer, &clock, this->context_ptr, RCL_MS_TO_NS(100), nullptr, rcl_get_default_allocator());
+    &timer, &clock, this->context_ptr, RCL_MS_TO_NS(200), nullptr, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
   {
@@ -326,7 +326,7 @@ TEST_F(TestTimerFixture, test_timer_overrun) {
   rcl_reset_error();
 
   // Ensure period is re-aligned.
-  ret = rcl_wait(&wait_set, RCL_MS_TO_NS(50));
+  ret = rcl_wait(&wait_set, RCL_MS_TO_NS(10));
   EXPECT_EQ(RCL_RET_TIMEOUT, ret) << rcl_get_error_string().str;
   rcl_reset_error();
 

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -166,7 +166,6 @@ TEST_F(TestTimerFixture, test_timer_with_invalid_clock) {
   {
     rcl_ret_t ret = rcl_clock_fini(&clock);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    rcl_reset_error();
   });
 
   ret = rcl_timer_init(
@@ -176,7 +175,6 @@ TEST_F(TestTimerFixture, test_timer_with_invalid_clock) {
   {
     rcl_ret_t ret = rcl_timer_fini(&timer);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    rcl_reset_error();
   });
 
   rcl_clock_t * timer_clock;
@@ -187,7 +185,6 @@ TEST_F(TestTimerFixture, test_timer_with_invalid_clock) {
   // Trigger clock jump callbacks
   ret = rcl_enable_ros_time_override(timer_clock);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  rcl_reset_error();
 
   ret = rcl_timer_call(&timer);
   EXPECT_EQ(RCL_RET_ERROR, ret);
@@ -383,7 +380,6 @@ TEST_F(TestTimerFixture, test_timer_overrun) {
   {
     rcl_ret_t ret = rcl_clock_fini(&clock);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    rcl_reset_error();
   });
 
   rcl_timer_t timer = rcl_get_zero_initialized_timer();
@@ -394,7 +390,6 @@ TEST_F(TestTimerFixture, test_timer_overrun) {
   {
     rcl_ret_t ret = rcl_timer_fini(&timer);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    rcl_reset_error();
   });
 
   rcl_wait_set_t wait_set = rcl_get_zero_initialized_wait_set();
@@ -404,7 +399,6 @@ TEST_F(TestTimerFixture, test_timer_overrun) {
   {
     rcl_ret_t ret = rcl_wait_set_fini(&wait_set);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-    rcl_reset_error();
   });
 
   // Force multiple timer timeouts.
@@ -416,14 +410,11 @@ TEST_F(TestTimerFixture, test_timer_overrun) {
   ret = rcl_timer_is_ready(&timer, &is_ready);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   EXPECT_TRUE(is_ready);
-  rcl_reset_error();
 
   EXPECT_EQ(RCL_RET_OK, rcl_timer_call(&timer)) << rcl_get_error_string().str;
-  rcl_reset_error();
 
   ret = rcl_wait_set_add_timer(&wait_set, &timer, NULL);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  rcl_reset_error();
 
   // Ensure period is re-aligned.
   ret = rcl_wait(&wait_set, RCL_MS_TO_NS(10));
@@ -433,7 +424,6 @@ TEST_F(TestTimerFixture, test_timer_overrun) {
   ret = rcl_timer_is_ready(&timer, &is_ready);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   EXPECT_FALSE(is_ready);
-  rcl_reset_error();
 }
 
 TEST_F(TestTimerFixture, test_timer_with_zero_period) {
@@ -459,17 +449,15 @@ TEST_F(TestTimerFixture, test_timer_with_zero_period) {
 
   bool is_ready = false;
   ret = rcl_timer_is_ready(&timer, &is_ready);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   EXPECT_TRUE(is_ready) << rcl_get_error_string().str;
-  rcl_reset_error();
 
   int64_t time_until_next_call = 0;
   ret = rcl_timer_get_time_until_next_call(&timer, &time_until_next_call);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   EXPECT_LE(time_until_next_call, 0);
-  rcl_reset_error();
 
   EXPECT_EQ(RCL_RET_OK, rcl_timer_call(&timer)) << rcl_get_error_string().str;
-  rcl_reset_error();
 }
 
 TEST_F(TestTimerFixture, test_canceled_timer) {
@@ -856,7 +844,6 @@ TEST_F(TestPreInitTimer, test_invalid_init_fini) {
   rcl_allocator_t bad_allocator = get_failing_allocator();
   rcl_timer_t timer_fail = rcl_get_zero_initialized_timer();
 
-  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_ALREADY_INIT, rcl_timer_init(
       &timer, &clock, this->context_ptr, 500, nullptr,
@@ -869,8 +856,7 @@ TEST_F(TestPreInitTimer, test_invalid_init_fini) {
       bad_allocator)) << rcl_get_error_string().str;
   rcl_reset_error();
 
-  EXPECT_EQ(RCL_RET_OK, rcl_timer_fini(nullptr));
-  rcl_reset_error();
+  EXPECT_EQ(RCL_RET_OK, rcl_timer_fini(nullptr)) << rcl_get_error_string().str;
 }
 
 TEST_F(TestPreInitTimer, test_timer_get_period) {

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -153,7 +153,8 @@ TEST_F(TestTimerFixture, test_timer_with_invalid_clock) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_ret_t ret = rcl_clock_init(RCL_STEADY_TIME, &clock, &allocator);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_clock_fini(&clock);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     rcl_reset_error();
@@ -163,7 +164,8 @@ TEST_F(TestTimerFixture, test_timer_with_invalid_clock) {
   ret = rcl_timer_init(
     &timer, &clock, this->context_ptr, 0, nullptr, allocator);
   ASSERT_EQ(RCL_RET_OK, ret);
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT({
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     rcl_ret_t ret = rcl_timer_fini(&timer);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     rcl_reset_error();


### PR DESCRIPTION
Precisely what the title says.

CI up to `rcl`:
* Linux (w/ coverage) [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11183)](http://ci.ros2.org/job/ci_linux/11183/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6462)](http://ci.ros2.org/job/ci_linux-aarch64/6462/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9134)](http://ci.ros2.org/job/ci_osx/9134/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11138)](http://ci.ros2.org/job/ci_windows/11138/)