### PR TITLE
Cope with base function restrictions in mocks.

### DIFF
--- a/rcl/test/rcl/test_logging.cpp
+++ b/rcl/test/rcl/test_logging.cpp
@@ -242,14 +242,13 @@ TEST(TestLogging, test_failing_external_logging) {
   std::stringstream stderr_sstream;
   auto fwrite_mock = mocking_utils::patch(
     "lib:rcl", fwrite,
-    ([&, base = fwrite](const void * ptr, size_t size,
-    size_t count, FILE * stream)
+    [&](const void * ptr, size_t size, size_t count, FILE * stream)
     {
       if (sizeof(char) == size && stderr == stream) {
         stderr_sstream << std::string(reinterpret_cast<const char *>(ptr), count);
       }
-      return base(ptr, size, count, stream);
-    }));
+      return count;
+    });
 
   constexpr char stderr_message[] = "internal error";
 #ifdef MOCKING_UTILS_SUPPORT_VA_LIST

--- a/rcl/test/rcl/test_rmw_impl_id_check_func.cpp
+++ b/rcl/test/rcl/test_rmw_impl_id_check_func.cpp
@@ -128,12 +128,15 @@ TEST(TestRmwCheck, test_mock_rmw_impl_check) {
 
     auto mock = mocking_utils::patch(
       "lib:rcl", rcutils_strdup,
-      [base = rcutils_strdup](const char * str, auto allocator)
+      [](const char * str, auto allocator)
       {
         static int counter = 1;
         if (counter == 1) {
           counter++;
-          return base(str, allocator);
+          char * dup = static_cast<char *>(
+            allocator.allocate(strlen(str) + 1, allocator.state));
+          memcpy(dup, str, strlen(str) + 1);
+          return dup;
         } else {
           return static_cast<char *>(NULL);
         }


### PR DESCRIPTION
Fixes https://github.com/ros2/rcl/issues/749. Base function (past PLT indirection) address is inaccessible on CentOS.