### PR TITLE
Adding tests to arguments.c

### DIFF
--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -320,6 +320,10 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_alloc_unpar
   rcl_reset_error();
 
   EXPECT_EQ(
+    RCL_RET_BAD_ALLOC, rcl_arguments_get_unparsed_ros(&parsed_args, bad_alloc, &actual_unparsed));
+  rcl_reset_error();
+
+  EXPECT_EQ(
     RCL_RET_INVALID_ARGUMENT,
     rcl_arguments_get_unparsed_ros(nullptr, allocator, &actual_unparsed));
   rcl_reset_error();

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -328,13 +328,24 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_alloc_unpar
     rcl_arguments_get_unparsed_ros(nullptr, allocator, &actual_unparsed));
   rcl_reset_error();
 
+  EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
+}
+
+TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_empty_unparsed) {
+  rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_arguments_t empty_parsed_args = rcl_get_zero_initialized_arguments();
+  int * actual_unparsed = NULL;
+  int * actual_unparsed_ros = NULL;
+
   EXPECT_EQ(
     RCL_RET_INVALID_ARGUMENT,
     rcl_arguments_get_unparsed(&empty_parsed_args, allocator, &actual_unparsed));
   rcl_reset_error();
 
-  EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
+  EXPECT_EQ(
+    RCL_RET_INVALID_ARGUMENT,
+    rcl_arguments_get_unparsed_ros(&empty_parsed_args, allocator, &actual_unparsed_ros));
+  rcl_reset_error();
 }
 
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_params_get_counts) {

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -1235,9 +1235,14 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_alloc_parse
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
   rcl_allocator_t bomb_alloc = get_time_bombed_allocator();
 
-  for (int i = 0; i < 9; i++) {
+  for (int i = 0; i < 100; i++) {
     set_time_bombed_allocator_count(bomb_alloc, i);
     rcl_ret_t ret = rcl_parse_arguments(argc, argv, bomb_alloc, &parsed_args);
-    EXPECT_EQ(RCL_RET_BAD_ALLOC, ret) << rcl_get_error_string().str;
+    if (RCL_RET_OK == ret) {
+      EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
+      break;
+    } else {
+      EXPECT_EQ(RCL_RET_BAD_ALLOC, ret);
+    }
   }
 }

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -1168,7 +1168,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_allocs_copy
   {
     EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
   });
-  
+
   rcl_arguments_t copied_args = rcl_get_zero_initialized_arguments();
   rcl_allocator_t bomb_alloc = get_time_bombed_allocator();
   rcl_allocator_t saved_alloc = parsed_args.impl->allocator;

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -502,14 +502,6 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_copy_bad_alloc)
   ret = rcl_arguments_copy(&parsed_args, &copied_args);
   EXPECT_EQ(RCL_RET_BAD_ALLOC, ret) << rcl_get_error_string().str;
   rcl_reset_error();
-
-  rcl_allocator_t bomb_alloc = get_time_bombed_allocator();
-  set_time_bombed_allocator_count(bomb_alloc, 1);
-  parsed_args.impl->allocator = bomb_alloc;
-  ret = rcl_arguments_copy(&parsed_args, &copied_args);
-  EXPECT_EQ(RCL_RET_BAD_ALLOC, ret) << rcl_get_error_string().str;
-  rcl_reset_error();
-
   parsed_args.impl->allocator = saved_alloc;
 
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args)) << rcl_get_error_string().str;
@@ -1233,4 +1225,39 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_alloc_parse
     rcl_ret_t ret = rcl_parse_arguments(argc, argv, bomb_alloc, &parsed_args);
     EXPECT_EQ(RCL_RET_BAD_ALLOC, ret) << rcl_get_error_string().str;
   }
+}
+
+TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_allocs_copy) {
+  const std::string parameters_filepath1 = (test_path / "test_parameters.1.yaml").string();
+  const std::string parameters_filepath2 = (test_path / "test_parameters.2.yaml").string();
+  const char * const argv[] = {
+    "process_name", "--ros-args", "--params-file", parameters_filepath1.c_str(),
+    "-r", "__ns:=/namespace", "random:=arg", "--params-file", parameters_filepath2.c_str(),
+    "-r", "/foo/bar:=/fiz/buz", "--remap", "foo:=/baz",
+    "-e", "/foo", "--", "foo"
+  };
+  const int argc = sizeof(argv) / sizeof(const char *);
+  rcl_ret_t ret;
+
+  rcl_allocator_t alloc = rcl_get_default_allocator();
+  rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
+
+  ret = rcl_parse_arguments(argc, argv, alloc, &parsed_args);
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
+  });
+
+  rcl_arguments_t copied_args = rcl_get_zero_initialized_arguments();
+  rcl_allocator_t bomb_alloc = get_time_bombed_allocator();
+  rcl_allocator_t saved_alloc = parsed_args.impl->allocator;
+  parsed_args.impl->allocator = bomb_alloc;
+  for (int i = 0; i < 8; i++) {
+    set_time_bombed_allocator_count(bomb_alloc, i);
+    ret = rcl_arguments_copy(&parsed_args, &copied_args);
+    EXPECT_EQ(RCL_RET_BAD_ALLOC, ret) << rcl_get_error_string().str;
+    rcl_reset_error();
+  }
+  parsed_args.impl->allocator = saved_alloc;
 }

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -1062,6 +1062,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_no_param_overri
   rcl_arguments_t empty_parsed_arg = rcl_get_zero_initialized_arguments();
   ret = rcl_arguments_get_param_overrides(&empty_parsed_arg, &params);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
 
   rcl_params_t preallocated_params;
   params = &preallocated_params;
@@ -1216,13 +1217,19 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_null_get_param_
 
   ret = rcl_arguments_get_param_files(nullptr, allocator, &parameter_files);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string().str;
+  EXPECT_TRUE(rcl_error_is_set());
+  rcl_reset_error();
 
   ret = rcl_arguments_get_param_files(&parsed_args, allocator, nullptr);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string().str;
+  EXPECT_TRUE(rcl_error_is_set());
+  rcl_reset_error();
 
   rcl_arguments_t empty_parsed_args = rcl_get_zero_initialized_arguments();
   ret = rcl_arguments_get_param_files(&empty_parsed_args, allocator, &parameter_files);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string().str;
+  EXPECT_TRUE(rcl_error_is_set());
+  rcl_reset_error();
 }
 
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_alloc_parse_arg) {
@@ -1243,6 +1250,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_alloc_parse
       break;
     } else {
       EXPECT_EQ(RCL_RET_BAD_ALLOC, ret);
+      rcl_reset_error();
     }
   }
 }


### PR DESCRIPTION
This PR aims to increase current coverage of the `arguments.c` module of `rcl` adding various bad allocator tests. 

This PR doesn't achieve the 95% coverage goal for the module, for that it would be required/desirable to either add fault injection tests or exposing the internal functions so it's easier to test them.