### PR TITLE
Move actual domain id from node to context

### DIFF
--- a/rcl/include/rcl/context.h
+++ b/rcl/include/rcl/context.h
@@ -242,8 +242,7 @@ rcl_context_get_instance_id(rcl_context_t * context);
 
 /// Returns the context domain id.
 /**
- * The given context must be non-`NULL` and be valid.
- * If context is `NULL`, then `0` will be returned.
+ * The given context must be non-`NULL` and valid.
  * If context is uninitialized, then it is undefined behavior.
  *
  * <hr>

--- a/rcl/include/rcl/context.h
+++ b/rcl/include/rcl/context.h
@@ -248,9 +248,12 @@ rcl_context_get_instance_id(rcl_context_t * context);
  * Attribute          | Adherence
  * ------------------ | -------------
  * Allocates Memory   | No
- * Thread-Safe        | No
+ * Thread-Safe        | Yes [1]
  * Uses Atomics       | No
  * Lock-Free          | No
+ *
+ * <i>[1] Calling the function asynchronously with `rcl_init` or `rcl_shutdown` can result
+ *  in the function sometimes succeeding and sometimes returning `RCL_RET_INVALID_ARGUMENT`.
  *
  * \param[in] context object from which the domain id should be retrieved.
  * \param[out] domain_id output variable where the domain id will be returned.

--- a/rcl/include/rcl/context.h
+++ b/rcl/include/rcl/context.h
@@ -257,7 +257,7 @@ rcl_context_get_instance_id(rcl_context_t * context);
  *
  * \param[in] context from which the domain id should be retrieved.
  * \param[out] domain_id output variable where the domain id will be returned.
- * \return RCL_RET_INVALID_ARGUMENT if `context` is invalid, or
+ * \return RCL_RET_INVALID_ARGUMENT if `context` is invalid \ref `rcl_context_is_valid`, or
  * \return RCL_RET_INVALID_ARGUMENT if `domain_id` is `NULL`, or
  * \return RCL_RET_OK if the domain id was correctly retrieved.
  */

--- a/rcl/include/rcl/context.h
+++ b/rcl/include/rcl/context.h
@@ -240,6 +240,31 @@ RCL_WARN_UNUSED
 rcl_context_instance_id_t
 rcl_context_get_instance_id(rcl_context_t * context);
 
+/// Returns the context domain id.
+/**
+ * The given context must be non-`NULL` and be valid.
+ * If context is `NULL`, then `0` will be returned.
+ * If context is uninitialized, then it is undefined behavior.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | No
+ *
+ * \param[in] context object from which the domain id should be retrieved.
+ * \param[out] domain_id output variable where the domain id will be returned.
+ * \return RCL_RET_INVALID_ARGUMENT if `context` is invalid, or
+ *  RCL_RET_INVALID_ARGUMENT if `domain_id` is `NULL`, or
+ *  RCL_RET_OK if the domain id was correctly retrieved.
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_context_get_domain_id(rcl_context_t * context, size_t * domain_id);
+
 /// Return `true` if the given context is currently valid, otherwise `false`.
 /**
  * If context is `NULL`, then `false` is returned.

--- a/rcl/include/rcl/context.h
+++ b/rcl/include/rcl/context.h
@@ -242,8 +242,7 @@ rcl_context_get_instance_id(rcl_context_t * context);
 
 /// Returns the context domain id.
 /**
- * The given context must be non-`NULL` and valid.
- * If context is uninitialized, then it is undefined behavior.
+ * \pre If context is uninitialized, then it is undefined behavior.
  *
  * <hr>
  * Attribute          | Adherence

--- a/rcl/include/rcl/context.h
+++ b/rcl/include/rcl/context.h
@@ -255,7 +255,7 @@ rcl_context_get_instance_id(rcl_context_t * context);
  * <i>[1] Calling the function asynchronously with `rcl_init` or `rcl_shutdown` can result
  *  in the function sometimes succeeding and sometimes returning `RCL_RET_INVALID_ARGUMENT`.
  *
- * \param[in] context object from which the domain id should be retrieved.
+ * \param[in] context from which the domain id should be retrieved.
  * \param[out] domain_id output variable where the domain id will be returned.
  * \return RCL_RET_INVALID_ARGUMENT if `context` is invalid, or
  * \return RCL_RET_INVALID_ARGUMENT if `domain_id` is `NULL`, or

--- a/rcl/include/rcl/context.h
+++ b/rcl/include/rcl/context.h
@@ -255,8 +255,8 @@ rcl_context_get_instance_id(rcl_context_t * context);
  * \param[in] context object from which the domain id should be retrieved.
  * \param[out] domain_id output variable where the domain id will be returned.
  * \return RCL_RET_INVALID_ARGUMENT if `context` is invalid, or
- *  RCL_RET_INVALID_ARGUMENT if `domain_id` is `NULL`, or
- *  RCL_RET_OK if the domain id was correctly retrieved.
+ * \return RCL_RET_INVALID_ARGUMENT if `domain_id` is `NULL`, or
+ * \return RCL_RET_OK if the domain id was correctly retrieved.
  */
 RCL_PUBLIC
 RCL_WARN_UNUSED

--- a/rcl/src/rcl/context.c
+++ b/rcl/src/rcl/context.c
@@ -84,7 +84,8 @@ rcl_context_get_domain_id(rcl_context_t * context, size_t * domain_id)
     return RCL_RET_INVALID_ARGUMENT;
   }
   RCL_CHECK_ARGUMENT_FOR_NULL(domain_id, RCL_RET_INVALID_ARGUMENT);
-  return context->impl->rmw_context.actual_domain_id;
+  *domain_id = context->impl->rmw_context.actual_domain_id;
+  return RCL_RET_OK;
 }
 
 bool

--- a/rcl/src/rcl/context.c
+++ b/rcl/src/rcl/context.c
@@ -77,6 +77,16 @@ rcl_context_get_instance_id(rcl_context_t * context)
   return rcutils_atomic_load_uint64_t((atomic_uint_least64_t *)(&context->instance_id_storage));
 }
 
+rcl_ret_t
+rcl_context_get_domain_id(rcl_context_t * context, size_t * domain_id)
+{
+  if (!rcl_context_is_valid(context)) {
+    return RCL_RET_INVALID_ARGUMENT;
+  }
+  RCL_CHECK_ARGUMENT_FOR_NULL(domain_id, RCL_RET_INVALID_ARGUMENT);
+  return context->impl->rmw_context.actual_domain_id;
+}
+
 bool
 rcl_context_is_valid(rcl_context_t * context)
 {

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -468,9 +468,10 @@ rcl_node_get_options(const rcl_node_t * node)
 rcl_ret_t
 rcl_node_get_domain_id(const rcl_node_t * node, size_t * domain_id)
 {
-  RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_NODE_INVALID);
+  if (!rcl_node_is_valid(node)) {
+    return RCL_RET_NODE_INVALID;
+  }
   RCL_CHECK_ARGUMENT_FOR_NULL(domain_id, RCL_RET_INVALID_ARGUMENT);
-  RCL_CHECK_FOR_NULL_WITH_MSG(node->context, "invalid node", return RCL_RET_NODE_INVALID);
   rcl_ret_t ret = rcl_context_get_domain_id(node->context, domain_id);
   if (RCL_RET_OK != ret) {
     return ret;

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -471,7 +471,10 @@ rcl_node_get_domain_id(const rcl_node_t * node, size_t * domain_id)
   RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_NODE_INVALID);
   RCL_CHECK_ARGUMENT_FOR_NULL(domain_id, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_FOR_NULL_WITH_MSG(node->context, "invalid node", return RCL_RET_NODE_INVALID);
-  *domain_id = node->context->impl->rmw_context.actual_domain_id;
+  rcl_ret_t ret = rcl_context_get_domain_id(node->context, domain_id);
+  if (RCL_RET_OK != ret) {
+    return ret;
+  }
   return RCL_RET_OK;
 }
 

--- a/rcl/test/rcl/test_context.cpp
+++ b/rcl/test/rcl/test_context.cpp
@@ -87,6 +87,28 @@ TEST_F(CLASSNAME(TestContextFixture, RMW_IMPLEMENTATION), nominal) {
   EXPECT_NE(instance_id, 0UL) << rcl_get_error_string().str;
   rcl_reset_error();
 
+  // test rcl_context_get_domain_id
+  size_t domain_id;
+
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
+    EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_context_get_domain_id(&context, nullptr));
+  });
+  EXPECT_TRUE(rcl_error_is_set());
+  rcl_reset_error();
+
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
+    EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_context_get_domain_id(nullptr, &domain_id));
+  });
+  EXPECT_TRUE(rcl_error_is_set());
+  rcl_reset_error();
+
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
+    EXPECT_EQ(RCL_RET_OK, rcl_context_get_domain_id(&context, &domain_id));
+  });
+
   // test rcl_context_is_valid
   bool is_valid;
   EXPECT_NO_MEMORY_OPERATIONS(

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -262,7 +262,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   ASSERT_TRUE(rcl_error_is_set());
   rcl_reset_error();
   ret = rcl_node_get_domain_id(&invalid_node, &actual_domain_id);
-  EXPECT_EQ(RCL_RET_OK, ret);
+  EXPECT_EQ(RCL_RET_NODE_INVALID, ret);
   rcl_reset_error();
   EXPECT_NO_MEMORY_OPERATIONS(
   {

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -270,6 +270,14 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) 
   });
   EXPECT_EQ(RCL_RET_OK, ret);
   EXPECT_EQ(42u, actual_domain_id);
+  actual_domain_id = 0u;
+  EXPECT_NO_MEMORY_OPERATIONS(
+  {
+    ret = rcl_context_get_domain_id(&context, &actual_domain_id);
+  });
+  EXPECT_EQ(RCL_RET_OK, ret);
+  EXPECT_EQ(42u, actual_domain_id);
+
   // Test rcl_node_get_rmw_handle().
   rmw_node_t * node_handle;
   node_handle = rcl_node_get_rmw_handle(nullptr);


### PR DESCRIPTION
Follow up of discussion https://github.com/ros2/rcl/pull/689#discussion_r448978801.

The function `rcl_node_get_domain_id` could be deprecated.