### PR TITLE
Do not invalidate context before successful shutdown.

### DIFF
--- a/rcl/src/rcl/init.c
+++ b/rcl/src/rcl/init.c
@@ -241,14 +241,14 @@ rcl_shutdown(rcl_context_t * context)
     return RCL_RET_ALREADY_SHUTDOWN;
   }
 
-  // reset the instance id to 0 to indicate "invalid"
-  rcutils_atomic_store((atomic_uint_least64_t *)(&context->instance_id_storage), 0);
-
   rmw_ret_t rmw_ret = rmw_shutdown(&(context->impl->rmw_context));
   if (RMW_RET_OK != rmw_ret) {
     RCL_SET_ERROR_MSG(rmw_get_error_string().str);
     return rcl_convert_rmw_ret_to_rcl_ret(rmw_ret);
   }
+
+  // reset the instance id to 0 to indicate "invalid"
+  rcutils_atomic_store((atomic_uint_least64_t *)(&context->instance_id_storage), 0);
 
   return RCL_RET_OK;
 }


### PR DESCRIPTION
Another small bug I found while writing tests.

CI up to `rcl`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12061)](http://ci.ros2.org/job/ci_linux/12061/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7084)](http://ci.ros2.org/job/ci_linux-aarch64/7084/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9836)](http://ci.ros2.org/job/ci_osx/9836/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11994)](http://ci.ros2.org/job/ci_windows/11994/)

