### PR TITLE
Set variant values to NULL on fini

### DIFF
--- a/rcl_yaml_param_parser/src/parser.c
+++ b/rcl_yaml_param_parser/src/parser.c
@@ -593,33 +593,41 @@ void rcl_yaml_variant_fini(
 
   if (NULL != param_var->bool_value) {
     allocator.deallocate(param_var->bool_value, allocator.state);
+    param_var->bool_value = NULL;
   } else if (NULL != param_var->integer_value) {
     allocator.deallocate(param_var->integer_value, allocator.state);
+    param_var->integer_value = NULL;
   } else if (NULL != param_var->double_value) {
     allocator.deallocate(param_var->double_value, allocator.state);
+    param_var->double_value = NULL;
   } else if (NULL != param_var->string_value) {
     allocator.deallocate(param_var->string_value, allocator.state);
+    param_var->string_value = NULL;
   } else if (NULL != param_var->bool_array_value) {
     if (NULL != param_var->bool_array_value->values) {
       allocator.deallocate(param_var->bool_array_value->values, allocator.state);
     }
     allocator.deallocate(param_var->bool_array_value, allocator.state);
+    param_var->bool_array_value = NULL;
   } else if (NULL != param_var->integer_array_value) {
     if (NULL != param_var->integer_array_value->values) {
       allocator.deallocate(param_var->integer_array_value->values, allocator.state);
     }
     allocator.deallocate(param_var->integer_array_value, allocator.state);
+    param_var->integer_array_value = NULL;
   } else if (NULL != param_var->double_array_value) {
     if (NULL != param_var->double_array_value->values) {
       allocator.deallocate(param_var->double_array_value->values, allocator.state);
     }
     allocator.deallocate(param_var->double_array_value, allocator.state);
+    param_var->double_array_value = NULL;
   } else if (NULL != param_var->string_array_value) {
     if (RCUTILS_RET_OK != rcutils_string_array_fini(param_var->string_array_value)) {
       // Log and continue ...
       RCUTILS_SAFE_FWRITE_TO_STDERR("Error deallocating string array");
     }
     allocator.deallocate(param_var->string_array_value, allocator.state);
+    param_var->string_array_value = NULL;
   } else {
     /// Nothing to do to keep pclint happy
   }


### PR DESCRIPTION
This just helps clean up rcl_variant_t a little better on finalization, which is important for the fault injection tests.

Depends on #754.

Signed-off-by: Stephen Brawner <brawner@gmail.com>