### PR TITLE
Fix rcl_parse_yaml_file() error handling.

### DIFF
--- a/rcl_yaml_param_parser/include/rcl_yaml_param_parser/parser.h
+++ b/rcl_yaml_param_parser/include/rcl_yaml_param_parser/parser.h
@@ -57,9 +57,11 @@ RCL_YAML_PARAM_PARSER_PUBLIC
 void rcl_yaml_node_struct_fini(
   rcl_params_t * params_st);
 
-/// \brief Parse the YAML file, initialize and populate params_st
+/// \brief Parse the YAML file and populate \p params_st
+/// \pre Given \p params_st must be a valid parameter struct
+///   as retured by `rcl_yaml_node_struct_init()`
 /// \param[in] file_path is the path to the YAML file
-/// \param[inout] params_st points to the populated parameter struct
+/// \param[inout] params_st points to the struct to be populated
 /// \return true on success and false on failure
 RCL_YAML_PARAM_PARSER_PUBLIC
 bool rcl_parse_yaml_file(

--- a/rcl_yaml_param_parser/include/rcl_yaml_param_parser/parser.h
+++ b/rcl_yaml_param_parser/include/rcl_yaml_param_parser/parser.h
@@ -59,7 +59,7 @@ void rcl_yaml_node_struct_fini(
 
 /// \brief Parse the YAML file and populate \p params_st
 /// \pre Given \p params_st must be a valid parameter struct
-///   as retured by `rcl_yaml_node_struct_init()`
+///   as returned by `rcl_yaml_node_struct_init()`
 /// \param[in] file_path is the path to the YAML file
 /// \param[inout] params_st points to the struct to be populated
 /// \return true on success and false on failure

--- a/rcl_yaml_param_parser/src/parser.c
+++ b/rcl_yaml_param_parser/src/parser.c
@@ -1810,12 +1810,7 @@ bool rcl_parse_yaml_file(
     allocator.deallocate(ns_tracker.parameter_ns, allocator.state);
   }
 
-  if (RCUTILS_RET_OK != ret) {
-    rcl_yaml_node_struct_fini(params_st);
-    return false;
-  }
-
-  return true;
+  return RCUTILS_RET_OK == ret;
 }
 
 ///


### PR DESCRIPTION
It should not `fini` its output argument, silently invalidating the given pointer.

CI up to `rcl_yaml_param_parser` and `rcl`:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12158)](http://ci.ros2.org/job/ci_linux/12158/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7148)](http://ci.ros2.org/job/ci_linux-aarch64/7148/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=9892)](http://ci.ros2.org/job/ci_osx/9892/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12048)](http://ci.ros2.org/job/ci_windows/12048/)
