### PR TITLE
Reformat rmw_impl_id_check to call a testable function

### DIFF
--- a/rcl/include/rcl/rmw_implementation_identifier_check.h
+++ b/rcl/include/rcl/rmw_implementation_identifier_check.h
@@ -26,7 +26,7 @@ extern "C"
 #define RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME "RCL_ASSERT_RMW_ID_MATCHES"
 
 RCL_PUBLIC
-rcl_ret_t rcl_rmw_implementation_check(void);
+rcl_ret_t rcl_rmw_implementation_identifier_check(void);
 
 #ifdef __cplusplus
 }

--- a/rcl/include/rcl/rmw_implementation_identifier_check.h
+++ b/rcl/include/rcl/rmw_implementation_identifier_check.h
@@ -22,6 +22,9 @@ extern "C"
 
 #include "rcl/visibility_control.h"
 
+#define RMW_IMPLEMENTATION_ENV_VAR_NAME "RMW_IMPLEMENTATION"
+#define RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME "RCL_ASSERT_RMW_ID_MATCHES"
+
 RCL_PUBLIC
 rcl_ret_t rcl_rmw_implementation_check(void);
 

--- a/rcl/include/rcl/rmw_implementation_identifier_check.h
+++ b/rcl/include/rcl/rmw_implementation_identifier_check.h
@@ -1,0 +1,32 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCL__RMW_IMPLEMENTATION_IDENTIFIER_CHECK_H_
+#define RCL__RMW_IMPLEMENTATION_IDENTIFIER_CHECK_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rcl/visibility_control.h"
+
+RCL_PUBLIC
+rcl_ret_t rcl_rmw_implementation_check(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RCL__RMW_IMPLEMENTATION_IDENTIFIER_CHECK_H_

--- a/rcl/src/rcl/rmw_implementation_identifier_check.c
+++ b/rcl/src/rcl/rmw_implementation_identifier_check.c
@@ -32,9 +32,6 @@ extern "C"
 
 #include "rcl/rmw_implementation_identifier_check.h"
 
-#define RMW_IMPLEMENTATION_ENV_VAR_NAME "RMW_IMPLEMENTATION"
-#define RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME "RCL_ASSERT_RMW_ID_MATCHES"
-
 // Extracted this portable method of doing a "shared library constructor" from SO:
 //   http://stackoverflow.com/a/2390626/671658
 // Initializer/finalizer sample for MSVC and GCC/Clang.

--- a/rcl/src/rcl/rmw_implementation_identifier_check.c
+++ b/rcl/src/rcl/rmw_implementation_identifier_check.c
@@ -66,8 +66,7 @@ rcl_ret_t rcl_rmw_implementation_check(void)
     RMW_IMPLEMENTATION_ENV_VAR_NAME,
     &expected_rmw_impl_env);
   if (NULL != get_env_error_str) {
-    RCUTILS_LOG_ERROR_NAMED(
-      ROS_PACKAGE_NAME,
+    RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
       "Error getting env var '" RCUTILS_STRINGIFY(RMW_IMPLEMENTATION_ENV_VAR_NAME) "': %s\n",
       get_env_error_str);
     return RCL_RET_ERROR;
@@ -76,7 +75,7 @@ rcl_ret_t rcl_rmw_implementation_check(void)
     // Copy the environment variable so it doesn't get over-written by the next getenv call.
     expected_rmw_impl = rcutils_strdup(expected_rmw_impl_env, allocator);
     if (!expected_rmw_impl) {
-      RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME, "allocation failed");
+      RCL_SET_ERROR_MSG("allocation failed");
       return RCL_RET_BAD_ALLOC;
     }
   }
@@ -86,8 +85,7 @@ rcl_ret_t rcl_rmw_implementation_check(void)
   get_env_error_str = rcutils_get_env(
     RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME, &asserted_rmw_impl_env);
   if (NULL != get_env_error_str) {
-    RCUTILS_LOG_ERROR_NAMED(
-      ROS_PACKAGE_NAME,
+    RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
       "Error getting env var '"
       RCUTILS_STRINGIFY(RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME) "': %s\n",
       get_env_error_str);
@@ -97,15 +95,14 @@ rcl_ret_t rcl_rmw_implementation_check(void)
     // Copy the environment variable so it doesn't get over-written by the next getenv call.
     asserted_rmw_impl = rcutils_strdup(asserted_rmw_impl_env, allocator);
     if (!asserted_rmw_impl) {
-      RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME, "allocation failed");
+      RCL_SET_ERROR_MSG("allocation failed");
       return RCL_RET_BAD_ALLOC;
     }
   }
 
   // If both environment variables are set, and they do not match, print an error and exit.
   if (expected_rmw_impl && asserted_rmw_impl && strcmp(expected_rmw_impl, asserted_rmw_impl) != 0) {
-    RCUTILS_LOG_ERROR_NAMED(
-      ROS_PACKAGE_NAME,
+    RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
       "Values of RMW_IMPLEMENTATION ('%s') and RCL_ASSERT_RMW_ID_MATCHES ('%s') environment "
       "variables do not match, exiting with %d.",
       expected_rmw_impl, asserted_rmw_impl, RCL_RET_ERROR
@@ -131,20 +128,17 @@ rcl_ret_t rcl_rmw_implementation_check(void)
   if (expected_rmw_impl) {
     const char * actual_rmw_impl_id = rmw_get_implementation_identifier();
     if (!actual_rmw_impl_id) {
-      RCUTILS_LOG_ERROR_NAMED(
-        ROS_PACKAGE_NAME,
+      RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
         "Error getting RMW implementation identifier / RMW implementation not installed "
         "(expected identifier of '%s'), with error message '%s', exiting with %d.",
         expected_rmw_impl,
         rcl_get_error_string().str,
         RCL_RET_ERROR
       );
-      rcl_reset_error();
       return RCL_RET_ERROR;
     }
     if (strcmp(actual_rmw_impl_id, expected_rmw_impl) != 0) {
-      RCUTILS_LOG_ERROR_NAMED(
-        ROS_PACKAGE_NAME,
+      RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
         "Expected RMW implementation identifier of '%s' but instead found '%s', exiting with %d.",
         expected_rmw_impl,
         actual_rmw_impl_id,
@@ -161,6 +155,7 @@ rcl_ret_t rcl_rmw_implementation_check(void)
 INITIALIZER(initialize) {
   rcl_ret_t ret = rcl_rmw_implementation_check();
   if (ret != RCL_RET_OK) {
+    RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME, rcl_get_error_string().str);
     exit(ret);
   }
 }

--- a/rcl/src/rcl/rmw_implementation_identifier_check.c
+++ b/rcl/src/rcl/rmw_implementation_identifier_check.c
@@ -127,12 +127,14 @@ rcl_ret_t rcl_rmw_implementation_identifier_check(void)
   // If either environment variable is set, and it does not match, print an error and exit.
   if (expected_rmw_impl) {
     const char * actual_rmw_impl_id = rmw_get_implementation_identifier();
+    const rcutils_error_string_t rmw_error_msg = rcl_get_error_string();
+    rcl_reset_error();
     if (!actual_rmw_impl_id) {
       RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
         "Error getting RMW implementation identifier / RMW implementation not installed "
         "(expected identifier of '%s'), with error message '%s', exiting with %d.",
         expected_rmw_impl,
-        rcl_get_error_string().str,
+        rmw_error_msg.str,
         RCL_RET_ERROR
       );
       return RCL_RET_ERROR;

--- a/rcl/src/rcl/rmw_implementation_identifier_check.c
+++ b/rcl/src/rcl/rmw_implementation_identifier_check.c
@@ -30,6 +30,8 @@ extern "C"
 
 #include "rcl/types.h"
 
+#include "rcl/rmw_implementation_identifier_check.h"
+
 #define RMW_IMPLEMENTATION_ENV_VAR_NAME "RMW_IMPLEMENTATION"
 #define RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME "RCL_ASSERT_RMW_ID_MATCHES"
 
@@ -55,7 +57,7 @@ extern "C"
   static void f(void)
 #endif
 
-rcl_ret_t _internal_rmw_check(void)
+rcl_ret_t rcl_rmw_implementation_check(void)
 {
   // If the environment variable RMW_IMPLEMENTATION is set, or
   // the environment variable RCL_ASSERT_RMW_ID_MATCHES is set,
@@ -160,8 +162,8 @@ rcl_ret_t _internal_rmw_check(void)
 }
 
 INITIALIZER(initialize) {
-  rcl_ret_t check_status = _internal_rmw_check();
-  if (check_status != RCL_RET_OK) {exit(check_status);}
+  rcl_ret_t ret = rcl_rmw_implementation_check();
+  if (ret != RCL_RET_OK) {exit(ret);}
 }
 
 #ifdef __cplusplus

--- a/rcl/src/rcl/rmw_implementation_identifier_check.c
+++ b/rcl/src/rcl/rmw_implementation_identifier_check.c
@@ -155,7 +155,7 @@ rcl_ret_t rcl_rmw_implementation_check(void)
 INITIALIZER(initialize) {
   rcl_ret_t ret = rcl_rmw_implementation_check();
   if (ret != RCL_RET_OK) {
-    RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME, rcl_get_error_string().str);
+    RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME, "%s\n", rcl_get_error_string().str);
     exit(ret);
   }
 }

--- a/rcl/src/rcl/rmw_implementation_identifier_check.c
+++ b/rcl/src/rcl/rmw_implementation_identifier_check.c
@@ -54,7 +54,7 @@ extern "C"
   static void f(void)
 #endif
 
-rcl_ret_t rcl_rmw_implementation_check(void)
+rcl_ret_t rcl_rmw_implementation_identifier_check(void)
 {
   // If the environment variable RMW_IMPLEMENTATION is set, or
   // the environment variable RCL_ASSERT_RMW_ID_MATCHES is set,
@@ -153,7 +153,7 @@ rcl_ret_t rcl_rmw_implementation_check(void)
 }
 
 INITIALIZER(initialize) {
-  rcl_ret_t ret = rcl_rmw_implementation_check();
+  rcl_ret_t ret = rcl_rmw_implementation_identifier_check();
   if (ret != RCL_RET_OK) {
     RCUTILS_LOG_ERROR_NAMED(ROS_PACKAGE_NAME, "%s\n", rcl_get_error_string().str);
     exit(ret);

--- a/rcl/src/rcl/rmw_implementation_identifier_check.c
+++ b/rcl/src/rcl/rmw_implementation_identifier_check.c
@@ -163,7 +163,9 @@ rcl_ret_t rcl_rmw_implementation_check(void)
 
 INITIALIZER(initialize) {
   rcl_ret_t ret = rcl_rmw_implementation_check();
-  if (ret != RCL_RET_OK) {exit(ret);}
+  if (ret != RCL_RET_OK) {
+    exit(ret);
+  }
 }
 
 #ifdef __cplusplus

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -281,6 +281,14 @@ function(test_target_function)
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
   )
 
+  rcl_add_custom_gtest(test_rmw_impl_id_check_func${target_suffix}
+    SRCS rcl/test_rmw_impl_id_check_func.cpp
+    ENV ${rmw_implementation_env_var}
+    APPEND_LIBRARY_DIRS ${extra_lib_dirs}
+    LIBRARIES ${PROJECT_NAME}
+    AMENT_DEPENDENCIES ${rmw_implementation}
+  )
+
   # Launch tests
 
   rcl_add_custom_executable(service_fixture${target_suffix}

--- a/rcl/test/rcl/test_rmw_impl_id_check_func.cpp
+++ b/rcl/test/rcl/test_rmw_impl_id_check_func.cpp
@@ -21,7 +21,7 @@
 #include "rcl/rmw_implementation_identifier_check.h"
 
 TEST(TestRmwCheck, test_rmw_check_id_impl) {
-  EXPECT_EQ(RCL_RET_OK, rcl_rmw_implementation_check());
+  EXPECT_EQ(RCL_RET_OK, rcl_rmw_implementation_identifier_check());
 }
 
 TEST(TestRmwCheck, test_failing_configuration) {
@@ -39,28 +39,28 @@ TEST(TestRmwCheck, test_failing_configuration) {
   // Fail test case, reason: RMW_IMPLEMENTATION_ENV_VAR_NAME set, not matching rmw impl
   EXPECT_TRUE(rcutils_set_env(RMW_IMPLEMENTATION_ENV_VAR_NAME, "some_random_name"));
   EXPECT_TRUE(rcutils_set_env(RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME, ""));
-  EXPECT_EQ(RCL_RET_MISMATCHED_RMW_ID, rcl_rmw_implementation_check());
+  EXPECT_EQ(RCL_RET_MISMATCHED_RMW_ID, rcl_rmw_implementation_identifier_check());
   EXPECT_TRUE(rcl_error_is_set());
   rcl_reset_error();
 
   // Fail test case, reason: RMW_IMPLEMENTATION_ENV_VAR_NAME set, not matching rmw impl
   EXPECT_TRUE(rcutils_set_env(RMW_IMPLEMENTATION_ENV_VAR_NAME, ""));
   EXPECT_TRUE(rcutils_set_env(RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME, "some_random_name"));
-  EXPECT_EQ(RCL_RET_MISMATCHED_RMW_ID, rcl_rmw_implementation_check());
+  EXPECT_EQ(RCL_RET_MISMATCHED_RMW_ID, rcl_rmw_implementation_identifier_check());
   EXPECT_TRUE(rcl_error_is_set());
   rcl_reset_error();
 
   // Fail test case, reason: env variables not equal
   EXPECT_TRUE(rcutils_set_env(RMW_IMPLEMENTATION_ENV_VAR_NAME, "some_random_name"));
   EXPECT_TRUE(rcutils_set_env(RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME, "diff_random"));
-  EXPECT_EQ(RCL_RET_ERROR, rcl_rmw_implementation_check());
+  EXPECT_EQ(RCL_RET_ERROR, rcl_rmw_implementation_identifier_check());
   EXPECT_TRUE(rcl_error_is_set());
   rcl_reset_error();
 
   // Fail test case, reason: equal env variables do not match rmw impl
   EXPECT_TRUE(rcutils_set_env(RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME, "some_random_name"));
   EXPECT_TRUE(rcutils_set_env(RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME, "some_random_name"));
-  EXPECT_EQ(RCL_RET_MISMATCHED_RMW_ID, rcl_rmw_implementation_check());
+  EXPECT_EQ(RCL_RET_MISMATCHED_RMW_ID, rcl_rmw_implementation_identifier_check());
   EXPECT_TRUE(rcl_error_is_set());
   rcl_reset_error();
 

--- a/rcl/test/rcl/test_rmw_impl_id_check_func.cpp
+++ b/rcl/test/rcl/test_rmw_impl_id_check_func.cpp
@@ -14,9 +14,9 @@
 
 #include <gtest/gtest.h>
 
-// #include "rcutils/get_env.h"
 #include "rcutils/env.h"
 
+#include "rcl/error_handling.h"
 #include "rcl/rcl.h"
 #include "rcl/rmw_implementation_identifier_check.h"
 
@@ -40,21 +40,29 @@ TEST(TestRmwCheck, test_failing_configuration) {
   EXPECT_TRUE(rcutils_set_env(RMW_IMPLEMENTATION_ENV_VAR_NAME, "some_random_name"));
   EXPECT_TRUE(rcutils_set_env(RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME, ""));
   EXPECT_EQ(RCL_RET_MISMATCHED_RMW_ID, rcl_rmw_implementation_check());
+  EXPECT_TRUE(rcl_error_is_set());
+  rcl_reset_error();
 
   // Fail test case, reason: RMW_IMPLEMENTATION_ENV_VAR_NAME set, not matching rmw impl
   EXPECT_TRUE(rcutils_set_env(RMW_IMPLEMENTATION_ENV_VAR_NAME, ""));
   EXPECT_TRUE(rcutils_set_env(RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME, "some_random_name"));
   EXPECT_EQ(RCL_RET_MISMATCHED_RMW_ID, rcl_rmw_implementation_check());
+  EXPECT_TRUE(rcl_error_is_set());
+  rcl_reset_error();
 
   // Fail test case, reason: env variables not equal
   EXPECT_TRUE(rcutils_set_env(RMW_IMPLEMENTATION_ENV_VAR_NAME, "some_random_name"));
   EXPECT_TRUE(rcutils_set_env(RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME, "diff_random"));
   EXPECT_EQ(RCL_RET_ERROR, rcl_rmw_implementation_check());
+  EXPECT_TRUE(rcl_error_is_set());
+  rcl_reset_error();
 
   // Fail test case, reason: equal env variables do not match rmw impl
   EXPECT_TRUE(rcutils_set_env(RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME, "some_random_name"));
   EXPECT_TRUE(rcutils_set_env(RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME, "some_random_name"));
   EXPECT_EQ(RCL_RET_MISMATCHED_RMW_ID, rcl_rmw_implementation_check());
+  EXPECT_TRUE(rcl_error_is_set());
+  rcl_reset_error();
 
   // Restore env variables set in the test
   EXPECT_TRUE(rcutils_set_env(RMW_IMPLEMENTATION_ENV_VAR_NAME, get_env_var_name));

--- a/rcl/test/rcl/test_rmw_impl_id_check_func.cpp
+++ b/rcl/test/rcl/test_rmw_impl_id_check_func.cpp
@@ -1,0 +1,22 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "rcl/rcl.h"
+#include "rcl/rmw_implementation_identifier_check.h"
+
+TEST(TestRmwCheck, test_rmw_check_id_impl) {
+  EXPECT_EQ(RCL_RET_OK, rcl_rmw_implementation_check());
+}


### PR DESCRIPTION
As the title says, to be able of testing this check with different environment configurations. This PR includes reformat of the function, exposing of the internal function through an internal header and tests for the method exposed.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>