### PR TITLE
Yield rcl_context_fini() error codes.

### DIFF
--- a/rcl/src/rcl/context.c
+++ b/rcl/src/rcl/context.c
@@ -112,7 +112,7 @@ __cleanup_context(rcl_context_t * context)
 
   // clean up global_arguments if initialized
   if (NULL != context->global_arguments.impl) {
-    rcl_ret_t ret = rcl_arguments_fini(&(context->global_arguments));
+    ret = rcl_arguments_fini(&(context->global_arguments));
     if (RCL_RET_OK != ret) {
       RCUTILS_SAFE_FWRITE_TO_STDERR(
         "[rcl|context.c:" RCUTILS_STRINGIFY(__LINE__)
@@ -130,10 +130,10 @@ __cleanup_context(rcl_context_t * context)
 
     // finalize init options if valid
     if (NULL != context->impl->init_options.impl) {
-      rcl_ret_t inner_ret = rcl_init_options_fini(&(context->impl->init_options));
-      if (RCL_RET_OK != inner_ret) {
+      rcl_ret_t init_options_fini_ret = rcl_init_options_fini(&(context->impl->init_options));
+      if (RCL_RET_OK != init_options_fini_ret) {
         if (RCL_RET_OK == ret) {
-          ret = inner_ret;
+          ret = init_options_fini_ret;
         }
         RCUTILS_SAFE_FWRITE_TO_STDERR(
           "[rcl|context.c:" RCUTILS_STRINGIFY(__LINE__)
@@ -146,10 +146,10 @@ __cleanup_context(rcl_context_t * context)
 
     // clean up rmw_context
     if (NULL != context->impl->rmw_context.implementation_identifier) {
-      rmw_ret_t rmw_ret = rmw_context_fini(&(context->impl->rmw_context));
-      if (RMW_RET_OK != rmw_ret) {
+      rmw_ret_t rmw_context_fini_ret = rmw_context_fini(&(context->impl->rmw_context));
+      if (RMW_RET_OK != rmw_context_fini_ret) {
         if (RCL_RET_OK == ret) {
-          ret = rcl_convert_rmw_ret_to_rcl_ret(rmw_ret);
+          ret = rcl_convert_rmw_ret_to_rcl_ret(rmw_context_fini_ret);
         }
         RCUTILS_SAFE_FWRITE_TO_STDERR(
           "[rcl|context.c:" RCUTILS_STRINGIFY(__LINE__)

--- a/rcl/src/rcl/context.c
+++ b/rcl/src/rcl/context.c
@@ -21,6 +21,7 @@ extern "C"
 
 #include <stdbool.h>
 
+#include "./common.h"
 #include "./context_impl.h"
 #include "rcutils/stdatomic_helper.h"
 
@@ -56,8 +57,7 @@ rcl_context_fini(rcl_context_t * context)
   }
   RCL_CHECK_ALLOCATOR_WITH_MSG(
     &(context->impl->allocator), "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
-  __cleanup_context(context);
-  return RCL_RET_OK;
+  return __cleanup_context(context);
 }
 
 // See `rcl_shutdown()` for invalidation of the context.
@@ -103,9 +103,10 @@ rcl_context_get_rmw_context(rcl_context_t * context)
   return &(context->impl->rmw_context);
 }
 
-void
+rcl_ret_t
 __cleanup_context(rcl_context_t * context)
 {
+  rcl_ret_t ret = RCL_RET_OK;
   // reset the instance id to 0 to indicate "invalid" (should already be 0, but this is defensive)
   rcutils_atomic_store((atomic_uint_least64_t *)(&context->instance_id_storage), 0);
 
@@ -129,8 +130,11 @@ __cleanup_context(rcl_context_t * context)
 
     // finalize init options if valid
     if (NULL != context->impl->init_options.impl) {
-      rcl_ret_t ret = rcl_init_options_fini(&(context->impl->init_options));
-      if (RCL_RET_OK != ret) {
+      rcl_ret_t inner_ret = rcl_init_options_fini(&(context->impl->init_options));
+      if (RCL_RET_OK != inner_ret) {
+        if (RCL_RET_OK == ret) {
+          ret = inner_ret;
+        }
         RCUTILS_SAFE_FWRITE_TO_STDERR(
           "[rcl|context.c:" RCUTILS_STRINGIFY(__LINE__)
           "] failed to finalize init options while cleaning up context, memory may be leaked: ");
@@ -144,6 +148,9 @@ __cleanup_context(rcl_context_t * context)
     if (NULL != context->impl->rmw_context.implementation_identifier) {
       rmw_ret_t rmw_ret = rmw_context_fini(&(context->impl->rmw_context));
       if (RMW_RET_OK != rmw_ret) {
+        if (RCL_RET_OK == ret) {
+          ret = rcl_convert_rmw_ret_to_rcl_ret(rmw_ret);
+        }
         RCUTILS_SAFE_FWRITE_TO_STDERR(
           "[rcl|context.c:" RCUTILS_STRINGIFY(__LINE__)
           "] failed to finalize rmw context while cleaning up context, memory may be leaked: ");
@@ -168,6 +175,8 @@ __cleanup_context(rcl_context_t * context)
 
   // zero-initialize the context
   *context = rcl_get_zero_initialized_context();
+
+  return ret;
 }
 
 #ifdef __cplusplus

--- a/rcl/src/rcl/context_impl.h
+++ b/rcl/src/rcl/context_impl.h
@@ -41,7 +41,7 @@ typedef struct rcl_context_impl_t
 } rcl_context_impl_t;
 
 RCL_LOCAL
-void
+rcl_ret_t
 __cleanup_context(rcl_context_t * context);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Precisely what the title says, do not eat up return codes.

CI up to `rcl`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12065)](http://ci.ros2.org/job/ci_linux/12065/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7086)](http://ci.ros2.org/job/ci_linux-aarch64/7086/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9838)](http://ci.ros2.org/job/ci_osx/9838/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11996)](http://ci.ros2.org/job/ci_windows/11996/)
