### PR TITLE
Add test for subscription message lost event

### DIFF
--- a/rcl/test/rcl/test_events.cpp
+++ b/rcl/test/rcl/test_events.cpp
@@ -721,7 +721,7 @@ TEST_F(TestEventFixture, test_bad_event_ini)
     &subscription,
     unknown_sub_type);
   EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT);
-  
+
   tear_down_publisher_subscriber();
 }
 

--- a/rcl/test/rcl/test_events.cpp
+++ b/rcl/test/rcl/test_events.cpp
@@ -783,21 +783,28 @@ TEST_F(TestEventFixture, test_sub_message_lost_event)
   rcl_ret_t ret = setup_subscriber(subscription_qos_profile);
   ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
 
-  // Check if supported
-  subscription_event = rcl_get_zero_initialized_event();
-  ret = rcl_subscription_event_init(
-    &subscription_event,
-    &subscription,
-    RCL_SUBSCRIPTION_MESSAGE_LOST);
-  EXPECT_TRUE(ret == RCL_RET_OK || ret == RCL_RET_UNSUPPORTED);
+  if (is_fastrtps) {
+    // Check not supported
+    subscription_event = rcl_get_zero_initialized_event();
+    ret = rcl_subscription_event_init(
+      &subscription_event,
+      &subscription,
+      RCL_SUBSCRIPTION_MESSAGE_LOST);
+    EXPECT_EQ(ret, RCL_RET_UNSUPPORTED);
 
-  if (ret == RCL_RET_UNSUPPORTED) {
     // clean up and exit test early
     ret = rcl_event_fini(&subscription_event);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
     ret = rcl_subscription_fini(&subscription, this->node_ptr);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
     return;
+  } else {
+    subscription_event = rcl_get_zero_initialized_event();
+    ret = rcl_subscription_event_init(
+      &subscription_event,
+      &subscription,
+      RCL_SUBSCRIPTION_MESSAGE_LOST);
+    EXPECT_EQ(ret, RCL_RET_OK);
   }
 
   // Can't reproduce reliably this event

--- a/rcl/test/rcl/test_events.cpp
+++ b/rcl/test/rcl/test_events.cpp
@@ -783,27 +783,26 @@ TEST_F(TestEventFixture, test_sub_message_lost_event)
   rcl_ret_t ret = setup_subscriber(subscription_qos_profile);
   ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
 
-  if (is_fastrtps) {
-    // Check not supported
-    subscription_event = rcl_get_zero_initialized_event();
+  subscription_event = rcl_get_zero_initialized_event();
     ret = rcl_subscription_event_init(
       &subscription_event,
       &subscription,
       RCL_SUBSCRIPTION_MESSAGE_LOST);
-    EXPECT_EQ(ret, RCL_RET_UNSUPPORTED);
-
-    // clean up and exit test early
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
     ret = rcl_event_fini(&subscription_event);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
     ret = rcl_subscription_fini(&subscription, this->node_ptr);
     EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+  });
+
+  if (is_fastrtps) {
+    // Check not supported
+    EXPECT_EQ(ret, RCL_RET_UNSUPPORTED);
+
+    // clean up and exit test early
     return;
   } else {
-    subscription_event = rcl_get_zero_initialized_event();
-    ret = rcl_subscription_event_init(
-      &subscription_event,
-      &subscription,
-      RCL_SUBSCRIPTION_MESSAGE_LOST);
     EXPECT_EQ(ret, RCL_RET_OK);
   }
 
@@ -814,12 +813,6 @@ TEST_F(TestEventFixture, test_sub_message_lost_event)
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
   EXPECT_EQ(message_lost_status.total_count, 0u);
   EXPECT_EQ(message_lost_status.total_count_change, 0u);
-
-  // clean up
-  ret = rcl_event_fini(&subscription_event);
-  EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
-  ret = rcl_subscription_fini(&subscription, this->node_ptr);
-  EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
 }
 
 static

--- a/rcl/test/rcl/test_events.cpp
+++ b/rcl/test/rcl/test_events.cpp
@@ -812,6 +812,8 @@ TEST_F(TestEventFixture, test_sub_message_lost_event)
   rmw_message_lost_status_t message_lost_status;
   ret = rcl_take_event(&subscription_event, &message_lost_status);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+  EXPECT_EQ(message_lost_status.total_count, 0u);
+  EXPECT_EQ(message_lost_status.total_count_change, 0u);
 
   // clean up
   ret = rcl_event_fini(&subscription_event);

--- a/rcl/test/rcl/test_events.cpp
+++ b/rcl/test/rcl/test_events.cpp
@@ -784,10 +784,10 @@ TEST_F(TestEventFixture, test_sub_message_lost_event)
   ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
 
   subscription_event = rcl_get_zero_initialized_event();
-    ret = rcl_subscription_event_init(
-      &subscription_event,
-      &subscription,
-      RCL_SUBSCRIPTION_MESSAGE_LOST);
+  ret = rcl_subscription_event_init(
+    &subscription_event,
+    &subscription,
+    RCL_SUBSCRIPTION_MESSAGE_LOST);
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
   {
     ret = rcl_event_fini(&subscription_event);


### PR DESCRIPTION
Add test for `RCL_SUBSCRIPTION_MESSAGE_LOST` event. Pending to check reason of error with `rmw_cyclonedds_cpp` implementation.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>