### PR TITLE
[foxy backport] Remove std::cout line from test_rcl_lifecycle.cpp (#773)

### DIFF
--- a/rcl_lifecycle/test/test_rcl_lifecycle.cpp
+++ b/rcl_lifecycle/test/test_rcl_lifecycle.cpp
@@ -326,7 +326,6 @@ TEST(TestRclLifecycle, state_machine) {
   // Node is null
   ret = rcl_lifecycle_state_machine_fini(&state_machine, nullptr, &allocator);
   EXPECT_EQ(ret, RCL_RET_ERROR);
-  std::cout << "state_machine: " << __LINE__ << std::endl;
 }
 
 TEST(TestRclLifecycle, state_transitions) {


### PR DESCRIPTION
Signed-off-by: Stephen Brawner <brawner@gmail.com>