### PR TITLE
Add cov tests 95%

### DIFF
--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -361,7 +361,7 @@ rcl_add_custom_gtest(test_validate_enclave_name
 rcl_add_custom_gtest(test_domain_id
   SRCS rcl/test_domain_id.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME}
+  LIBRARIES ${PROJECT_NAME} mimick
 )
 
 rcl_add_custom_gtest(test_localhost

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -158,7 +158,7 @@ function(test_target_function)
     SRCS rcl/test_init.cpp
     ENV ${rmw_implementation_env_var} ${memory_tools_ld_preload_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
+    LIBRARIES ${PROJECT_NAME} mimick osrf_testing_tools_cpp::memory_tools
     AMENT_DEPENDENCIES ${rmw_implementation}
   )
 

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -399,7 +399,7 @@ rcl_add_custom_gtest(test_common
 rcl_add_custom_gtest(test_log_level
   SRCS rcl/test_log_level.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME}
+  LIBRARIES ${PROJECT_NAME} mimick
   AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
 )
 

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -288,7 +288,7 @@ function(test_target_function)
     SRCS rcl/test_rmw_impl_id_check_func.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME}
+    LIBRARIES ${PROJECT_NAME} mimick
     AMENT_DEPENDENCIES ${rmw_implementation}
   )
 

--- a/rcl/test/rcl/test_domain_id.cpp
+++ b/rcl/test/rcl/test_domain_id.cpp
@@ -20,6 +20,8 @@
 #include "rcl/error_handling.h"
 #include "rcutils/env.h"
 
+#include "../mocking_utils/patch.hpp"
+
 TEST(TestGetDomainId, test_nominal) {
   ASSERT_TRUE(rcutils_set_env("ROS_DOMAIN_ID", "42"));
   size_t domain_id = RCL_DEFAULT_DOMAIN_ID;
@@ -49,4 +51,14 @@ TEST(TestGetDomainId, test_nominal) {
   EXPECT_EQ(RCL_DEFAULT_DOMAIN_ID, domain_id);
 
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_get_default_domain_id(nullptr));
+}
+
+TEST(TestGetDomainId, test_mock_get_default_domain_id) {
+  auto mock = mocking_utils::patch_and_return(
+    "lib:rcl", rcutils_get_env, "argument env_name is null");
+  size_t domain_id = RCL_DEFAULT_DOMAIN_ID;
+  EXPECT_EQ(RCL_RET_ERROR, rcl_get_default_domain_id(&domain_id));
+  EXPECT_EQ(RCL_DEFAULT_DOMAIN_ID, domain_id);
+  EXPECT_TRUE(rcl_error_is_set());
+  rcl_reset_error();
 }

--- a/rcl/test/rcl/test_init.cpp
+++ b/rcl/test/rcl/test_init.cpp
@@ -420,8 +420,7 @@ MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, !=)
 // Tests rcl_init_options_init() mocked to fail
 TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_mocked_rcl_init_options_ini) {
   rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
-  auto mock = mocking_utils::patch(
-    "lib:rcl", rmw_init_options_init, [](auto...) {return RMW_RET_ERROR;});
+  auto mock = mocking_utils::patch_and_return("lib:rcl", rmw_init_options_init, RMW_RET_ERROR);
   EXPECT_EQ(RCL_RET_ERROR, rcl_init_options_init(&init_options, rcl_get_default_allocator()));
   rcl_reset_error();
 }
@@ -431,8 +430,7 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_mocked_rcl_init_optio
   rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
   rcl_ret_t ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  auto mock = mocking_utils::patch(
-    "lib:rcl", rmw_init_options_fini, [](auto...) {return RMW_RET_ERROR;});
+  auto mock = mocking_utils::patch_and_return("lib:rcl", rmw_init_options_fini, RMW_RET_ERROR);
   EXPECT_EQ(RCL_RET_ERROR, rcl_init_options_fini(&init_options));
   rcl_reset_error();
 }
@@ -452,8 +450,7 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_init_copy_mocked_
     EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options_dst)) << rcl_get_error_string().str;
   });
 
-  auto mock = mocking_utils::patch(
-    "lib:rcl", rmw_init_options_fini, [](auto...) {return RMW_RET_ERROR;});
+  auto mock = mocking_utils::patch_and_return("lib:rcl", rmw_init_options_fini, RMW_RET_ERROR);
   EXPECT_EQ(RCL_RET_ERROR, rcl_init_options_copy(&init_options, &init_options_dst));
   rcl_reset_error();
 }
@@ -473,8 +470,7 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_init_options_copy
     EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options_dst)) << rcl_get_error_string().str;
   });
 
-  auto mock = mocking_utils::patch(
-    "lib:rcl", rmw_init_options_copy, [](auto...) {return RMW_RET_ERROR;});
+  auto mock = mocking_utils::patch_and_return("lib:rcl", rmw_init_options_copy, RMW_RET_ERROR);
   EXPECT_EQ(RCL_RET_ERROR, rcl_init_options_copy(&init_options, &init_options_dst));
   rcl_reset_error();
 }

--- a/rcl/test/rcl/test_init.cpp
+++ b/rcl/test/rcl/test_init.cpp
@@ -26,6 +26,7 @@
 
 #include "./allocator_testing_utils.h"
 #include "../src/rcl/init_options_impl.h"
+#include "../mocking_utils/patch.hpp"
 
 #ifdef RMW_IMPLEMENTATION
 # define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX

--- a/rcl/test/rcl/test_init.cpp
+++ b/rcl/test/rcl/test_init.cpp
@@ -25,8 +25,8 @@
 #include "rcutils/snprintf.h"
 
 #include "./allocator_testing_utils.h"
-#include "../src/rcl/init_options_impl.h"
 #include "../mocking_utils/patch.hpp"
+#include "../src/rcl/init_options_impl.h"
 
 #ifdef RMW_IMPLEMENTATION
 # define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX

--- a/rcl/test/rcl/test_init.cpp
+++ b/rcl/test/rcl/test_init.cpp
@@ -468,7 +468,7 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_mocked_rcl_init_optio
   rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
   rcl_ret_t ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  auto mock = mocking_utils::patch_and_return("lib:rcl", rmw_init_options_fini, RMW_RET_ERROR);
+  auto mock = mocking_utils::inject_on_return("lib:rcl", rmw_init_options_fini, RMW_RET_ERROR);
   EXPECT_EQ(RCL_RET_ERROR, rcl_init_options_fini(&init_options));
   rcl_reset_error();
 }
@@ -488,7 +488,7 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_init_copy_mocked_
     EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options_dst)) << rcl_get_error_string().str;
   });
 
-  auto mock = mocking_utils::patch_and_return("lib:rcl", rmw_init_options_fini, RMW_RET_ERROR);
+  auto mock = mocking_utils::inject_on_return("lib:rcl", rmw_init_options_fini, RMW_RET_ERROR);
   EXPECT_EQ(RCL_RET_ERROR, rcl_init_options_copy(&init_options, &init_options_dst));
   rcl_reset_error();
 }

--- a/rcl/test/rcl/test_init.cpp
+++ b/rcl/test/rcl/test_init.cpp
@@ -467,10 +467,15 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_init_options_copy
   rcl_init_options_t init_options_dst = rcl_get_zero_initialized_init_options();
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
   {
-    EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options_dst)) << rcl_get_error_string().str;
+    // dst is in a invalid state after failed copy
+    EXPECT_EQ(
+      RCL_RET_INVALID_ARGUMENT,
+      rcl_init_options_fini(&init_options_dst)) << rcl_get_error_string().str;
+    rcl_reset_error();
   });
 
+  // rmw_init_options_copy error is logged
   auto mock = mocking_utils::patch_and_return("lib:rcl", rmw_init_options_copy, RMW_RET_ERROR);
-  EXPECT_EQ(RCL_RET_ERROR, rcl_init_options_copy(&init_options, &init_options_dst));
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_init_options_copy(&init_options, &init_options_dst));
   rcl_reset_error();
 }

--- a/rcl/test/rcl/test_init.cpp
+++ b/rcl/test/rcl/test_init.cpp
@@ -483,11 +483,6 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_init_copy_mocked_
     EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str;
   });
   rcl_init_options_t init_options_dst = rcl_get_zero_initialized_init_options();
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
-  {
-    EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options_dst)) << rcl_get_error_string().str;
-  });
-
   auto mock = mocking_utils::inject_on_return("lib:rcl", rmw_init_options_fini, RMW_RET_ERROR);
   EXPECT_EQ(RCL_RET_ERROR, rcl_init_options_copy(&init_options, &init_options_dst));
   rcl_reset_error();

--- a/rcl/test/rcl/test_init.cpp
+++ b/rcl/test/rcl/test_init.cpp
@@ -449,6 +449,7 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_init_options_acce
   EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options_dst));
 }
 
+// Define dummy comparison operators for rcutils_allocator_t type for use with the Mimick Library
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, ==)
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, <)
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, >)

--- a/rcl/test/rcl/test_log_level.cpp
+++ b/rcl/test/rcl/test_log_level.cpp
@@ -222,6 +222,11 @@ TEST(TestLogLevel, log_level_init_fini) {
   EXPECT_TRUE(rcl_error_is_set());
   rcl_reset_error();
 
+  rcl_allocator_t bad_allocator = get_failing_allocator();
+  rcl_log_levels_t empty_log_levels = rcl_get_zero_initialized_log_levels();
+  EXPECT_EQ(
+    RCL_RET_BAD_ALLOC, rcl_log_levels_init(&empty_log_levels, &bad_allocator, capacity_count));
+
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_log_levels_fini(nullptr));
 }
 

--- a/rcl/test/rcl/test_log_level.cpp
+++ b/rcl/test/rcl/test_log_level.cpp
@@ -199,6 +199,14 @@ TEST(TestLogLevel, log_level_dot_logger_name) {
 TEST(TestLogLevel, log_level_init_fini) {
   rcl_log_levels_t log_levels = rcl_get_zero_initialized_log_levels();
   rcl_allocator_t allocator = rcl_get_default_allocator();
+
+  // Test zero size ini/fini
+  const size_t zero_count = 0;
+  EXPECT_EQ(
+    RCL_RET_OK,
+    rcl_log_levels_init(&log_levels, &allocator, &zero_count));
+  EXPECT_EQ(RCL_RET_OK, rcl_log_levels_fini(&log_levels));
+
   const size_t capacity_count = 1;
   EXPECT_EQ(
     RCL_RET_OK,

--- a/rcl/test/rcl/test_log_level.cpp
+++ b/rcl/test/rcl/test_log_level.cpp
@@ -338,7 +338,7 @@ TEST(TestLogLevel, test_add_logger_setting) {
 
   rcl_allocator_t saved_allocator = log_levels.allocator;
   log_levels.allocator = {NULL, NULL, NULL, NULL, NULL};
-    EXPECT_EQ(
+  EXPECT_EQ(
     RCL_RET_INVALID_ARGUMENT,
     rcl_log_levels_add_logger_setting(&log_levels, "rcl", RCUTILS_LOG_SEVERITY_DEBUG));
   EXPECT_TRUE(rcl_error_is_set());

--- a/rcl/test/rcl/test_log_level.cpp
+++ b/rcl/test/rcl/test_log_level.cpp
@@ -221,10 +221,7 @@ TEST(TestLogLevel, log_level_init_fini) {
   EXPECT_TRUE(rcl_error_is_set());
   rcl_reset_error();
 
-  EXPECT_EQ(RCUTILS_LOG_SEVERITY_UNSET, log_levels.default_logger_level);
-  EXPECT_EQ(1ul, log_levels.num_logger_settings);
-  EXPECT_STREQ("test.abc", log_levels.logger_settings[0].name);
-  EXPECT_EQ(RCUTILS_LOG_SEVERITY_INFO, log_levels.logger_settings[0].level);
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_log_levels_fini(nullptr));
 }
 
 int main(int argc, char ** argv)

--- a/rcl/test/rcl/test_rmw_impl_id_check_func.cpp
+++ b/rcl/test/rcl/test_rmw_impl_id_check_func.cpp
@@ -147,8 +147,6 @@ TEST(TestRmwCheck, test_mock_rmw_impl_check) {
     EXPECT_TRUE(rcl_error_is_set());
     rcl_reset_error();
     EXPECT_TRUE(rcutils_set_env(RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME, expected_rmw_id_matches));
-    // Deallocated on internal cleaunp
-    EXPECT_EQ(NULL, new_string);
   }
   {
     // Fail reading rmw_impl_identifier

--- a/rcl/test/rcl/test_rmw_impl_id_check_func.cpp
+++ b/rcl/test/rcl/test_rmw_impl_id_check_func.cpp
@@ -147,7 +147,8 @@ TEST(TestRmwCheck, test_mock_rmw_impl_check) {
     EXPECT_TRUE(rcl_error_is_set());
     rcl_reset_error();
     EXPECT_TRUE(rcutils_set_env(RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME, expected_rmw_id_matches));
-    allocator.deallocate(new_string, allocator.state);
+    // Deallocated on internal cleaunp
+    EXPECT_EQ(NULL, new_string);
   }
   {
     // Fail reading rmw_impl_identifier

--- a/rcl/test/rcl/test_rmw_impl_id_check_func.cpp
+++ b/rcl/test/rcl/test_rmw_impl_id_check_func.cpp
@@ -123,15 +123,15 @@ TEST(TestRmwCheck, test_mock_rmw_impl_check) {
     const char * get_env_id_matches_name = rcutils_get_env(
       RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME,
       &expected_rmw_id_matches);
-    EXPECT_FALSE(get_env_id_matches_name);
+    EXPECT_EQ(NULL, get_env_id_matches_name);
     EXPECT_TRUE(rcutils_set_env(RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME, "some_random_name"));
 
     // Return an allocated string as strdup would do for the first case
     // calling the function
     rcl_allocator_t allocator = rcl_get_default_allocator();
     size_t dummy_str_size = 3u;
-    char * new_string = static_cast<char *>(allocator.allocate(dummy_str_size, allocator.state));
-    memset(new_string, '\0', dummy_str_size);
+    char * new_string = static_cast<char *>(allocator.zero_allocate(
+        dummy_str_size, 1u, allocator.state));
 
     auto mock = mocking_utils::patch(
       "lib:rcl", rcutils_strdup, [&new_string](auto...) {

--- a/rcl/test/rcl/test_rmw_impl_id_check_func.cpp
+++ b/rcl/test/rcl/test_rmw_impl_id_check_func.cpp
@@ -126,19 +126,14 @@ TEST(TestRmwCheck, test_mock_rmw_impl_check) {
     EXPECT_EQ(NULL, get_env_id_matches_name);
     EXPECT_TRUE(rcutils_set_env(RCL_ASSERT_RMW_ID_MATCHES_ENV_VAR_NAME, "some_random_name"));
 
-    // Return an allocated string as strdup would do for the first case
-    // calling the function
-    rcl_allocator_t allocator = rcl_get_default_allocator();
-    size_t dummy_str_size = 3u;
-    char * new_string = static_cast<char *>(allocator.zero_allocate(
-        dummy_str_size, 1u, allocator.state));
-
     auto mock = mocking_utils::patch(
-      "lib:rcl", rcutils_strdup, [&new_string](auto...) {
+      "lib:rcl", rcutils_strdup,
+      [base = rcutils_strdup](const char * str, auto allocator)
+      {
         static int counter = 1;
         if (counter == 1) {
           counter++;
-          return new_string;
+          return base(str, allocator);
         } else {
           return static_cast<char *>(NULL);
         }


### PR DESCRIPTION
Improves coverage up to 95% to modules:  `domain_id`, `init_options`, `rmw_impl_id_check_func` and `log_level`