### PR TITLE
Remove unused pytest dependency from rcl.

### DIFF
--- a/rcl/package.xml
+++ b/rcl/package.xml
@@ -23,7 +23,6 @@
   <depend>tracetools</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>rcpputils</test_depend>


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This is somewhat related to ros2/ros2#951, but is really just something I noticed while debugging that.  CI is over in that other issue.