### PR TITLE
Remove unused internal prototypes

### DIFF
--- a/rcl/src/rcl/remap_impl.h
+++ b/rcl/src/rcl/remap_impl.h
@@ -51,10 +51,6 @@ typedef struct rcl_remap_impl_t
   rcl_allocator_t allocator;
 } rcl_remap_impl_t;
 
-/// Get an rcl_remap_t structure initialized with NULL.
-rcl_remap_t
-rcl_remap_get_zero_initialized();
-
 /// Copy one remap structure into another.
 /**
  * <hr>
@@ -73,34 +69,12 @@ rcl_remap_get_zero_initialized();
  * \return `RCL_RET_BAD_ALLOC` if allocating memory failed, or
  * \return `RCL_RET_ERROR` if an unspecified error occurs.
  */
-RCL_PUBLIC
+RCL_LOCAL
 RCL_WARN_UNUSED
 rcl_ret_t
 rcl_remap_copy(
   const rcl_remap_t * rule,
   rcl_remap_t * rule_out);
-
-/// Reclaim resources used in an rcl_remap_t structure.
-/**
- * <hr>
- * Attribute          | Adherence
- * ------------------ | -------------
- * Allocates Memory   | No
- * Thread-Safe        | Yes
- * Uses Atomics       | No
- * Lock-Free          | Yes
- *
- * \param[in] rule A rule to deallocate back to a zero initialized state.
- * \return `RCL_RET_OK` if the structure was free'd, or
- * \return `RCL_RET_INVALID_ARGUMENT` if any arguments are invalid, or
- * \return `RCL_RET_BAD_ALLOC` if allocating memory failed, or
- * \return `RCL_RET_NODE_INVALID_NAME` if the name is invalid, or
- * \return `RCL_RET_ERROR` if an unspecified error occurs.
- */
-RCL_WARN_UNUSED
-rcl_ret_t
-rcl_remap_fini(
-  rcl_remap_t * rule);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
As the title says. These functions prototypes are already declared in the `rcl/remap.h` public header.

The access to `rcl_remap_copy` was changed to `RCL_LOCAL` because it is not part of the public header.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>