### PR TITLE
Use RCL_RET_* codes only.

### DIFF
--- a/rcl/include/rcl/init.h
+++ b/rcl/include/rcl/init.h
@@ -69,6 +69,7 @@ extern "C"
  * \return `RCL_RET_OK` if initialization is successful, or
  * \return `RCL_RET_ALREADY_INIT` if rcl_init has already been called, or
  * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
+ * \return `RCL_RET_INVALID_ROS_ARGS` if an invalid ROS argument is found, or
  * \return `RCL_RET_BAD_ALLOC` if allocating memory failed, or
  * \return `RCL_RET_ERROR` if an unspecified error occurs.
  */

--- a/rcl/src/rcl/init.c
+++ b/rcl/src/rcl/init.c
@@ -188,13 +188,13 @@ rcl_init(
       "Enclave name is not valid: '%s'. Invalid index: %zu",
       rcl_enclave_name_validation_result_string(validation_result),
       invalid_index);
-    fail_ret = RMW_RET_ERROR;
+    fail_ret = RCL_RET_ERROR;
     goto fail;
   }
 
   if (!context->impl->init_options.impl->rmw_init_options.enclave) {
     RCL_SET_ERROR_MSG("failed to set context name");
-    fail_ret = RMW_RET_BAD_ALLOC;
+    fail_ret = RCL_RET_BAD_ALLOC;
     goto fail;
   }
 
@@ -204,7 +204,7 @@ rcl_init(
     context->impl->init_options.impl->rmw_init_options.enclave,
     &context->impl->allocator,
     security_options);
-  if (RMW_RET_OK != ret) {
+  if (RCL_RET_OK != ret) {
     fail_ret = ret;
     goto fail;
   }

--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -311,7 +311,7 @@ rcl_publish_serialized_message(
     if (ret == RMW_RET_BAD_ALLOC) {
       return RCL_RET_BAD_ALLOC;
     }
-    return RMW_RET_ERROR;
+    return RCL_RET_ERROR;
   }
   return RCL_RET_OK;
 }

--- a/rcl/src/rcl/security.c
+++ b/rcl/src/rcl/security.c
@@ -42,7 +42,7 @@ rcl_get_security_options_from_environment(
 
   if (!use_security) {
     security_options->enforce_security = RMW_SECURITY_ENFORCEMENT_PERMISSIVE;
-    return RMW_RET_OK;
+    return RCL_RET_OK;
   }
 
   ret = rcl_get_enforcement_policy(&security_options->enforce_security);


### PR DESCRIPTION
Precisely what the title says. Also, update documentation.

CI up to `rcl` for safety:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=11160)](http://ci.ros2.org/job/ci_linux/11160/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6450)](http://ci.ros2.org/job/ci_linux-aarch64/6450/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9107)](http://ci.ros2.org/job/ci_osx/9107/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11082)](http://ci.ros2.org/job/ci_windows/11082/)