### PR TITLE
Add deallocate calls to free strdup allocated memory

### DIFF
--- a/rcl/src/rcl/rmw_implementation_identifier_check.c
+++ b/rcl/src/rcl/rmw_implementation_identifier_check.c
@@ -119,7 +119,7 @@ rcl_ret_t rcl_rmw_implementation_identifier_check(void)
   if (expected_rmw_impl && asserted_rmw_impl) {
     // The strings at this point must be equal.
     // No need for asserted_rmw_impl anymore, free the memory.
-    allocator.deallocate((char *)asserted_rmw_impl, allocator.state);
+    allocator.deallocate(asserted_rmw_impl, allocator.state);
     asserted_rmw_impl = NULL;
   } else {
     // One or none are set.
@@ -160,12 +160,8 @@ rcl_ret_t rcl_rmw_implementation_identifier_check(void)
   ret = RCL_RET_OK;
 // fallthrough
 cleanup:
-  if (expected_rmw_impl) {
-    allocator.deallocate((char *)expected_rmw_impl, allocator.state);
-  }
-  if (asserted_rmw_impl) {
-    allocator.deallocate((char *)asserted_rmw_impl, allocator.state);
-  }
+  allocator.deallocate(expected_rmw_impl, allocator.state);
+  allocator.deallocate(asserted_rmw_impl, allocator.state);
   return ret;
 }
 


### PR DESCRIPTION
While adding mock tests for the `rmw_impl_check` module, I realized part of the allocated memory is not freed when an error occurs. This PR aims to solve the issue, let me know if you think this is a good approach. including the deallocate calls before each return is another possible option.

Not sure if this can be considered a bug and require backport.

Signed-off-by: Jorge Perez <jjperez@ekumenlabs.com>