### PR TITLE
Fix mem leaks in unit test from 776

### DIFF
--- a/rcl_yaml_param_parser/test/test_parse_yaml.cpp
+++ b/rcl_yaml_param_parser/test/test_parse_yaml.cpp
@@ -312,9 +312,12 @@ TEST(test_file_parser, seq_map1) {
   ASSERT_TRUE(rcutils_exists(path)) << "No test YAML file found at " << path;
   rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
   ASSERT_TRUE(NULL != params_hdl) << rcutils_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    rcl_yaml_node_struct_fini(params_hdl);
+  });
   bool res = rcl_parse_yaml_file(path, params_hdl);
   EXPECT_FALSE(res);
-  // No cleanup, rcl_parse_yaml_file takes care of that if it fails.
 }
 
 TEST(test_file_parser, seq_map2) {
@@ -336,9 +339,12 @@ TEST(test_file_parser, seq_map2) {
   ASSERT_TRUE(rcutils_exists(path)) << "No test YAML file found at " << path;
   rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
   ASSERT_TRUE(NULL != params_hdl) << rcutils_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    rcl_yaml_node_struct_fini(params_hdl);
+  });
   bool res = rcl_parse_yaml_file(path, params_hdl);
   EXPECT_FALSE(res);
-  // No cleanup, rcl_parse_yaml_file takes care of that if it fails
 }
 
 TEST(test_file_parser, params_with_no_node) {
@@ -360,9 +366,12 @@ TEST(test_file_parser, params_with_no_node) {
   ASSERT_TRUE(rcutils_exists(path)) << "No test YAML file found at " << path;
   rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
   ASSERT_TRUE(NULL != params_hdl) << rcutils_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    rcl_yaml_node_struct_fini(params_hdl);
+  });
   bool res = rcl_parse_yaml_file(path, params_hdl);
   EXPECT_FALSE(res);
-  // No cleanup, rcl_parse_yaml_file takes care of that if it fails.
 }
 
 TEST(test_file_parser, no_alias_support) {
@@ -384,9 +393,12 @@ TEST(test_file_parser, no_alias_support) {
   ASSERT_TRUE(rcutils_exists(path)) << "No test YAML file found at " << path;
   rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
   ASSERT_TRUE(NULL != params_hdl) << rcutils_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    rcl_yaml_node_struct_fini(params_hdl);
+  });
   bool res = rcl_parse_yaml_file(path, params_hdl);
   EXPECT_FALSE(res);
-  // No cleanup, rcl_parse_yaml_file takes care of that if it fails.
 }
 
 TEST(test_file_parser, empty_string) {
@@ -436,9 +448,12 @@ TEST(test_file_parser, no_value1) {
   ASSERT_TRUE(rcutils_exists(path)) << "No test YAML file found at " << path;
   rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
   ASSERT_TRUE(NULL != params_hdl) << rcutils_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    rcl_yaml_node_struct_fini(params_hdl);
+  });
   bool res = rcl_parse_yaml_file(path, params_hdl);
   EXPECT_FALSE(res);
-  // No cleanup, rcl_parse_yaml_file takes care of that if it fails.
 }
 
 TEST(test_file_parser, indented_ns) {
@@ -460,9 +475,12 @@ TEST(test_file_parser, indented_ns) {
   ASSERT_TRUE(rcutils_exists(path)) << "No test YAML file found at " << path;
   rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
   ASSERT_TRUE(NULL != params_hdl) << rcutils_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    rcl_yaml_node_struct_fini(params_hdl);
+  });
   bool res = rcl_parse_yaml_file(path, params_hdl);
   EXPECT_FALSE(res);
-  // No cleanup, rcl_parse_yaml_file takes care of that if it fails.
 }
 
 // Regression test for https://github.com/ros2/rcl/issues/419
@@ -485,9 +503,12 @@ TEST(test_file_parser, maximum_number_parameters) {
   ASSERT_TRUE(rcutils_exists(path)) << "No test YAML file found at " << path;
   rcl_params_t * params_hdl = rcl_yaml_node_struct_init(allocator);
   ASSERT_TRUE(NULL != params_hdl) << rcutils_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    rcl_yaml_node_struct_fini(params_hdl);
+  });
   bool res = rcl_parse_yaml_file(path, params_hdl);
   EXPECT_FALSE(res);
-  // No cleanup, rcl_parse_yaml_file takes care of that if it fails.
 }
 
 int32_t main(int32_t argc, char ** argv)

--- a/rcl_yaml_param_parser/test/test_parser.cpp
+++ b/rcl_yaml_param_parser/test/test_parser.cpp
@@ -330,11 +330,9 @@ TEST(RclYamlParamParser, test_parse_file_with_bad_allocator) {
     bool res = rcl_parse_yaml_file(path, params_hdl);
     // Not verifying res is true or false here, because eventually it will come back with an ok
     // result. We're just trying to make sure that bad allocations are properly handled
-    if (res) {
-      // This is already freed in the case of a non-ok error in rcl_parse_yaml_file
-      rcl_yaml_node_struct_fini(params_hdl);
-      params_hdl = NULL;
-    }
+    (void)res;
+    rcl_yaml_node_struct_fini(params_hdl);
+    params_hdl = NULL;
   }
 
   // Check sporadic failing calloc calls
@@ -347,11 +345,9 @@ TEST(RclYamlParamParser, test_parse_file_with_bad_allocator) {
     bool res = rcl_parse_yaml_file(path, params_hdl);
     // Not verifying res is true or false here, because eventually it will come back with an ok
     // result. We're just trying to make sure that bad allocations are properly handled
-    if (res) {
-      // This is already freed in the case of a non-ok error in rcl_parse_yaml_file
-      rcl_yaml_node_struct_fini(params_hdl);
-      params_hdl = NULL;
-    }
+    (void)res;
+    rcl_yaml_node_struct_fini(params_hdl);
+    params_hdl = NULL;
   }
 }
 


### PR DESCRIPTION
PR #776 removed the the call to `rcl_yaml_node_struct_fini` from `rcl_parse_yaml_file` in the case of failure. Unfortunately the unit tests weren't updated and now exhibit some memory leaks. This PR addresses those leaks.
Signed-off-by: Stephen Brawner <brawner@gmail.com>