### PR TITLE
Add extra check for invalid event implementation

### DIFF
--- a/rcl/src/rcl/event.c
+++ b/rcl/src/rcl/event.c
@@ -137,8 +137,9 @@ rcl_take_event(
   void * event_info)
 {
   bool taken = false;
-  RCL_CHECK_ARGUMENT_FOR_NULL(event, RCL_RET_EVENT_INVALID);
-  // if (!rcl_event_is_valid(event). RCL_RET_EVENT_INVALID);
+  if (!rcl_event_is_valid(event)) {
+    return RCL_RET_EVENT_INVALID;
+  }
   RCL_CHECK_ARGUMENT_FOR_NULL(event_info, RCL_RET_INVALID_ARGUMENT);
   rmw_ret_t ret = rmw_take_event(&event->impl->rmw_handle, event_info, &taken);
   if (RMW_RET_OK != ret) {
@@ -180,8 +181,7 @@ rcl_event_fini(rcl_event_t * event)
 rmw_event_t *
 rcl_event_get_rmw_handle(const rcl_event_t * event)
 {
-  // if (!rcl_event_is_valid(event)) {
-  if (NULL == event) {
+  if (!rcl_event_is_valid(event)) {
     return NULL;  // error already set
   } else {
     return &event->impl->rmw_handle;

--- a/rcl/src/rcl/event.c
+++ b/rcl/src/rcl/event.c
@@ -138,6 +138,7 @@ rcl_take_event(
 {
   bool taken = false;
   RCL_CHECK_ARGUMENT_FOR_NULL(event, RCL_RET_EVENT_INVALID);
+  // if (!rcl_event_is_valid(event). RCL_RET_EVENT_INVALID);
   RCL_CHECK_ARGUMENT_FOR_NULL(event_info, RCL_RET_INVALID_ARGUMENT);
   rmw_ret_t ret = rmw_take_event(&event->impl->rmw_handle, event_info, &taken);
   if (RMW_RET_OK != ret) {
@@ -179,6 +180,7 @@ rcl_event_fini(rcl_event_t * event)
 rmw_event_t *
 rcl_event_get_rmw_handle(const rcl_event_t * event)
 {
+  // if (!rcl_event_is_valid(event)) {
   if (NULL == event) {
     return NULL;  // error already set
   } else {

--- a/rcl/test/rcl/test_events.cpp
+++ b/rcl/test/rcl/test_events.cpp
@@ -768,7 +768,7 @@ TEST_F(TestEventFixture, test_event_is_valid)
 /*
  * Test passing not init to take_event/get_handle
  */
-TEST_F(TestEventFixture, test_invalid_to_take_event){
+TEST_F(TestEventFixture, test_invalid_to_take_event) {
   // nullptr
   rmw_offered_deadline_missed_status_t deadline_status;
   EXPECT_EQ(RCL_RET_EVENT_INVALID, rcl_take_event(NULL, &deadline_status));

--- a/rcl/test/rcl/test_events.cpp
+++ b/rcl/test/rcl/test_events.cpp
@@ -726,14 +726,6 @@ TEST_F(TestEventFixture, test_bad_event_ini)
 }
 
 /*
- * Passing bad argument to get_rmw_handle
- */
-TEST_F(TestEventFixture, test_bad_get_handle)
-{
-  EXPECT_EQ(NULL, rcl_event_get_rmw_handle(NULL));
-}
-
-/*
  * Test cases for the event_is_valid function
  */
 TEST_F(TestEventFixture, test_event_is_valid)
@@ -771,6 +763,21 @@ TEST_F(TestEventFixture, test_event_is_valid)
   ret = rcl_event_fini(&publisher_event_test);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
   tear_down_publisher_subscriber();
+}
+
+/*
+ * Test passing not init to take_event/get_handle
+ */
+TEST_F(TestEventFixture, test_invalid_to_take_event){
+  // nullptr
+  rmw_offered_deadline_missed_status_t deadline_status;
+  EXPECT_EQ(RCL_RET_EVENT_INVALID, rcl_take_event(NULL, &deadline_status));
+  EXPECT_EQ(NULL, rcl_event_get_rmw_handle(NULL));
+
+  // Zero Init, invalid
+  rcl_event_t publisher_event_test = rcl_get_zero_initialized_event();
+  EXPECT_EQ(RCL_RET_EVENT_INVALID, rcl_take_event(&publisher_event_test, &deadline_status));
+  EXPECT_EQ(NULL, rcl_event_get_rmw_handle(&publisher_event_test));
 }
 
 /*

--- a/rcl/test/rcl/test_events.cpp
+++ b/rcl/test/rcl/test_events.cpp
@@ -768,7 +768,7 @@ TEST_F(TestEventFixture, test_event_is_valid)
 /*
  * Test passing not init to take_event/get_handle
  */
-TEST_F(TestEventFixture, test_invalid_to_take_event) {
+TEST_F(TestEventFixture, test_event_is_invalid) {
   // nullptr
   rmw_offered_deadline_missed_status_t deadline_status;
   EXPECT_EQ(RCL_RET_EVENT_INVALID, rcl_take_event(NULL, &deadline_status));


### PR DESCRIPTION
Makes use of the checks added in #720 to avoid trying to access handler of invalid events. (&event->impl->rmw_handle this will cause unexpected exit if the implementation is empty).

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>