### PR TITLE
Remove std::cout line from test_rcl_lifecycle.cpp

### DIFF
--- a/rcl_lifecycle/test/test_rcl_lifecycle.cpp
+++ b/rcl_lifecycle/test/test_rcl_lifecycle.cpp
@@ -337,7 +337,6 @@ TEST(TestRclLifecycle, state_machine) {
   ret = rcl_lifecycle_state_machine_fini(&state_machine, nullptr, &allocator);
   EXPECT_EQ(ret, RCL_RET_ERROR);
   rcutils_reset_error();
-  std::cout << "state_machine: " << __LINE__ << std::endl;
 }
 
 TEST(TestRclLifecycle, state_transitions) {


### PR DESCRIPTION
This debug print snuck in during #649. I only have myself to blame. 
Signed-off-by: Stephen Brawner <brawner@gmail.com>