### PR TITLE
Move rcl_remap_copy to public header

### DIFF
--- a/rcl/include/rcl/remap.h
+++ b/rcl/include/rcl/remap.h
@@ -247,6 +247,31 @@ rcl_remap_node_namespace(
   rcl_allocator_t allocator,
   char ** output_namespace);
 
+/// Copy one remap structure into another.
+/**
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] rule The structure to be copied.
+ *  Its allocator is used to copy memory into the new structure.
+ * \param[out] rule_out A zero-initialized rcl_remap_t structure to be copied into.
+ * \return `RCL_RET_OK` if the structure was copied successfully, or
+ * \return `RCL_RET_INVALID_ARGUMENT` if any function arguments are invalid, or
+ * \return `RCL_RET_BAD_ALLOC` if allocating memory failed, or
+ * \return `RCL_RET_ERROR` if an unspecified error occurs.
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_remap_copy(
+  const rcl_remap_t * rule,
+  rcl_remap_t * rule_out);
+
 /// Reclaim resources held inside rcl_remap_t structure.
 /**
  * <hr>

--- a/rcl/src/rcl/remap_impl.h
+++ b/rcl/src/rcl/remap_impl.h
@@ -69,7 +69,7 @@ typedef struct rcl_remap_impl_t
  * \return `RCL_RET_BAD_ALLOC` if allocating memory failed, or
  * \return `RCL_RET_ERROR` if an unspecified error occurs.
  */
-RCL_LOCAL
+RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
 rcl_remap_copy(

--- a/rcl/src/rcl/remap_impl.h
+++ b/rcl/src/rcl/remap_impl.h
@@ -51,31 +51,6 @@ typedef struct rcl_remap_impl_t
   rcl_allocator_t allocator;
 } rcl_remap_impl_t;
 
-/// Copy one remap structure into another.
-/**
- * <hr>
- * Attribute          | Adherence
- * ------------------ | -------------
- * Allocates Memory   | Yes
- * Thread-Safe        | No
- * Uses Atomics       | No
- * Lock-Free          | Yes
- *
- * \param[in] rule The structure to be copied.
- *  Its allocator is used to copy memory into the new structure.
- * \param[out] rule_out A zero-initialized rcl_remap_t structure to be copied into.
- * \return `RCL_RET_OK` if the structure was copied successfully, or
- * \return `RCL_RET_INVALID_ARGUMENT` if any function arguments are invalid, or
- * \return `RCL_RET_BAD_ALLOC` if allocating memory failed, or
- * \return `RCL_RET_ERROR` if an unspecified error occurs.
- */
-RCL_PUBLIC
-RCL_WARN_UNUSED
-rcl_ret_t
-rcl_remap_copy(
-  const rcl_remap_t * rule,
-  rcl_remap_t * rule_out);
-
 #ifdef __cplusplus
 }
 #endif

--- a/rcl/test/rcl/test_remap.cpp
+++ b/rcl/test/rcl/test_remap.cpp
@@ -19,9 +19,9 @@
 #include "rcl/remap.h"
 #include "rcl/error_handling.h"
 
+#include "./allocator_testing_utils.h"
 #include "./arg_macros.hpp"
 #include "./arguments_impl.h"
-#include "./allocator_testing_utils.h"
 #include "./remap_impl.h"
 
 #ifdef RMW_IMPLEMENTATION

--- a/rcl/test/rcl/test_remap.cpp
+++ b/rcl/test/rcl/test_remap.cpp
@@ -22,7 +22,6 @@
 #include "./allocator_testing_utils.h"
 #include "./arg_macros.hpp"
 #include "./arguments_impl.h"
-#include "./remap_impl.h"
 
 #ifdef RMW_IMPLEMENTATION
 # define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX


### PR DESCRIPTION
Follow up for failing test: https://github.com/ros2/rcl/pull/703#issuecomment-653678953.

I thought this was the only thing needed for making the local function available in the test: https://github.com/ros2/rcl/blob/6f3c3fb10391edaacb2676e2345a754bef1b76f2/rcl/src/rcl/remap_impl.h#L72-L77

I had to make available the function in the internal impl file: https://github.com/ros2/rcl/blob/2f4f0d4af517ca53b38c871ac283e7e395cbc6e3/rcl/src/rcl/remap_impl.h#L72

I think it is not a problem making internal functions available in the impl headers, because AFAIK those functions won't be available when using the package. In particular, for this function, I changed it from PUBLIC to LOCAL with this PR:
#699.

Last edit: After discussion with @ivanpauno and @hidmic I moved the function be available in the public header of `rcl`

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>