### PR TITLE
Remove unused check context.c

### DIFF
--- a/rcl/src/rcl/context.c
+++ b/rcl/src/rcl/context.c
@@ -95,11 +95,6 @@ rcl_context_get_rmw_context(rcl_context_t * context)
 void
 __cleanup_context(rcl_context_t * context)
 {
-  // if null, nothing can be done
-  if (NULL == context) {
-    return;
-  }
-
   // reset the instance id to 0 to indicate "invalid" (should already be 0, but this is defensive)
   rcutils_atomic_store((atomic_uint_least64_t *)(&context->instance_id_storage), 0);
 

--- a/rcl/test/rcl/test_context.cpp
+++ b/rcl/test/rcl/test_context.cpp
@@ -124,3 +124,7 @@ TEST_F(CLASSNAME(TestContextFixture, RMW_IMPLEMENTATION), nominal) {
   ret = rcl_init_options_fini(&init_options);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 }
+
+TEST_F(CLASSNAME(TestContextFixture, RMW_IMPLEMENTATION), bad_fini) {
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_context_fini(nullptr));
+}

--- a/rcl/test/rcl/test_context.cpp
+++ b/rcl/test/rcl/test_context.cpp
@@ -127,4 +127,5 @@ TEST_F(CLASSNAME(TestContextFixture, RMW_IMPLEMENTATION), nominal) {
 
 TEST_F(CLASSNAME(TestContextFixture, RMW_IMPLEMENTATION), bad_fini) {
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_context_fini(nullptr));
+  rcl_reset_error();
 }


### PR DESCRIPTION
This NULL test in `__cleanup_context` never reached because `rcl_context_fini` already checks for NULL.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>