### PR TITLE
Fix a memory leak in a test

### DIFF
--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -767,4 +767,6 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_options_fai
 
   rcl_node_options_t default_options = rcl_node_get_default_options();
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_node_options_copy(&default_options, &prev_ini_options));
+
+  EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&prev_ini_options.arguments));
 }

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -73,14 +73,6 @@ public:
   }
 };
 
-bool is_opensplice =
-  std::string(rmw_get_implementation_identifier()).find("opensplice") != std::string::npos;
-#if defined(_WIN32)
-bool is_windows = true;
-#else
-bool is_windows = false;
-#endif  // defined(_WIN32)
-
 /* Tests the node accessors, i.e. rcl_node_get_* functions.
  */
 TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_accessors) {


### PR DESCRIPTION
As the title says; fix a small memory leak in one of the rcl tests.  While we are in here, also remove some dead code from the test.