### PR TITLE
Check rcutils_strdup() outcome immediately.

### DIFF
--- a/rcl/src/rcl/init.c
+++ b/rcl/src/rcl/init.c
@@ -172,6 +172,13 @@ rcl_init(
     context->impl->init_options.impl->rmw_init_options.enclave = rcutils_strdup(
       "/", context->impl->allocator);
   }
+
+  if (!context->impl->init_options.impl->rmw_init_options.enclave) {
+    RCL_SET_ERROR_MSG("failed to set context name");
+    fail_ret = RCL_RET_BAD_ALLOC;
+    goto fail;
+  }
+
   int validation_result;
   size_t invalid_index;
   ret = rcl_validate_enclave_name(
@@ -189,12 +196,6 @@ rcl_init(
       rcl_enclave_name_validation_result_string(validation_result),
       invalid_index);
     fail_ret = RCL_RET_ERROR;
-    goto fail;
-  }
-
-  if (!context->impl->init_options.impl->rmw_init_options.enclave) {
-    RCL_SET_ERROR_MSG("failed to set context name");
-    fail_ret = RCL_RET_BAD_ALLOC;
     goto fail;
   }
 


### PR DESCRIPTION
Within `rcl_node_init()` implementation. Small bug I came across.

CI up to `rcl`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12123)](http://ci.ros2.org/job/ci_linux/12123/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7099)](http://ci.ros2.org/job/ci_linux-aarch64/7099/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9872)](http://ci.ros2.org/job/ci_osx/9872/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12006)](http://ci.ros2.org/job/ci_windows/12006/)