### PR TITLE
Make public ini/fini rosout publisher

### DIFF
--- a/rcl/include/rcl/logging_rosout.h
+++ b/rcl/include/rcl/logging_rosout.h
@@ -98,7 +98,7 @@ rcl_logging_rosout_fini();
  * \return `RCL_RET_BAD_ALLOC` if allocating memory failed, or
  * \return `RCL_RET_ERROR` if an unspecified error occurs.
  */
-RCL_LOCAL
+RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
 rcl_logging_rosout_init_publisher_for_node(
@@ -124,7 +124,7 @@ rcl_logging_rosout_init_publisher_for_node(
  * \return `RCL_RET_BAD_ALLOC` if allocating memory failed, or
  * \return `RCL_RET_ERROR` if an unspecified error occurs.
  */
-RCL_LOCAL
+RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
 rcl_logging_rosout_fini_publisher_for_node(

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -265,7 +265,7 @@ function(test_target_function)
   )
 
   rcl_add_custom_gtest(test_logging_rosout${target_suffix}
-    SRCS rcl/test_logging_rosout.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/logging_rosout.c
+    SRCS rcl/test_logging_rosout.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME}

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -265,7 +265,7 @@ function(test_target_function)
   )
 
   rcl_add_custom_gtest(test_logging_rosout${target_suffix}
-    SRCS rcl/test_logging_rosout.cpp
+    SRCS rcl/test_logging_rosout.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/logging_rosout.c
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME}

--- a/rcl/test/rcl/test_logging_rosout.cpp
+++ b/rcl/test/rcl/test_logging_rosout.cpp
@@ -287,6 +287,30 @@ TEST_F(
 
   // Init twice returns RCL_RET_OK
   EXPECT_EQ(RCL_RET_OK, rcl_logging_rosout_init(&allocator));
+  
+  EXPECT_EQ(RCL_RET_OK, rcl_logging_rosout_fini());
+}
+
+/* Bad params
+ */
+TEST_F(
+  CLASSNAME(
+    TestLogRosoutFixtureNotParam, RMW_IMPLEMENTATION),
+  test_bad_params_init_fini_node_publisher)
+{
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  rcl_node_t not_init_node = rcl_get_zero_initialized_node();
+  EXPECT_EQ(RCL_RET_OK, rcl_logging_rosout_init(&allocator));
+
+  EXPECT_EQ(RCL_RET_NODE_INVALID, rcl_logging_rosout_init_publisher_for_node(nullptr));
+  rcl_reset_error();
+  EXPECT_EQ(RCL_RET_ERROR, rcl_logging_rosout_init_publisher_for_node(&not_init_node));
+  rcl_reset_error();
+
+  EXPECT_EQ(RCL_RET_NODE_INVALID, rcl_logging_rosout_fini_publisher_for_node(nullptr));
+  rcl_reset_error();
+  EXPECT_EQ(RCL_RET_ERROR, rcl_logging_rosout_fini_publisher_for_node(&not_init_node));
+  rcl_reset_error();
 
   EXPECT_EQ(RCL_RET_OK, rcl_logging_rosout_fini());
 }

--- a/rcl/test/rcl/test_logging_rosout.cpp
+++ b/rcl/test/rcl/test_logging_rosout.cpp
@@ -287,7 +287,7 @@ TEST_F(
 
   // Init twice returns RCL_RET_OK
   EXPECT_EQ(RCL_RET_OK, rcl_logging_rosout_init(&allocator));
-  
+
   EXPECT_EQ(RCL_RET_OK, rcl_logging_rosout_fini());
 }
 


### PR DESCRIPTION
The added tests work as expected but including `logging_rosout.c` in the `CmakeLists.txt` of the test environment seem to cause a regression of the parameterized tests. I will be investigating this.

Edit: To solve this I had to make the functions to be tested public in the logging_rosout.h file. Not sure which would be the purpose of having those functions LOCAL in the public header

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>