### PR TITLE
Zero initialize guard condition on failed init.

### DIFF
--- a/rcl/src/rcl/guard_condition.c
+++ b/rcl/src/rcl/guard_condition.c
@@ -87,6 +87,7 @@ __rcl_guard_condition_init_from_rmw_impl(
     if (!guard_condition->impl->rmw_handle) {
       // Deallocate impl and exit.
       allocator->deallocate(guard_condition->impl, allocator->state);
+      guard_condition->impl = NULL;
       RCL_SET_ERROR_MSG(rmw_get_error_string().str);
       return RCL_RET_ERROR;
     }


### PR DESCRIPTION
A tiny bug I found while writing tests.

CI up to `rcl`:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12060)](http://ci.ros2.org/job/ci_linux/12060/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7083)](http://ci.ros2.org/job/ci_linux-aarch64/7083/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9835)](http://ci.ros2.org/job/ci_osx/9835/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11993)](http://ci.ros2.org/job/ci_windows/11993/)
