### PR TITLE
Set transition_map->states/transition size to 0 on fini

### DIFF
--- a/rcl_lifecycle/src/transition_map.c
+++ b/rcl_lifecycle/src/transition_map.c
@@ -70,9 +70,11 @@ rcl_lifecycle_transition_map_fini(
   // free the primary states
   allocator->deallocate(transition_map->states, allocator->state);
   transition_map->states = NULL;
+  transition_map->states_size = 0;
   // free the tansitions
   allocator->deallocate(transition_map->transitions, allocator->state);
   transition_map->transitions = NULL;
+  transition_map->transitions_size = 0;
 
   return fcn_ret;
 }


### PR DESCRIPTION
This was discovered during fault injection tests. But states_size and transititions_size need to be set to 0 on finalization because if finalization is ever called again, the for loop is entered without checking if states is null.

Signed-off-by: Stephen Brawner <brawner@gmail.com>