### PR TITLE
Fix bug error handling get_param_files

### DIFF
--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -94,7 +94,7 @@ rcl_arguments_get_param_files(
       // deallocate allocated memory
       for (int r = i; r >= 0; --r) {
         if (NULL == (*parameter_files)[r]) {
-          break;
+          continue;
         }
         allocator.deallocate((*parameter_files)[r], allocator.state);
       }

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -93,9 +93,6 @@ rcl_arguments_get_param_files(
     if (NULL == (*parameter_files)[i]) {
       // deallocate allocated memory
       for (int r = i; r >= 0; --r) {
-        if (NULL == (*parameter_files)[r]) {
-          continue;
-        }
         allocator.deallocate((*parameter_files)[r], allocator.state);
       }
       allocator.deallocate((*parameter_files), allocator.state);

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -96,7 +96,7 @@ rcl_arguments_get_param_files(
         if (NULL == (*parameter_files)[r]) {
           break;
         }
-        allocator.deallocate((*parameter_files)[r]), allocator.state);
+        allocator.deallocate((*parameter_files)[r], allocator.state);
       }
       allocator.deallocate((*parameter_files), allocator.state);
       (*parameter_files) = NULL;

--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -93,10 +93,10 @@ rcl_arguments_get_param_files(
     if (NULL == (*parameter_files)[i]) {
       // deallocate allocated memory
       for (int r = i; r >= 0; --r) {
-        if (NULL == (*parameter_files[r])) {
+        if (NULL == (*parameter_files)[r]) {
           break;
         }
-        allocator.deallocate((*parameter_files[r]), allocator.state);
+        allocator.deallocate((*parameter_files)[r]), allocator.state);
       }
       allocator.deallocate((*parameter_files), allocator.state);
       (*parameter_files) = NULL;

--- a/rcl/test/rcl/allocator_testing_utils.h
+++ b/rcl/test/rcl/allocator_testing_utils.h
@@ -87,6 +87,80 @@ set_failing_allocator_is_failing(rcutils_allocator_t & failing_allocator, bool s
   ((__failing_allocator_state *)failing_allocator.state)->is_failing = state;
 }
 
+typedef struct __time_bomb_allocator_state
+{
+  int count_until_failure;
+} __time_bomb_allocator_state;
+
+void * time_bomb_malloc(size_t size, void * state)
+{
+  __time_bomb_allocator_state * time_bomb_state = (__time_bomb_allocator_state *)state;
+  if (time_bomb_state->count_until_failure >= 0 &&
+      time_bomb_state->count_until_failure-- == 0)
+  {
+    return nullptr;
+  }
+  return rcutils_get_default_allocator().allocate(size, rcutils_get_default_allocator().state);
+}
+
+void *
+time_bomb_realloc(void * pointer, size_t size, void * state)
+{
+  __time_bomb_allocator_state * time_bomb_state = (__time_bomb_allocator_state *)state;
+  if (time_bomb_state->count_until_failure >= 0 &&
+      time_bomb_state->count_until_failure-- == 0)
+  {
+    return nullptr;
+  }
+  return rcutils_get_default_allocator().reallocate(
+    pointer, size, rcutils_get_default_allocator().state);
+}
+
+void
+time_bomb_free(void * pointer, size_t size, void * state)
+{
+  __time_bomb_allocator_state * time_bomb_state = (__time_bomb_allocator_state *)state;
+  if (time_bomb_state->count_until_failure >= 0 &&
+      time_bomb_state->count_until_failure-- == 0)
+  {
+    return;
+  }
+  rcutils_get_default_allocator().deallocate(pointer, rcutils_get_default_allocator().state);
+}
+
+void *
+time_bomb_calloc(size_t number_of_elements, size_t size_of_element, void * state)
+{
+  __time_bomb_allocator_state * time_bomb_state = (__time_bomb_allocator_state *)state;
+  if (time_bomb_state->count_until_failure >= 0 &&
+      time_bomb_state->count_until_failure-- == 0)
+  {
+    return nullptr;
+  }
+  return rcutils_get_default_allocator().zero_allocate(
+    number_of_elements, size_of_element, rcutils_get_default_allocator().state);
+}
+
+static inline rcutils_allocator_t
+get_time_bombed_allocator(void)
+{
+  static __time_bomb_allocator_state state;
+  state.count_until_failure = 1;
+  auto time_bombed_allocator = rcutils_get_default_allocator();
+  time_bombed_allocator.allocate = time_bomb_malloc;
+  time_bombed_allocator.deallocate = time_bomb_free;
+  time_bombed_allocator.reallocate = time_bomb_realloc;
+  time_bombed_allocator.zero_allocate = time_bomb_calloc;
+  time_bombed_allocator.state = &state;
+  return time_bombed_allocator;
+}
+
+static inline void
+set_time_bombed_allocator_count(rcutils_allocator_t & time_bombed_allocator, int count)
+{
+  ((__time_bomb_allocator_state *)time_bombed_allocator.state)->count_until_failure = count;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/rcl/test/rcl/allocator_testing_utils.h
+++ b/rcl/test/rcl/allocator_testing_utils.h
@@ -87,14 +87,14 @@ set_failing_allocator_is_failing(rcutils_allocator_t & failing_allocator, bool s
   ((__failing_allocator_state *)failing_allocator.state)->is_failing = state;
 }
 
-typedef struct __time_bomb_allocator_state
+typedef struct time_bomb_allocator_state
 {
   int count_until_failure;
-} __time_bomb_allocator_state;
+} time_bomb_allocator_state;
 
 void * time_bomb_malloc(size_t size, void * state)
 {
-  __time_bomb_allocator_state * time_bomb_state = (__time_bomb_allocator_state *)state;
+  time_bomb_allocator_state * time_bomb_state = (time_bomb_allocator_state *)state;
   if (time_bomb_state->count_until_failure >= 0 &&
     time_bomb_state->count_until_failure-- == 0)
   {
@@ -106,7 +106,7 @@ void * time_bomb_malloc(size_t size, void * state)
 void *
 time_bomb_realloc(void * pointer, size_t size, void * state)
 {
-  __time_bomb_allocator_state * time_bomb_state = (__time_bomb_allocator_state *)state;
+  time_bomb_allocator_state * time_bomb_state = (time_bomb_allocator_state *)state;
   if (time_bomb_state->count_until_failure >= 0 &&
     time_bomb_state->count_until_failure-- == 0)
   {
@@ -119,7 +119,7 @@ time_bomb_realloc(void * pointer, size_t size, void * state)
 void
 time_bomb_free(void * pointer, void * state)
 {
-  __time_bomb_allocator_state * time_bomb_state = (__time_bomb_allocator_state *)state;
+  time_bomb_allocator_state * time_bomb_state = (time_bomb_allocator_state *)state;
   if (time_bomb_state->count_until_failure >= 0 &&
     time_bomb_state->count_until_failure-- == 0)
   {
@@ -131,7 +131,7 @@ time_bomb_free(void * pointer, void * state)
 void *
 time_bomb_calloc(size_t number_of_elements, size_t size_of_element, void * state)
 {
-  __time_bomb_allocator_state * time_bomb_state = (__time_bomb_allocator_state *)state;
+  time_bomb_allocator_state * time_bomb_state = (time_bomb_allocator_state *)state;
   if (time_bomb_state->count_until_failure >= 0 &&
     time_bomb_state->count_until_failure-- == 0)
   {
@@ -144,7 +144,7 @@ time_bomb_calloc(size_t number_of_elements, size_t size_of_element, void * state
 static inline rcutils_allocator_t
 get_time_bombed_allocator(void)
 {
-  static __time_bomb_allocator_state state;
+  time_bomb_allocator_state state;
   state.count_until_failure = 1;
   auto time_bombed_allocator = rcutils_get_default_allocator();
   time_bombed_allocator.allocate = time_bomb_malloc;
@@ -158,7 +158,7 @@ get_time_bombed_allocator(void)
 static inline void
 set_time_bombed_allocator_count(rcutils_allocator_t & time_bombed_allocator, int count)
 {
-  ((__time_bomb_allocator_state *)time_bombed_allocator.state)->count_until_failure = count;
+  ((time_bomb_allocator_state *)time_bombed_allocator.state)->count_until_failure = count;
 }
 
 #ifdef __cplusplus

--- a/rcl/test/rcl/allocator_testing_utils.h
+++ b/rcl/test/rcl/allocator_testing_utils.h
@@ -144,7 +144,7 @@ time_bomb_calloc(size_t number_of_elements, size_t size_of_element, void * state
 static inline rcutils_allocator_t
 get_time_bombed_allocator(void)
 {
-  time_bomb_allocator_state state;
+  static time_bomb_allocator_state state;
   state.count_until_failure = 1;
   auto time_bombed_allocator = rcutils_get_default_allocator();
   time_bombed_allocator.allocate = time_bomb_malloc;

--- a/rcl/test/rcl/allocator_testing_utils.h
+++ b/rcl/test/rcl/allocator_testing_utils.h
@@ -96,7 +96,7 @@ void * time_bomb_malloc(size_t size, void * state)
 {
   __time_bomb_allocator_state * time_bomb_state = (__time_bomb_allocator_state *)state;
   if (time_bomb_state->count_until_failure >= 0 &&
-      time_bomb_state->count_until_failure-- == 0)
+    time_bomb_state->count_until_failure-- == 0)
   {
     return nullptr;
   }
@@ -108,7 +108,7 @@ time_bomb_realloc(void * pointer, size_t size, void * state)
 {
   __time_bomb_allocator_state * time_bomb_state = (__time_bomb_allocator_state *)state;
   if (time_bomb_state->count_until_failure >= 0 &&
-      time_bomb_state->count_until_failure-- == 0)
+    time_bomb_state->count_until_failure-- == 0)
   {
     return nullptr;
   }
@@ -117,11 +117,11 @@ time_bomb_realloc(void * pointer, size_t size, void * state)
 }
 
 void
-time_bomb_free(void * pointer, size_t size, void * state)
+time_bomb_free(void * pointer, void * state)
 {
   __time_bomb_allocator_state * time_bomb_state = (__time_bomb_allocator_state *)state;
   if (time_bomb_state->count_until_failure >= 0 &&
-      time_bomb_state->count_until_failure-- == 0)
+    time_bomb_state->count_until_failure-- == 0)
   {
     return;
   }
@@ -133,7 +133,7 @@ time_bomb_calloc(size_t number_of_elements, size_t size_of_element, void * state
 {
   __time_bomb_allocator_state * time_bomb_state = (__time_bomb_allocator_state *)state;
   if (time_bomb_state->count_until_failure >= 0 &&
-      time_bomb_state->count_until_failure-- == 0)
+    time_bomb_state->count_until_failure-- == 0)
   {
     return nullptr;
   }

--- a/rcl/test/rcl/allocator_testing_utils.h
+++ b/rcl/test/rcl/allocator_testing_utils.h
@@ -92,7 +92,7 @@ typedef struct time_bomb_allocator_state
   int count_until_failure;
 } time_bomb_allocator_state;
 
-void * time_bomb_malloc(size_t size, void * state)
+static void * time_bomb_malloc(size_t size, void * state)
 {
   time_bomb_allocator_state * time_bomb_state = (time_bomb_allocator_state *)state;
   if (time_bomb_state->count_until_failure >= 0 &&
@@ -103,7 +103,7 @@ void * time_bomb_malloc(size_t size, void * state)
   return rcutils_get_default_allocator().allocate(size, rcutils_get_default_allocator().state);
 }
 
-void *
+static void *
 time_bomb_realloc(void * pointer, size_t size, void * state)
 {
   time_bomb_allocator_state * time_bomb_state = (time_bomb_allocator_state *)state;
@@ -116,7 +116,7 @@ time_bomb_realloc(void * pointer, size_t size, void * state)
     pointer, size, rcutils_get_default_allocator().state);
 }
 
-void
+static void
 time_bomb_free(void * pointer, void * state)
 {
   time_bomb_allocator_state * time_bomb_state = (time_bomb_allocator_state *)state;
@@ -128,7 +128,7 @@ time_bomb_free(void * pointer, void * state)
   rcutils_get_default_allocator().deallocate(pointer, rcutils_get_default_allocator().state);
 }
 
-void *
+static void *
 time_bomb_calloc(size_t number_of_elements, size_t size_of_element, void * state)
 {
   time_bomb_allocator_state * time_bomb_state = (time_bomb_allocator_state *)state;


### PR DESCRIPTION
When the passed allocator fails, the function `rcl_arguments_get_param_files` fails to exit cleanly. The changed clause "break" caused memory not to be deallocated. The pointers changed caused segfaults.

I added a "bomb_allocator" required to reproduce the error. This can be used for other tests within `rcl`.