### PR TITLE
Add needed extra null check

### DIFF
--- a/rcl/src/rcl/remap.c
+++ b/rcl/src/rcl/remap.c
@@ -43,6 +43,7 @@ rcl_remap_copy(
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(rule, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(rule_out, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(rule->impl, RCL_RET_INVALID_ARGUMENT);
 
   if (NULL != rule_out->impl) {
     RCL_SET_ERROR_MSG("rule_out must be zero initialized");

--- a/rcl/test/rcl/test_remap.cpp
+++ b/rcl/test/rcl/test_remap.cpp
@@ -596,6 +596,12 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), internal_remap_use) {
   EXPECT_EQ(RCL_RET_BAD_ALLOC, rcl_remap_copy(parsed_args.impl->remap_rules, &remap_dst));
   parsed_args.impl->remap_rules->impl->allocator = alloc;
 
+  // Not valid null ptrs
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_remap_copy(nullptr, &remap_dst));
+  rcl_reset_error();
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_remap_copy(parsed_args.impl->remap_rules, nullptr));
+  rcl_reset_error();
+
   // Not valid empty source
   rcl_remap_t remap_empty = rcl_get_zero_initialized_remap();
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_remap_copy(&remap_empty, &remap_dst));

--- a/rcl/test/rcl/test_remap.cpp
+++ b/rcl/test/rcl/test_remap.cpp
@@ -596,6 +596,11 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), internal_remap_use) {
   EXPECT_EQ(RCL_RET_BAD_ALLOC, rcl_remap_copy(parsed_args.impl->remap_rules, &remap_dst));
   parsed_args.impl->remap_rules->impl->allocator = alloc;
 
+  // Not valid empty source
+  rcl_remap_t remap_empty = rcl_get_zero_initialized_remap();
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_remap_copy(&remap_empty, &remap_dst));
+  rcl_reset_error();
+
   // Expected usage
   EXPECT_EQ(RCL_RET_OK, rcl_remap_copy(parsed_args.impl->remap_rules, &remap_dst));
 


### PR DESCRIPTION
This check is needed to return `INVALID_ARGUMENT` when passing a zero initialized remap structure to the `rcl_remap_copy` function. Otherwise it will segfault in the call to `rcl_allocator_t allocator = rule->impl->allocator;`

I will wait for #709 to be able of testing it before pushing.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>