### PR TITLE
[foxy backport] Fix rcl_parse_yaml_file() error handling. (#776)

### DIFF
--- a/rcl_yaml_param_parser/include/rcl_yaml_param_parser/parser.h
+++ b/rcl_yaml_param_parser/include/rcl_yaml_param_parser/parser.h
@@ -57,9 +57,11 @@ RCL_YAML_PARAM_PARSER_PUBLIC
 void rcl_yaml_node_struct_fini(
   rcl_params_t * params_st);
 
-/// \brief Parse the YAML file, initialize and populate params_st
+/// \brief Parse the YAML file and populate \p params_st
+/// \pre Given \p params_st must be a valid parameter struct
+///   as returned by `rcl_yaml_node_struct_init()`
 /// \param[in] file_path is the path to the YAML file
-/// \param[inout] params_st points to the populated parameter struct
+/// \param[inout] params_st points to the struct to be populated
 /// \return true on success and false on failure
 RCL_YAML_PARAM_PARSER_PUBLIC
 bool rcl_parse_yaml_file(

--- a/rcl_yaml_param_parser/src/parser.c
+++ b/rcl_yaml_param_parser/src/parser.c
@@ -1801,12 +1801,7 @@ bool rcl_parse_yaml_file(
     allocator.deallocate(ns_tracker.parameter_ns, allocator.state);
   }
 
-  if (RCUTILS_RET_OK != ret) {
-    rcl_yaml_node_struct_fini(params_st);
-    return false;
-  }
-
-  return true;
+  return RCUTILS_RET_OK == ret;
 }
 
 ///


### PR DESCRIPTION
It should not fini its output argument, silently invalidating the given pointer.