### PR TITLE
Add basic unit tests for refactored functions in rcl_yaml_param_parser (coverage part 1/3)

### DIFF
--- a/rcl_yaml_param_parser/CMakeLists.txt
+++ b/rcl_yaml_param_parser/CMakeLists.txt
@@ -58,6 +58,30 @@ if(BUILD_TESTING)
   ament_lint_auto_find_test_dependencies()
 
   # Gtests
+  ament_add_gtest(test_namespace
+    test/test_namespace.cpp
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  )
+  if(TARGET test_namespace)
+    ament_target_dependencies(test_namespace
+      "rcutils"
+      "osrf_testing_tools_cpp"
+    )
+    target_link_libraries(test_namespace ${PROJECT_NAME})
+  endif()
+
+  ament_add_gtest(test_node_params
+    test/test_node_params.cpp
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  )
+  if(TARGET test_node_params)
+    ament_target_dependencies(test_node_params
+      "rcutils"
+      "osrf_testing_tools_cpp"
+    )
+    target_link_libraries(test_node_params ${PROJECT_NAME})
+  endif()
+
   ament_add_gtest(test_parse_yaml
     test/test_parse_yaml.cpp
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
@@ -66,6 +90,18 @@ if(BUILD_TESTING)
     target_link_libraries(test_parse_yaml ${PROJECT_NAME})
     target_include_directories(test_parse_yaml
       PRIVATE ${osrf_testing_tools_cpp_INCLUDE_DIRS})
+  endif()
+
+  ament_add_gtest(test_parse
+    test/test_parse.cpp
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  )
+  if(TARGET test_parse)
+    ament_target_dependencies(test_parse
+      "rcutils"
+      "osrf_testing_tools_cpp"
+    )
+    target_link_libraries(test_parse ${PROJECT_NAME})
   endif()
 
   ament_add_gtest(test_parser
@@ -78,6 +114,18 @@ if(BUILD_TESTING)
       "osrf_testing_tools_cpp"
     )
     target_link_libraries(test_parser ${PROJECT_NAME})
+  endif()
+
+  ament_add_gtest(test_yaml_variant
+    test/test_yaml_variant.cpp
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+  )
+  if(TARGET test_yaml_variant)
+    ament_target_dependencies(test_yaml_variant
+      "rcutils"
+      "osrf_testing_tools_cpp"
+    )
+    target_link_libraries(test_yaml_variant ${PROJECT_NAME})
   endif()
 
 endif()

--- a/rcl_yaml_param_parser/test/test_namespace.cpp
+++ b/rcl_yaml_param_parser/test/test_namespace.cpp
@@ -21,7 +21,7 @@
 
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcl_yaml_param_parser/parser.h"
-#include "rcl_yaml_param_parser/impl/namespace.h"
+#include "../src/impl/namespace.h"
 #include "rcutils/allocator.h"
 #include "rcutils/strdup.h"
 

--- a/rcl_yaml_param_parser/test/test_namespace.cpp
+++ b/rcl_yaml_param_parser/test/test_namespace.cpp
@@ -1,0 +1,98 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <yaml.h>
+
+#include <string>
+#include <vector>
+
+#include "osrf_testing_tools_cpp/scope_exit.hpp"
+#include "rcl_yaml_param_parser/parser.h"
+#include "rcl_yaml_param_parser/impl/namespace.h"
+#include "rcutils/allocator.h"
+#include "rcutils/strdup.h"
+
+TEST(TestNamespace, add_name_to_ns) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  namespace_tracker_t ns_tracker;
+  ns_tracker.node_ns = rcutils_strdup("", allocator);
+  ASSERT_STREQ("", ns_tracker.node_ns);
+  ns_tracker.parameter_ns = rcutils_strdup("", allocator);
+  ASSERT_STREQ("", ns_tracker.parameter_ns);
+  ns_tracker.num_node_ns = 0;
+  ns_tracker.num_parameter_ns = 0;
+
+  rcutils_ret_t ret = add_name_to_ns(&ns_tracker, nullptr, NS_TYPE_NODE, allocator);
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
+  EXPECT_STREQ("", ns_tracker.node_ns);
+
+  ret = add_name_to_ns(&ns_tracker, "node1", NS_TYPE_NODE, allocator);
+  EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
+  EXPECT_STREQ("node1", ns_tracker.node_ns);
+  EXPECT_EQ(1u, ns_tracker.num_node_ns);
+
+  ret = add_name_to_ns(&ns_tracker, "node2", NS_TYPE_NODE, allocator);
+  EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
+  EXPECT_STREQ("node1/node2", ns_tracker.node_ns);
+  EXPECT_EQ(2u, ns_tracker.num_node_ns);
+
+  ret = add_name_to_ns(&ns_tracker, "param1", NS_TYPE_PARAM, allocator);
+  EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
+  EXPECT_STREQ("param1", ns_tracker.parameter_ns);
+  EXPECT_EQ(1u, ns_tracker.num_parameter_ns);
+
+  ret = add_name_to_ns(&ns_tracker, "param2", NS_TYPE_PARAM, allocator);
+  EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
+  EXPECT_STREQ("param1.param2", ns_tracker.parameter_ns);
+  EXPECT_EQ(2u, ns_tracker.num_parameter_ns);
+}
+
+TEST(TestNamespace, replace_ns) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  namespace_tracker_t ns_tracker;
+  ns_tracker.node_ns = rcutils_strdup("node1/node2", allocator);
+  ASSERT_STREQ("node1/node2", ns_tracker.node_ns);
+  ns_tracker.parameter_ns = rcutils_strdup("param1.param2", allocator);
+  ASSERT_STREQ("param1.param2", ns_tracker.parameter_ns);
+  ns_tracker.num_node_ns = 2;
+  ns_tracker.num_parameter_ns = 2;
+
+  char * expected_ns = rcutils_strdup("new_ns1/new_ns2/new_ns3", allocator);
+  ASSERT_STREQ("new_ns1/new_ns2/new_ns3", expected_ns);
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    allocator.deallocate(expected_ns, allocator.state);
+  });
+
+  rcutils_ret_t ret =
+    replace_ns(&ns_tracker, expected_ns, 3, NS_TYPE_NODE, allocator);
+  EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
+  EXPECT_STREQ(expected_ns, ns_tracker.node_ns);
+  EXPECT_EQ(3u, ns_tracker.num_node_ns);
+
+  char * expected_param_ns =
+    rcutils_strdup("new_param1.new_param2.new_param3", allocator);
+  ASSERT_STREQ("new_param1.new_param2.new_param3", expected_param_ns);
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    allocator.deallocate(expected_param_ns, allocator.state);
+  });
+
+  ret = replace_ns(&ns_tracker, expected_param_ns, 3, NS_TYPE_PARAM, allocator);
+  EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
+  EXPECT_STREQ(expected_param_ns, ns_tracker.parameter_ns);
+  EXPECT_EQ(3u, ns_tracker.num_parameter_ns);
+}

--- a/rcl_yaml_param_parser/test/test_namespace.cpp
+++ b/rcl_yaml_param_parser/test/test_namespace.cpp
@@ -32,6 +32,11 @@ TEST(TestNamespace, add_name_to_ns) {
   ASSERT_STREQ("", ns_tracker.node_ns);
   ns_tracker.parameter_ns = rcutils_strdup("", allocator);
   ASSERT_STREQ("", ns_tracker.parameter_ns);
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    allocator.deallocate(ns_tracker.node_ns, allocator.state);
+    allocator.deallocate(ns_tracker.parameter_ns, allocator.state);
+  });
   ns_tracker.num_node_ns = 0;
   ns_tracker.num_parameter_ns = 0;
 
@@ -63,10 +68,10 @@ TEST(TestNamespace, add_name_to_ns) {
 TEST(TestNamespace, replace_ns) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   namespace_tracker_t ns_tracker;
-  ns_tracker.node_ns = rcutils_strdup("node1/node2", allocator);
-  ASSERT_STREQ("node1/node2", ns_tracker.node_ns);
-  ns_tracker.parameter_ns = rcutils_strdup("param1.param2", allocator);
-  ASSERT_STREQ("param1.param2", ns_tracker.parameter_ns);
+  ns_tracker.node_ns = rcutils_strdup("initial_node1/initial_node2", allocator);
+  ASSERT_STREQ("initial_node1/initial_node2", ns_tracker.node_ns);
+  ns_tracker.parameter_ns = rcutils_strdup("initial_param1.initial_param2", allocator);
+  ASSERT_STREQ("initial_param1.initial_param2", ns_tracker.parameter_ns);
   ns_tracker.num_node_ns = 2;
   ns_tracker.num_parameter_ns = 2;
 
@@ -74,6 +79,8 @@ TEST(TestNamespace, replace_ns) {
   ASSERT_STREQ("new_ns1/new_ns2/new_ns3", expected_ns);
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
   {
+    allocator.deallocate(ns_tracker.node_ns, allocator.state);
+    allocator.deallocate(ns_tracker.parameter_ns, allocator.state);
     allocator.deallocate(expected_ns, allocator.state);
   });
 

--- a/rcl_yaml_param_parser/test/test_namespace.cpp
+++ b/rcl_yaml_param_parser/test/test_namespace.cpp
@@ -28,26 +28,23 @@
 TEST(TestNamespace, add_name_to_ns) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   namespace_tracker_t ns_tracker;
-  ns_tracker.node_ns = rcutils_strdup("", allocator);
-  ASSERT_STREQ("", ns_tracker.node_ns);
-  ns_tracker.parameter_ns = rcutils_strdup("", allocator);
-  ASSERT_STREQ("", ns_tracker.parameter_ns);
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
-  {
-    allocator.deallocate(ns_tracker.node_ns, allocator.state);
-    allocator.deallocate(ns_tracker.parameter_ns, allocator.state);
-  });
+  ns_tracker.node_ns = nullptr;
+  ns_tracker.parameter_ns = nullptr;
   ns_tracker.num_node_ns = 0;
   ns_tracker.num_parameter_ns = 0;
 
   rcutils_ret_t ret = add_name_to_ns(&ns_tracker, nullptr, NS_TYPE_NODE, allocator);
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
-  EXPECT_STREQ("", ns_tracker.node_ns);
+  EXPECT_EQ(nullptr, ns_tracker.node_ns);
 
   ret = add_name_to_ns(&ns_tracker, "node1", NS_TYPE_NODE, allocator);
   EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
   EXPECT_STREQ("node1", ns_tracker.node_ns);
   EXPECT_EQ(1u, ns_tracker.num_node_ns);
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    allocator.deallocate(ns_tracker.node_ns, allocator.state);
+  });
 
   ret = add_name_to_ns(&ns_tracker, "node2", NS_TYPE_NODE, allocator);
   EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
@@ -58,6 +55,10 @@ TEST(TestNamespace, add_name_to_ns) {
   EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
   EXPECT_STREQ("param1", ns_tracker.parameter_ns);
   EXPECT_EQ(1u, ns_tracker.num_parameter_ns);
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    allocator.deallocate(ns_tracker.parameter_ns, allocator.state);
+  });
 
   ret = add_name_to_ns(&ns_tracker, "param2", NS_TYPE_PARAM, allocator);
   EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;

--- a/rcl_yaml_param_parser/test/test_node_params.cpp
+++ b/rcl_yaml_param_parser/test/test_node_params.cpp
@@ -28,6 +28,9 @@ TEST(TestNodeParams, init_fini) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   rcl_node_params_t node_params = {NULL, NULL, 0u};
   EXPECT_EQ(RCUTILS_RET_OK, node_params_init(&node_params, allocator));
+  EXPECT_NE(nullptr, node_params.parameter_names);
+  EXPECT_NE(nullptr, node_params.parameter_values);
+  EXPECT_EQ(0u, node_params.num_params);
   rcl_yaml_node_params_fini(&node_params, allocator);
   EXPECT_EQ(nullptr, node_params.parameter_names);
   EXPECT_EQ(nullptr, node_params.parameter_values);

--- a/rcl_yaml_param_parser/test/test_node_params.cpp
+++ b/rcl_yaml_param_parser/test/test_node_params.cpp
@@ -21,7 +21,7 @@
 
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcl_yaml_param_parser/parser.h"
-#include "rcl_yaml_param_parser/impl/node_params.h"
+#include "../src/impl/node_params.h"
 #include "rcutils/allocator.h"
 
 TEST(TestNodeParams, init_fini) {

--- a/rcl_yaml_param_parser/test/test_node_params.cpp
+++ b/rcl_yaml_param_parser/test/test_node_params.cpp
@@ -1,0 +1,39 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <yaml.h>
+
+#include <string>
+#include <vector>
+
+#include "osrf_testing_tools_cpp/scope_exit.hpp"
+#include "rcl_yaml_param_parser/parser.h"
+#include "rcl_yaml_param_parser/impl/node_params.h"
+#include "rcutils/allocator.h"
+
+TEST(TestNodeParams, init_fini) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  rcl_node_params_t node_params = {NULL, NULL, 0u};
+  EXPECT_EQ(RCUTILS_RET_OK, node_params_init(&node_params, allocator));
+  rcl_yaml_node_params_fini(&node_params, allocator);
+  EXPECT_EQ(nullptr, node_params.parameter_names);
+  EXPECT_EQ(nullptr, node_params.parameter_values);
+  EXPECT_EQ(0u, node_params.num_params);
+
+  // This function doesn't return anything, so just check it doesn't segfault on the second try
+  rcl_yaml_node_params_fini(&node_params, allocator);
+  rcl_yaml_node_params_fini(nullptr, allocator);
+}

--- a/rcl_yaml_param_parser/test/test_parse.cpp
+++ b/rcl_yaml_param_parser/test/test_parse.cpp
@@ -21,8 +21,8 @@
 
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcl_yaml_param_parser/parser.h"
-#include "rcl_yaml_param_parser/impl/parse.h"
-#include "rcl_yaml_param_parser/impl/node_params.h"
+#include "../src/impl/parse.h"
+#include "../src/impl/node_params.h"
 #include "rcutils/filesystem.h"
 
 TEST(TestParse, parse_value) {

--- a/rcl_yaml_param_parser/test/test_parse.cpp
+++ b/rcl_yaml_param_parser/test/test_parse.cpp
@@ -1,0 +1,417 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <yaml.h>
+
+#include <string>
+#include <vector>
+
+#include "osrf_testing_tools_cpp/scope_exit.hpp"
+#include "rcl_yaml_param_parser/parser.h"
+#include "rcl_yaml_param_parser/impl/parse.h"
+#include "rcl_yaml_param_parser/impl/node_params.h"
+#include "rcutils/filesystem.h"
+
+TEST(TestParse, parse_value) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  yaml_event_t event;
+  event.type = YAML_NO_EVENT;
+
+  bool is_seq = false;
+  size_t node_idx = 0u;
+  size_t parameter_idx = 0u;
+  data_types_t seq_data_type = DATA_TYPE_UNKNOWN;
+  rcl_params_t * params_st = rcl_yaml_node_struct_init(allocator);
+  ASSERT_NE(nullptr, params_st);
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    rcl_yaml_node_struct_fini(params_st);
+  });
+
+  ASSERT_EQ(RCUTILS_RET_OK, node_params_init(&params_st->params[0], allocator));
+  params_st->num_nodes = 1u;
+
+  // bool value
+  yaml_char_t bool_value[] = "true";
+  const size_t bool_value_length = sizeof(bool_value) / sizeof(bool_value[0]);
+  event.data.scalar.value = bool_value;
+  event.data.scalar.length = bool_value_length;
+
+  EXPECT_EQ(
+    RCUTILS_RET_OK,
+    parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
+    rcutils_get_error_string().str;
+  ASSERT_NE(nullptr, params_st->params[0].parameter_values[0].bool_value);
+  EXPECT_TRUE(*params_st->params[0].parameter_values[0].bool_value);
+  allocator.deallocate(params_st->params[0].parameter_values[0].bool_value, allocator.state);
+  params_st->params[0].parameter_values[0].bool_value = nullptr;
+
+  // integer value
+  yaml_char_t integer_value[] = "42";
+  const size_t integer_value_length = sizeof(integer_value) / sizeof(integer_value[0]);
+  event.data.scalar.value = integer_value;
+  event.data.scalar.length = integer_value_length;
+
+  EXPECT_EQ(
+    RCUTILS_RET_OK,
+    parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
+    rcutils_get_error_string().str;
+  ASSERT_NE(nullptr, params_st->params[0].parameter_values[0].integer_value);
+  EXPECT_EQ(42, *params_st->params[0].parameter_values[0].integer_value);
+  allocator.deallocate(params_st->params[0].parameter_values[0].integer_value, allocator.state);
+  params_st->params[0].parameter_values[0].integer_value = nullptr;
+
+  // double value
+  yaml_char_t double_value[] = "3.14159";
+  const size_t double_value_length = sizeof(double_value) / sizeof(double_value[0]);
+  event.data.scalar.value = double_value;
+  event.data.scalar.length = double_value_length;
+
+  EXPECT_EQ(
+    RCUTILS_RET_OK,
+    parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
+    rcutils_get_error_string().str;
+  ASSERT_NE(nullptr, params_st->params[0].parameter_values[0].double_value);
+  EXPECT_EQ(3.14159, *params_st->params[0].parameter_values[0].double_value);
+  allocator.deallocate(params_st->params[0].parameter_values[0].double_value, allocator.state);
+  params_st->params[0].parameter_values[0].double_value = nullptr;
+
+  // double value
+  yaml_char_t string_value[] = "hello, I am a string";
+  const size_t string_value_length = sizeof(string_value) / sizeof(string_value[0]);
+  event.data.scalar.value = string_value;
+  event.data.scalar.length = string_value_length;
+
+  EXPECT_EQ(
+    RCUTILS_RET_OK,
+    parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
+    rcutils_get_error_string().str;
+  ASSERT_NE(nullptr, params_st->params[0].parameter_values[0].string_value);
+  EXPECT_STREQ("hello, I am a string", params_st->params[0].parameter_values[0].string_value);
+  allocator.deallocate(params_st->params[0].parameter_values[0].string_value, allocator.state);
+  params_st->params[0].parameter_values[0].string_value = nullptr;
+}
+
+TEST(TestParse, parse_value_sequence) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  yaml_event_t event;
+  event.type = YAML_NO_EVENT;
+
+  bool is_seq = true;
+  size_t node_idx = 0u;
+  size_t parameter_idx = 0u;
+  data_types_t seq_data_type = DATA_TYPE_UNKNOWN;
+  rcl_params_t * params_st = rcl_yaml_node_struct_init(allocator);
+  ASSERT_NE(nullptr, params_st);
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    rcl_yaml_node_struct_fini(params_st);
+  });
+
+  ASSERT_EQ(RCUTILS_RET_OK, node_params_init(&params_st->params[0], allocator));
+  params_st->num_nodes = 1u;
+
+  // bool array value
+  yaml_char_t bool_value[] = "true";
+  const size_t bool_value_length = sizeof(bool_value) / sizeof(bool_value[0]);
+  event.data.scalar.value = bool_value;
+  event.data.scalar.length = bool_value_length;
+
+  // Check bad sequence type for bool
+  seq_data_type = DATA_TYPE_STRING;
+  EXPECT_EQ(
+    RCUTILS_RET_ERROR,
+    parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
+    rcutils_get_error_string().str;
+  EXPECT_EQ(nullptr, params_st->params[0].parameter_values[0].integer_array_value);
+
+  // Check proper sequence type
+  seq_data_type = DATA_TYPE_UNKNOWN;
+  EXPECT_EQ(
+    RCUTILS_RET_OK,
+    parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
+    rcutils_get_error_string().str;
+  ASSERT_NE(nullptr, params_st->params[0].parameter_values[0].bool_array_value);
+  EXPECT_TRUE(params_st->params[0].parameter_values[0].bool_array_value->values[0]);
+  allocator.deallocate(
+    params_st->params[0].parameter_values[0].bool_array_value->values, allocator.state);
+  allocator.deallocate(params_st->params[0].parameter_values[0].bool_array_value, allocator.state);
+  params_st->params[0].parameter_values[0].bool_array_value = nullptr;
+
+  // integer array value
+  yaml_char_t integer_value[] = "42";
+  const size_t integer_value_length = sizeof(integer_value) / sizeof(integer_value[0]);
+  event.data.scalar.value = integer_value;
+  event.data.scalar.length = integer_value_length;
+
+  // Check bad sequence type for int
+  seq_data_type = DATA_TYPE_STRING;
+  EXPECT_EQ(
+    RCUTILS_RET_ERROR,
+    parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
+    rcutils_get_error_string().str;
+  EXPECT_EQ(nullptr, params_st->params[0].parameter_values[0].integer_array_value);
+
+  // Check proper sequence type
+  seq_data_type = DATA_TYPE_UNKNOWN;
+  EXPECT_EQ(
+    RCUTILS_RET_OK,
+    parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
+    rcutils_get_error_string().str;
+  ASSERT_NE(nullptr, params_st->params[0].parameter_values[0].integer_array_value);
+  EXPECT_EQ(42, params_st->params[0].parameter_values[0].integer_array_value->values[0]);
+  allocator.deallocate(
+    params_st->params[0].parameter_values[0].integer_array_value->values, allocator.state);
+  allocator.deallocate(
+    params_st->params[0].parameter_values[0].integer_value, allocator.state);
+  params_st->params[0].parameter_values[0].integer_array_value = nullptr;
+
+  // double value
+  yaml_char_t double_value[] = "3.14159";
+  const size_t double_value_length = sizeof(double_value) / sizeof(double_value[0]);
+  event.data.scalar.value = double_value;
+  event.data.scalar.length = double_value_length;
+
+  // Check bad sequence type for double
+  seq_data_type = DATA_TYPE_STRING;
+  EXPECT_EQ(
+    RCUTILS_RET_ERROR,
+    parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
+    rcutils_get_error_string().str;
+  EXPECT_EQ(nullptr, params_st->params[0].parameter_values[0].integer_array_value);
+
+  // Check proper sequence type
+  seq_data_type = DATA_TYPE_UNKNOWN;
+  EXPECT_EQ(
+    RCUTILS_RET_OK,
+    parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
+    rcutils_get_error_string().str;
+  ASSERT_NE(nullptr, params_st->params[0].parameter_values[0].double_array_value);
+  EXPECT_EQ(3.14159, params_st->params[0].parameter_values[0].double_array_value->values[0]);
+  allocator.deallocate(
+    params_st->params[0].parameter_values[0].double_array_value->values, allocator.state);
+  allocator.deallocate(
+    params_st->params[0].parameter_values[0].double_array_value, allocator.state);
+  params_st->params[0].parameter_values[0].double_array_value = nullptr;
+
+  // double value
+  yaml_char_t string_value[] = "hello, I am a string";
+  const size_t string_value_length = sizeof(string_value) / sizeof(string_value[0]);
+  event.data.scalar.value = string_value;
+  event.data.scalar.length = string_value_length;
+
+  // Check bad sequence type for string
+  seq_data_type = DATA_TYPE_BOOL;
+  EXPECT_EQ(
+    RCUTILS_RET_ERROR,
+    parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
+    rcutils_get_error_string().str;
+  EXPECT_EQ(nullptr, params_st->params[0].parameter_values[0].integer_array_value);
+
+  // Check proper sequence type
+  seq_data_type = DATA_TYPE_UNKNOWN;
+  EXPECT_EQ(
+    RCUTILS_RET_OK,
+    parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
+    rcutils_get_error_string().str;
+  ASSERT_NE(nullptr, params_st->params[0].parameter_values[0].string_array_value);
+  EXPECT_STREQ(
+    "hello, I am a string",
+    params_st->params[0].parameter_values[0].string_array_value->data[0]);
+  EXPECT_EQ(
+    RCUTILS_RET_OK,
+    rcutils_string_array_fini(params_st->params[0].parameter_values[0].string_array_value)) <<
+    rcutils_get_error_string().str;
+  params_st->params[0].parameter_values[0].string_array_value = nullptr;
+}
+
+TEST(TestParse, parse_value_bad_args) {
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  yaml_event_t event;
+  event.type = YAML_NO_EVENT;
+
+  bool is_seq = false;
+  size_t node_idx = 0u;
+  size_t parameter_idx = 0u;
+  data_types_t seq_data_type = DATA_TYPE_UNKNOWN;
+  rcl_params_t * params_st = rcl_yaml_node_struct_init(allocator);
+  ASSERT_NE(nullptr, params_st);
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    rcl_yaml_node_struct_fini(params_st);
+  });
+
+  EXPECT_EQ(
+    RCUTILS_RET_INVALID_ARGUMENT,
+    parse_value(event, is_seq, node_idx, parameter_idx, nullptr, params_st));
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
+
+  EXPECT_EQ(
+    RCUTILS_RET_INVALID_ARGUMENT,
+    parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, nullptr));
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
+
+  // No node to update
+  const size_t num_nodes = params_st->num_nodes;
+  params_st->num_nodes = 0u;
+  EXPECT_EQ(
+    RCUTILS_RET_INVALID_ARGUMENT,
+    parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st));
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
+  params_st->num_nodes = num_nodes;
+
+  ASSERT_EQ(RCUTILS_RET_OK, node_params_init(&params_st->params[0], allocator));
+  params_st->num_nodes = 1u;
+
+  // event.data.scaler.value is NULL
+  event.start_mark = {0u, 0u, 0u};
+  event.data.scalar = {NULL, NULL, NULL, 0u, 0, 0, YAML_ANY_SCALAR_STYLE};
+  EXPECT_EQ(
+    RCUTILS_RET_INVALID_ARGUMENT,
+    parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st));
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
+
+  // event.data.scalar.length is 0
+  yaml_char_t event_value[] = "non_empty_string";
+  const size_t event_value_length = sizeof(event_value) / sizeof(event_value[0]);
+  event.data.scalar.value = event_value;
+  EXPECT_EQ(
+    RCUTILS_RET_ERROR,
+    parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
+    rcutils_get_error_string().str;
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
+
+  // parameter_values is NULL
+  event.data.scalar.length = event_value_length;
+  rcl_variant_t * tmp_variant_array = params_st->params[0].parameter_values;
+  params_st->params[0].parameter_values = NULL;
+  EXPECT_EQ(
+    RCUTILS_RET_BAD_ALLOC,
+    parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
+    rcutils_get_error_string().str;
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
+  params_st->params[0].parameter_values = tmp_variant_array;
+}
+
+TEST(TestParse, parse_key_bad_args)
+{
+  yaml_event_t event;
+  event.type = YAML_NO_EVENT;
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  uint32_t map_level = MAP_NODE_NAME_LVL;
+  bool is_new_map = false;
+  size_t node_idx = 0;
+  size_t parameter_idx = 0;
+  namespace_tracker_t ns_tracker;
+
+  rcl_params_t * params_st = rcl_yaml_node_struct_init(allocator);
+  ASSERT_NE(nullptr, params_st);
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    rcl_yaml_node_struct_fini(params_st);
+  });
+
+  ASSERT_EQ(RCUTILS_RET_OK, node_params_init(&params_st->params[0], allocator));
+  params_st->num_nodes = 1u;
+
+  // map_level is nullptr
+  EXPECT_EQ(
+    RCUTILS_RET_INVALID_ARGUMENT,
+    parse_key(event, nullptr, &is_new_map, &node_idx, &parameter_idx, &ns_tracker, params_st)) <<
+    rcutils_get_error_string().str;
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
+
+  // map_level is nullptr
+  EXPECT_EQ(
+    RCUTILS_RET_INVALID_ARGUMENT,
+    parse_key(event, nullptr, &is_new_map, &node_idx, &parameter_idx, &ns_tracker, params_st)) <<
+    rcutils_get_error_string().str;
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
+
+  // params_st is nullptr
+  EXPECT_EQ(
+    RCUTILS_RET_INVALID_ARGUMENT,
+    parse_key(event, &map_level, &is_new_map, &node_idx, &parameter_idx, &ns_tracker, nullptr)) <<
+    rcutils_get_error_string().str;
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
+
+  // event.data.scalar.value is nullptr
+  event.data.scalar.value = nullptr;
+  event.data.scalar.length = 1u;
+  EXPECT_EQ(
+    RCUTILS_RET_INVALID_ARGUMENT,
+    parse_key(
+      event, &map_level, &is_new_map, &node_idx, &parameter_idx, &ns_tracker, params_st)) <<
+    rcutils_get_error_string().str;
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
+
+  yaml_char_t string_value[] = "key_name";
+  const size_t string_value_length = sizeof(string_value) / sizeof(string_value[0]);
+
+  // event.data.scalar.length is 0
+  event.data.scalar.value = string_value;
+  event.data.scalar.length = 0u;
+  EXPECT_EQ(
+    RCUTILS_RET_ERROR,
+    parse_key(
+      event, &map_level, &is_new_map, &node_idx, &parameter_idx, &ns_tracker, params_st)) <<
+    rcutils_get_error_string().str;
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
+  event.data.scalar.length = string_value_length;
+
+  // map_level is MAP_UNINIT_LVL
+  map_level = MAP_UNINIT_LVL;
+  EXPECT_EQ(
+    RCUTILS_RET_ERROR,
+    parse_key(
+      event, &map_level, &is_new_map, &node_idx, &parameter_idx, &ns_tracker, params_st)) <<
+    rcutils_get_error_string().str;
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
+
+  // map_level is not a valid value
+  map_level = 42;
+  EXPECT_EQ(
+    RCUTILS_RET_ERROR,
+    parse_key(
+      event, &map_level, &is_new_map, &node_idx, &parameter_idx, &ns_tracker, params_st)) <<
+    rcutils_get_error_string().str;
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
+
+  // previous parameter names required for parameter namespace
+  map_level = MAP_PARAMS_LVL;
+  is_new_map = true;
+  params_st->params[0].parameter_names[0] = nullptr;
+  EXPECT_EQ(
+    RCUTILS_RET_ERROR,
+    parse_key(
+      event, &map_level, &is_new_map, &node_idx, &parameter_idx, &ns_tracker, params_st)) <<
+    rcutils_get_error_string().str;
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
+}

--- a/rcl_yaml_param_parser/test/test_parse.cpp
+++ b/rcl_yaml_param_parser/test/test_parse.cpp
@@ -29,6 +29,8 @@ TEST(TestParse, parse_value) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   yaml_event_t event;
   event.type = YAML_NO_EVENT;
+  event.start_mark = {0u, 0u, 0u};
+  event.data.scalar = {NULL, NULL, NULL, 1u, 0, 0, YAML_ANY_SCALAR_STYLE};
 
   bool is_seq = false;
   size_t node_idx = 0u;
@@ -109,6 +111,8 @@ TEST(TestParse, parse_value_sequence) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   yaml_event_t event;
   event.type = YAML_NO_EVENT;
+  event.start_mark = {0u, 0u, 0u};
+  event.data.scalar = {NULL, NULL, NULL, 1u, 0, 0, YAML_ANY_SCALAR_STYLE};
 
   bool is_seq = true;
   size_t node_idx = 0u;
@@ -176,7 +180,7 @@ TEST(TestParse, parse_value_sequence) {
   allocator.deallocate(
     params_st->params[0].parameter_values[0].integer_array_value->values, allocator.state);
   allocator.deallocate(
-    params_st->params[0].parameter_values[0].integer_value, allocator.state);
+    params_st->params[0].parameter_values[0].integer_array_value, allocator.state);
   params_st->params[0].parameter_values[0].integer_array_value = nullptr;
 
   // double value
@@ -235,6 +239,8 @@ TEST(TestParse, parse_value_sequence) {
     RCUTILS_RET_OK,
     rcutils_string_array_fini(params_st->params[0].parameter_values[0].string_array_value)) <<
     rcutils_get_error_string().str;
+  allocator.deallocate(
+    params_st->params[0].parameter_values[0].string_array_value, allocator.state);
   params_st->params[0].parameter_values[0].string_array_value = nullptr;
 }
 
@@ -242,6 +248,8 @@ TEST(TestParse, parse_value_bad_args) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   yaml_event_t event;
   event.type = YAML_NO_EVENT;
+  event.start_mark = {0u, 0u, 0u};
+  event.data.scalar = {NULL, NULL, NULL, 1u, 0, 0, YAML_ANY_SCALAR_STYLE};
 
   bool is_seq = false;
   size_t node_idx = 0u;
@@ -280,8 +288,7 @@ TEST(TestParse, parse_value_bad_args) {
   params_st->num_nodes = 1u;
 
   // event.data.scaler.value is NULL, but event.data.scalar.length > 0
-  event.start_mark = {0u, 0u, 0u};
-  event.data.scalar = {NULL, NULL, NULL, 1u, 0, 0, YAML_ANY_SCALAR_STYLE};
+  event.data.scalar.value = NULL;
   EXPECT_EQ(
     RCUTILS_RET_INVALID_ARGUMENT,
     parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st));
@@ -317,6 +324,8 @@ TEST(TestParse, parse_key_bad_args)
 {
   yaml_event_t event;
   event.type = YAML_NO_EVENT;
+  event.start_mark = {0u, 0u, 0u};
+
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   uint32_t map_level = MAP_NODE_NAME_LVL;
   bool is_new_map = false;

--- a/rcl_yaml_param_parser/test/test_parse.cpp
+++ b/rcl_yaml_param_parser/test/test_parse.cpp
@@ -279,16 +279,17 @@ TEST(TestParse, parse_value_bad_args) {
   ASSERT_EQ(RCUTILS_RET_OK, node_params_init(&params_st->params[0], allocator));
   params_st->num_nodes = 1u;
 
-  // event.data.scaler.value is NULL
+  // event.data.scaler.value is NULL, but event.data.scalar.length > 0
   event.start_mark = {0u, 0u, 0u};
-  event.data.scalar = {NULL, NULL, NULL, 0u, 0, 0, YAML_ANY_SCALAR_STYLE};
+  event.data.scalar = {NULL, NULL, NULL, 1u, 0, 0, YAML_ANY_SCALAR_STYLE};
   EXPECT_EQ(
     RCUTILS_RET_INVALID_ARGUMENT,
     parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st));
   EXPECT_TRUE(rcutils_error_is_set());
   rcutils_reset_error();
 
-  // event.data.scalar.length is 0
+  // event.data.scalar.length is 0 and style is not a QUOTED_SCALAR_STYLE
+  event.data.scalar.length = 0u;
   yaml_char_t event_value[] = "non_empty_string";
   const size_t event_value_length = sizeof(event_value) / sizeof(event_value[0]);
   event.data.scalar.value = event_value;

--- a/rcl_yaml_param_parser/test/test_parse.cpp
+++ b/rcl_yaml_param_parser/test/test_parse.cpp
@@ -56,10 +56,11 @@ TEST(TestParse, parse_value) {
     RCUTILS_RET_OK,
     parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
     rcutils_get_error_string().str;
-  ASSERT_NE(nullptr, params_st->params[0].parameter_values[0].bool_value);
-  EXPECT_TRUE(*params_st->params[0].parameter_values[0].bool_value);
-  allocator.deallocate(params_st->params[0].parameter_values[0].bool_value, allocator.state);
-  params_st->params[0].parameter_values[0].bool_value = nullptr;
+  ASSERT_NE(nullptr, params_st->params[node_idx].parameter_values[parameter_idx].bool_value);
+  EXPECT_TRUE(*params_st->params[node_idx].parameter_values[parameter_idx].bool_value);
+  allocator.deallocate(
+    params_st->params[node_idx].parameter_values[parameter_idx].bool_value, allocator.state);
+  params_st->params[node_idx].parameter_values[parameter_idx].bool_value = nullptr;
 
   // integer value
   yaml_char_t integer_value[] = "42";
@@ -71,10 +72,11 @@ TEST(TestParse, parse_value) {
     RCUTILS_RET_OK,
     parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
     rcutils_get_error_string().str;
-  ASSERT_NE(nullptr, params_st->params[0].parameter_values[0].integer_value);
-  EXPECT_EQ(42, *params_st->params[0].parameter_values[0].integer_value);
-  allocator.deallocate(params_st->params[0].parameter_values[0].integer_value, allocator.state);
-  params_st->params[0].parameter_values[0].integer_value = nullptr;
+  ASSERT_NE(nullptr, params_st->params[node_idx].parameter_values[parameter_idx].integer_value);
+  EXPECT_EQ(42, *params_st->params[node_idx].parameter_values[parameter_idx].integer_value);
+  allocator.deallocate(
+    params_st->params[node_idx].parameter_values[parameter_idx].integer_value, allocator.state);
+  params_st->params[node_idx].parameter_values[parameter_idx].integer_value = nullptr;
 
   // double value
   yaml_char_t double_value[] = "3.14159";
@@ -86,10 +88,11 @@ TEST(TestParse, parse_value) {
     RCUTILS_RET_OK,
     parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
     rcutils_get_error_string().str;
-  ASSERT_NE(nullptr, params_st->params[0].parameter_values[0].double_value);
-  EXPECT_EQ(3.14159, *params_st->params[0].parameter_values[0].double_value);
-  allocator.deallocate(params_st->params[0].parameter_values[0].double_value, allocator.state);
-  params_st->params[0].parameter_values[0].double_value = nullptr;
+  ASSERT_NE(nullptr, params_st->params[node_idx].parameter_values[parameter_idx].double_value);
+  EXPECT_EQ(3.14159, *params_st->params[node_idx].parameter_values[parameter_idx].double_value);
+  allocator.deallocate(
+    params_st->params[node_idx].parameter_values[parameter_idx].double_value, allocator.state);
+  params_st->params[node_idx].parameter_values[parameter_idx].double_value = nullptr;
 
   // double value
   yaml_char_t string_value[] = "hello, I am a string";
@@ -101,10 +104,13 @@ TEST(TestParse, parse_value) {
     RCUTILS_RET_OK,
     parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
     rcutils_get_error_string().str;
-  ASSERT_NE(nullptr, params_st->params[0].parameter_values[0].string_value);
-  EXPECT_STREQ("hello, I am a string", params_st->params[0].parameter_values[0].string_value);
-  allocator.deallocate(params_st->params[0].parameter_values[0].string_value, allocator.state);
-  params_st->params[0].parameter_values[0].string_value = nullptr;
+  ASSERT_NE(nullptr, params_st->params[node_idx].parameter_values[parameter_idx].string_value);
+  EXPECT_STREQ(
+    "hello, I am a string",
+    params_st->params[node_idx].parameter_values[parameter_idx].string_value);
+  allocator.deallocate(
+    params_st->params[node_idx].parameter_values[parameter_idx].string_value, allocator.state);
+  params_st->params[node_idx].parameter_values[parameter_idx].string_value = nullptr;
 }
 
 TEST(TestParse, parse_value_sequence) {
@@ -140,7 +146,9 @@ TEST(TestParse, parse_value_sequence) {
     RCUTILS_RET_ERROR,
     parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
     rcutils_get_error_string().str;
-  EXPECT_EQ(nullptr, params_st->params[0].parameter_values[0].integer_array_value);
+  EXPECT_EQ(
+    nullptr,
+    params_st->params[node_idx].parameter_values[parameter_idx].integer_array_value);
 
   // Check proper sequence type
   seq_data_type = DATA_TYPE_UNKNOWN;
@@ -148,12 +156,16 @@ TEST(TestParse, parse_value_sequence) {
     RCUTILS_RET_OK,
     parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
     rcutils_get_error_string().str;
-  ASSERT_NE(nullptr, params_st->params[0].parameter_values[0].bool_array_value);
-  EXPECT_TRUE(params_st->params[0].parameter_values[0].bool_array_value->values[0]);
+  ASSERT_NE(
+    nullptr, params_st->params[node_idx].parameter_values[parameter_idx].bool_array_value);
+  EXPECT_TRUE(
+    params_st->params[node_idx].parameter_values[parameter_idx].bool_array_value->values[0]);
   allocator.deallocate(
-    params_st->params[0].parameter_values[0].bool_array_value->values, allocator.state);
-  allocator.deallocate(params_st->params[0].parameter_values[0].bool_array_value, allocator.state);
-  params_st->params[0].parameter_values[0].bool_array_value = nullptr;
+    params_st->params[node_idx].parameter_values[parameter_idx].bool_array_value->values,
+    allocator.state);
+  allocator.deallocate(
+    params_st->params[node_idx].parameter_values[parameter_idx].bool_array_value, allocator.state);
+  params_st->params[node_idx].parameter_values[parameter_idx].bool_array_value = nullptr;
 
   // integer array value
   yaml_char_t integer_value[] = "42";
@@ -167,7 +179,8 @@ TEST(TestParse, parse_value_sequence) {
     RCUTILS_RET_ERROR,
     parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
     rcutils_get_error_string().str;
-  EXPECT_EQ(nullptr, params_st->params[0].parameter_values[0].integer_array_value);
+  EXPECT_EQ(
+    nullptr, params_st->params[node_idx].parameter_values[parameter_idx].integer_array_value);
 
   // Check proper sequence type
   seq_data_type = DATA_TYPE_UNKNOWN;
@@ -175,13 +188,19 @@ TEST(TestParse, parse_value_sequence) {
     RCUTILS_RET_OK,
     parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
     rcutils_get_error_string().str;
-  ASSERT_NE(nullptr, params_st->params[0].parameter_values[0].integer_array_value);
-  EXPECT_EQ(42, params_st->params[0].parameter_values[0].integer_array_value->values[0]);
+  ASSERT_NE(
+    nullptr,
+    params_st->params[node_idx].parameter_values[parameter_idx].integer_array_value);
+  EXPECT_EQ(
+    42,
+    params_st->params[node_idx].parameter_values[parameter_idx].integer_array_value->values[0]);
   allocator.deallocate(
-    params_st->params[0].parameter_values[0].integer_array_value->values, allocator.state);
+    params_st->params[node_idx].parameter_values[parameter_idx].integer_array_value->values,
+    allocator.state);
   allocator.deallocate(
-    params_st->params[0].parameter_values[0].integer_array_value, allocator.state);
-  params_st->params[0].parameter_values[0].integer_array_value = nullptr;
+    params_st->params[node_idx].parameter_values[parameter_idx].integer_array_value,
+    allocator.state);
+  params_st->params[node_idx].parameter_values[parameter_idx].integer_array_value = nullptr;
 
   // double value
   yaml_char_t double_value[] = "3.14159";
@@ -195,7 +214,8 @@ TEST(TestParse, parse_value_sequence) {
     RCUTILS_RET_ERROR,
     parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
     rcutils_get_error_string().str;
-  EXPECT_EQ(nullptr, params_st->params[0].parameter_values[0].integer_array_value);
+  EXPECT_EQ(
+    nullptr, params_st->params[node_idx].parameter_values[parameter_idx].integer_array_value);
 
   // Check proper sequence type
   seq_data_type = DATA_TYPE_UNKNOWN;
@@ -203,13 +223,18 @@ TEST(TestParse, parse_value_sequence) {
     RCUTILS_RET_OK,
     parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
     rcutils_get_error_string().str;
-  ASSERT_NE(nullptr, params_st->params[0].parameter_values[0].double_array_value);
-  EXPECT_EQ(3.14159, params_st->params[0].parameter_values[0].double_array_value->values[0]);
+  ASSERT_NE(
+    nullptr, params_st->params[node_idx].parameter_values[parameter_idx].double_array_value);
+  EXPECT_EQ(
+    3.14159,
+    params_st->params[node_idx].parameter_values[parameter_idx].double_array_value->values[0]);
   allocator.deallocate(
-    params_st->params[0].parameter_values[0].double_array_value->values, allocator.state);
+    params_st->params[node_idx].parameter_values[parameter_idx].double_array_value->values,
+    allocator.state);
   allocator.deallocate(
-    params_st->params[0].parameter_values[0].double_array_value, allocator.state);
-  params_st->params[0].parameter_values[0].double_array_value = nullptr;
+    params_st->params[node_idx].parameter_values[parameter_idx].double_array_value,
+    allocator.state);
+  params_st->params[node_idx].parameter_values[parameter_idx].double_array_value = nullptr;
 
   // double value
   yaml_char_t string_value[] = "hello, I am a string";
@@ -223,7 +248,8 @@ TEST(TestParse, parse_value_sequence) {
     RCUTILS_RET_ERROR,
     parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
     rcutils_get_error_string().str;
-  EXPECT_EQ(nullptr, params_st->params[0].parameter_values[0].integer_array_value);
+  EXPECT_EQ(
+    nullptr, params_st->params[node_idx].parameter_values[parameter_idx].integer_array_value);
 
   // Check proper sequence type
   seq_data_type = DATA_TYPE_UNKNOWN;
@@ -231,17 +257,20 @@ TEST(TestParse, parse_value_sequence) {
     RCUTILS_RET_OK,
     parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
     rcutils_get_error_string().str;
-  ASSERT_NE(nullptr, params_st->params[0].parameter_values[0].string_array_value);
+  ASSERT_NE(
+    nullptr, params_st->params[node_idx].parameter_values[parameter_idx].string_array_value);
   EXPECT_STREQ(
     "hello, I am a string",
-    params_st->params[0].parameter_values[0].string_array_value->data[0]);
+    params_st->params[node_idx].parameter_values[parameter_idx].string_array_value->data[0]);
   EXPECT_EQ(
     RCUTILS_RET_OK,
-    rcutils_string_array_fini(params_st->params[0].parameter_values[0].string_array_value)) <<
+    rcutils_string_array_fini(
+      params_st->params[node_idx].parameter_values[parameter_idx].string_array_value)) <<
     rcutils_get_error_string().str;
   allocator.deallocate(
-    params_st->params[0].parameter_values[0].string_array_value, allocator.state);
-  params_st->params[0].parameter_values[0].string_array_value = nullptr;
+    params_st->params[node_idx].parameter_values[parameter_idx].string_array_value,
+    allocator.state);
+  params_st->params[node_idx].parameter_values[parameter_idx].string_array_value = nullptr;
 }
 
 TEST(TestParse, parse_value_bad_args) {
@@ -287,7 +316,7 @@ TEST(TestParse, parse_value_bad_args) {
   ASSERT_EQ(RCUTILS_RET_OK, node_params_init(&params_st->params[0], allocator));
   params_st->num_nodes = 1u;
 
-  // event.data.scaler.value is NULL, but event.data.scalar.length > 0
+  // event.data.scalar.value is NULL, but event.data.scalar.length > 0
   event.data.scalar.value = NULL;
   EXPECT_EQ(
     RCUTILS_RET_INVALID_ARGUMENT,
@@ -342,14 +371,6 @@ TEST(TestParse, parse_key_bad_args)
 
   ASSERT_EQ(RCUTILS_RET_OK, node_params_init(&params_st->params[0], allocator));
   params_st->num_nodes = 1u;
-
-  // map_level is nullptr
-  EXPECT_EQ(
-    RCUTILS_RET_INVALID_ARGUMENT,
-    parse_key(event, nullptr, &is_new_map, &node_idx, &parameter_idx, &ns_tracker, params_st)) <<
-    rcutils_get_error_string().str;
-  EXPECT_TRUE(rcutils_error_is_set());
-  rcutils_reset_error();
 
   // map_level is nullptr
   EXPECT_EQ(

--- a/rcl_yaml_param_parser/test/test_yaml_variant.cpp
+++ b/rcl_yaml_param_parser/test/test_yaml_variant.cpp
@@ -1,0 +1,140 @@
+// Copyright 2020 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <yaml.h>
+
+#include <string>
+#include <vector>
+
+#include "osrf_testing_tools_cpp/scope_exit.hpp"
+#include "rcl_yaml_param_parser/parser.h"
+#include "rcl_yaml_param_parser/impl/yaml_variant.h"
+#include "rcutils/allocator.h"
+#include "rcutils/strdup.h"
+#include "rcutils/testing/fault_injection.h"
+
+#define TEST_VARIANT_COPY(dest_variant, src_variant, field, tmp_var, allocator) \
+  do { \
+    SCOPED_TRACE("TEST_VARIANT_COPY " #field); \
+    src_variant.field = &tmp_var; \
+    EXPECT_TRUE(rcl_yaml_variant_copy(&dest_variant, &src_variant, allocator)); \
+    ASSERT_NE(nullptr, dest_variant.field); \
+    EXPECT_EQ(*src_variant.field, *dest_variant.field); \
+    rcl_yaml_variant_fini(&dest_variant, allocator); \
+    variant.field = nullptr; \
+  } while (0)
+
+#define TEST_VARIANT_ARRAY_COPY( \
+    dest_variant, src_variant, field, array_type, value_type, tmp_array, array_size, allocator) \
+  do { \
+    SCOPED_TRACE("TEST_VARIANT_ARRAY_COPY " #field); \
+    src_variant.field = \
+      static_cast<array_type *>(allocator.allocate(sizeof(array_type), allocator.state)); \
+    ASSERT_NE(nullptr, src_variant.field); \
+    src_variant.field->values = \
+      static_cast<value_type *>( \
+      allocator.zero_allocate(array_size, sizeof(value_type), allocator.state)); \
+    ASSERT_NE(nullptr, src_variant.field->values); \
+    src_variant.field->size = array_size; \
+    for (size_t i = 0; i < array_size; ++i) { \
+      variant.field->values[i] = tmp_array[i]; \
+    } \
+    EXPECT_TRUE(rcl_yaml_variant_copy(&dest_variant, &src_variant, allocator)); \
+    ASSERT_NE(nullptr, dest_variant.field); \
+    ASSERT_NE(nullptr, dest_variant.field->values); \
+    for (size_t i = 0; i < array_size; ++i) { \
+      SCOPED_TRACE(i); \
+      EXPECT_EQ(src_variant.field->values[i], dest_variant.field->values[i]); \
+    } \
+    rcl_yaml_variant_fini(&src_variant, allocator); \
+    rcl_yaml_variant_fini(&dest_variant, allocator); \
+    src_variant.field = nullptr; \
+    dest_variant.field = nullptr; \
+  } while (0)
+
+TEST(TestYamlVariant, copy_fini) {
+  rcl_variant_t variant =
+  {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+
+  rcl_variant_t copy =
+  {nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+  EXPECT_FALSE(rcl_yaml_variant_copy(nullptr, &variant, allocator));
+  EXPECT_FALSE(rcl_yaml_variant_copy(&copy, nullptr, allocator));
+
+  bool tmp_bool = true;
+  TEST_VARIANT_COPY(copy, variant, bool_value, tmp_bool, allocator);
+
+  int64_t tmp_int = 42;
+  TEST_VARIANT_COPY(copy, variant, integer_value, tmp_int, allocator);
+
+  double tmp_double = 3.14159;
+  TEST_VARIANT_COPY(copy, variant, double_value, tmp_double, allocator);
+
+  // String version is slightly different and can't use the above macro
+  char * tmp_string = rcutils_strdup("hello there", allocator);
+  variant.string_value = tmp_string;
+  EXPECT_TRUE(rcl_yaml_variant_copy(&copy, &variant, allocator));
+  ASSERT_NE(nullptr, copy.string_value);
+  EXPECT_STREQ(tmp_string, copy.string_value);
+  rcl_yaml_variant_fini(&copy, allocator);
+  allocator.deallocate(tmp_string, allocator.state);
+  variant.string_value = nullptr;
+
+  constexpr size_t size = 3u;
+  constexpr bool bool_arry[size] = {true, false, true};
+  TEST_VARIANT_ARRAY_COPY(
+    copy, variant, bool_array_value, rcl_bool_array_t, bool, bool_arry, size, allocator);
+
+  constexpr int64_t int_arry[size] = {1, 2, 3};
+  TEST_VARIANT_ARRAY_COPY(
+    copy, variant, integer_array_value, rcl_int64_array_t, int64_t, int_arry, size, allocator);
+
+  constexpr double double_arry[size] = {10.0, 11.0, 12.0};
+  TEST_VARIANT_ARRAY_COPY(
+    copy, variant, double_array_value, rcl_double_array_t, double, double_arry, size, allocator);
+
+  // Strings just have to be different
+  variant.string_array_value =
+    static_cast<rcutils_string_array_t *>(
+    allocator.allocate(sizeof(rcutils_string_array_t), allocator.state));
+  ASSERT_NE(nullptr, variant.string_array_value);
+  *variant.string_array_value = rcutils_get_zero_initialized_string_array();
+  ASSERT_EQ(
+    RCUTILS_RET_OK, rcutils_string_array_init(variant.string_array_value, size, &allocator));
+  variant.string_array_value->size = size;
+  variant.string_array_value->data[0] = rcutils_strdup("string1", allocator);
+  variant.string_array_value->data[1] = rcutils_strdup("string2", allocator);
+  variant.string_array_value->data[2] = rcutils_strdup("string3", allocator);
+  for (size_t i = 0; i < size; ++i) {
+    ASSERT_NE(nullptr, variant.string_array_value->data[i]);
+  }
+  EXPECT_TRUE(rcl_yaml_variant_copy(&copy, &variant, allocator));
+  ASSERT_NE(nullptr, copy.string_array_value);
+  ASSERT_NE(nullptr, copy.string_array_value->data);
+  for (size_t i = 0; i < size; ++i) {
+    SCOPED_TRACE(i);
+    EXPECT_STREQ(variant.string_array_value->data[i], copy.string_array_value->data[i]);
+  }
+  rcl_yaml_variant_fini(&variant, allocator);
+  rcl_yaml_variant_fini(&copy, allocator);
+
+  // Check second fini works fine
+  rcl_yaml_variant_fini(&copy, allocator);
+
+  // Check fini with a nullptr doesn't crash.
+  rcl_yaml_variant_fini(nullptr, allocator);
+}

--- a/rcl_yaml_param_parser/test/test_yaml_variant.cpp
+++ b/rcl_yaml_param_parser/test/test_yaml_variant.cpp
@@ -21,7 +21,7 @@
 
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcl_yaml_param_parser/parser.h"
-#include "rcl_yaml_param_parser/impl/yaml_variant.h"
+#include "../src/impl/yaml_variant.h"
 #include "rcutils/allocator.h"
 #include "rcutils/strdup.h"
 #include "rcutils/testing/fault_injection.h"

--- a/rcl_yaml_param_parser/test/test_yaml_variant.cpp
+++ b/rcl_yaml_param_parser/test/test_yaml_variant.cpp
@@ -40,19 +40,21 @@
     src_variant.field = nullptr; \
   } while (0)
 
-#define TEST_VARIANT_ARRAY_COPY(field, array_type, value_type, tmp_array) \
+#define TEST_VARIANT_ARRAY_COPY(field, tmp_array) \
   do { \
     SCOPED_TRACE("TEST_VARIANT_ARRAY_COPY " #field); \
     constexpr size_t array_size = sizeof(tmp_array) / sizeof(tmp_array[0]); \
     rcl_variant_t src_variant{}; \
     rcl_variant_t dest_variant{}; \
     rcutils_allocator_t allocator = rcutils_get_default_allocator(); \
+    using ArrayT = std::remove_pointer<decltype(src_variant.field)>::type; \
     src_variant.field = \
-      static_cast<array_type *>(allocator.allocate(sizeof(array_type), allocator.state)); \
+      static_cast<ArrayT *>(allocator.allocate(sizeof(ArrayT), allocator.state)); \
     ASSERT_NE(nullptr, src_variant.field); \
+    using ValueT = std::remove_pointer<decltype(src_variant.field->values)>::type; \
     src_variant.field->values = \
-      static_cast<value_type *>( \
-      allocator.zero_allocate(array_size, sizeof(value_type), allocator.state)); \
+      static_cast<ValueT *>( \
+      allocator.zero_allocate(array_size, sizeof(ValueT), allocator.state)); \
     ASSERT_NE(nullptr, src_variant.field->values); \
     OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT( \
     { \
@@ -132,20 +134,17 @@ TEST(TestYamlVariant, copy_string_value) {
 
 TEST(TestYamlVariant, copy_bool_array_values) {
   constexpr bool bool_arry[] = {true, false, true};
-  TEST_VARIANT_ARRAY_COPY(
-    bool_array_value, rcl_bool_array_t, bool, bool_arry);
+  TEST_VARIANT_ARRAY_COPY(bool_array_value, bool_arry);
 }
 
 TEST(TestYamlVariant, copy_integer_array_values) {
   constexpr int64_t int_arry[] = {1, 2, 3};
-  TEST_VARIANT_ARRAY_COPY(
-    integer_array_value, rcl_int64_array_t, int64_t, int_arry);
+  TEST_VARIANT_ARRAY_COPY(integer_array_value, int_arry);
 }
 
 TEST(TestYamlVariant, copy_double_array_values) {
   constexpr double double_arry[] = {10.0, 11.0, 12.0};
-  TEST_VARIANT_ARRAY_COPY(
-    double_array_value, rcl_double_array_t, double, double_arry);
+  TEST_VARIANT_ARRAY_COPY(double_array_value, double_arry);
 }
 
 TEST(TestYamlVariant, copy_string_array_values) {


### PR DESCRIPTION
This is part 1 of added unit tests for increasing coverage of rcl_yaml_param_parser to 95%. This adds additional unit tests for the refactored source code. Depends on #754 and #765

Signed-off-by: Stephen Brawner <brawner@gmail.com>