### PR TITLE
Add mock test for rcl/subscription

### DIFF
--- a/rcl/package.xml
+++ b/rcl/package.xml
@@ -25,6 +25,8 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>mimick</test_depend>
+  <test_depend>mimick_vendor</test_depend>
   <test_depend>rcpputils</test_depend>
   <test_depend>rmw</test_depend>
   <test_depend>rmw_implementation_cmake</test_depend>

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(rcutils REQUIRED)
 find_package(rmw_implementation_cmake REQUIRED)
 
 find_package(osrf_testing_tools_cpp REQUIRED)
+find_package(mimick_vendor REQUIRED)
 
 get_target_property(memory_tools_ld_preload_env_var
   osrf_testing_tools_cpp::memory_tools LIBRARY_PRELOAD_ENVIRONMENT_VARIABLE)
@@ -223,7 +224,7 @@ function(test_target_function)
     SRCS rcl/test_subscription.cpp rcl/wait_for_entity_helpers.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME}
+    LIBRARIES ${PROJECT_NAME} mimick
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
   )
   if(rmw_implementation STREQUAL "rmw_fastrtps_cpp" OR

--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -765,7 +765,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_mock_map_fin
   /* Mock the rcl_get_default_topic_name_substitutions_mock function in the current module using
      the `rcl_get_default_topic_name_substitutions_mock_mock` blueprint. */
   mmk_mock(
-    "rcl_get_default_topic_name_substitutions@lib:rcl",
+    RCUTILS_STRINGIFY(rcl_get_default_topic_name_substitutions) "@lib:rcl",
     rcl_get_default_topic_name_substitutions_mock);
 
   /* Tell the mock to return RCUTILS_RET_ERROR (unknown error)


### PR DESCRIPTION
This case mocks a function from the library under test, probably a more frequent usage of the library to reach coverage target.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>