### PR TITLE
calling fini functions to avoid memory leak

### DIFF
--- a/rcl/test/rcl/test_expand_topic_name.cpp
+++ b/rcl/test/rcl/test_expand_topic_name.cpp
@@ -226,6 +226,9 @@ TEST(test_expand_topic_name, internal_error) {
     EXPECT_TRUE(rcl_error_is_set());
     rcl_reset_error();
   }
+
+  ret = rcutils_string_map_fini(&subs);
+  ASSERT_EQ(RCL_RET_OK, ret);
 }
 
 TEST(test_expand_topic_name, various_valid_topics) {

--- a/rcl/test/rcl/test_get_node_names.cpp
+++ b/rcl/test/rcl/test_get_node_names.cpp
@@ -279,6 +279,9 @@ TEST_F(
   ret = rcutils_string_array_fini(&node_namespaces);
   ASSERT_EQ(RCUTILS_RET_OK, ret);
 
+  ret = rcutils_string_array_fini(&enclaves);
+  ASSERT_EQ(RCUTILS_RET_OK, ret);
+
   ret = rcl_node_fini(&node1);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 

--- a/rcl/test/rcl/test_graph.cpp
+++ b/rcl/test/rcl/test_graph.cpp
@@ -1435,6 +1435,10 @@ TEST_F(CLASSNAME(TestGraphFixture, RMW_IMPLEMENTATION), test_bad_get_node_names)
     EXPECT_EQ(RCUTILS_RET_OK, ret);
     ret = rcutils_string_array_fini(&node_namespaces);
     EXPECT_EQ(RCUTILS_RET_OK, ret);
+    ret = rcutils_string_array_fini(&node_names_2);
+    EXPECT_EQ(RCUTILS_RET_OK, ret);
+    ret = rcutils_string_array_fini(&node_namespaces_2);
+    EXPECT_EQ(RCUTILS_RET_OK, ret);
     ret = rcutils_string_array_fini(&node_enclaves);
     EXPECT_EQ(RCUTILS_RET_OK, ret);
   });

--- a/rcl/test/rcl/test_log_level.cpp
+++ b/rcl/test/rcl/test_log_level.cpp
@@ -274,6 +274,10 @@ TEST(TestLogLevel, logger_log_level_copy) {
   // Expected usage
   rcl_log_levels_t copied_log_levels = rcl_get_zero_initialized_log_levels();
   EXPECT_EQ(RCL_RET_OK, rcl_log_levels_copy(&log_levels, &copied_log_levels));
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    EXPECT_EQ(RCL_RET_OK, rcl_log_levels_fini(&copied_log_levels));
+  });
   EXPECT_EQ(RCUTILS_LOG_SEVERITY_UNSET, copied_log_levels.default_logger_level);
   EXPECT_EQ(log_levels.default_logger_level, copied_log_levels.default_logger_level);
   EXPECT_EQ(1ul, copied_log_levels.num_logger_settings);

--- a/rcl/test/rcl/test_security.cpp
+++ b/rcl/test/rcl/test_security.cpp
@@ -257,6 +257,7 @@ TEST_F(TestGetSecureRoot, test_get_security_options) {
     TEST_RESOURCES_DIRECTORY TEST_SECURITY_DIRECTORY_RESOURCES_DIR_NAME
     PATH_SEPARATOR "enclaves" PATH_SEPARATOR TEST_ENCLAVE,
     options.security_root_path);
+  EXPECT_EQ(RMW_RET_OK, rmw_security_options_fini(&options, &allocator));
 }
 
 TEST_F(TestGetSecureRoot, test_rcl_security_enabled) {

--- a/rcl/test/rcl/test_service.cpp
+++ b/rcl/test/rcl/test_service.cpp
@@ -537,6 +537,10 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_fail_take_request
 
   test_msgs__srv__BasicTypes_Request service_request;
   test_msgs__srv__BasicTypes_Request__init(&service_request);
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    test_msgs__srv__BasicTypes_Request__fini(&service_request);
+  });
   rmw_service_info_t header;
 
   ret = rcl_take_request_with_info(nullptr, &header, &service_request);


### PR DESCRIPTION
Just a memory leak in rcl test, not necessary to open an issue.

- ./test_expand_topic_name
    <details><summary> memory leak </summary>
    <p>

    ```shell
    ==267449== 72 bytes in 1 blocks are definitely lost in loss record 1 of 4
    ==267449==    at 0x483D7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==267449==    by 0x4908F06: __default_allocate (allocator.c:37)
    ==267449==    by 0x4913497: rcutils_string_map_init (string_map.c:62)
    ==267449==    by 0x17F30C: test_expand_topic_name_internal_error_Test::TestBody() (test_expand_topic_name.cpp:159)
    ==267449==    by 0x1C54A1: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2447)
    ==267449==    by 0x1BDFFE: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2483)
    ==267449==    by 0x199A31: testing::Test::Run() (gtest.cc:2522)
    ==267449==    by 0x19A42A: testing::TestInfo::Run() (gtest.cc:2703)
    ==267449==    by 0x19AB1B: testing::TestCase::Run() (gtest.cc:2825)
    ==267449==    by 0x1A6204: testing::internal::UnitTestImpl::RunAllTests() (gtest.cc:5216)
    ==267449==    by 0x1C699B: bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2447)
    ==267449==    by 0x1BF112: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2483)

    ```

    </p>
    </details>

- ./test_get_node_names__rmw_[fastrtps/fastrtps_dynamic/cyclonedds]_cpp

    <details><summary> memory leak </summary>
    <p>

    ```shell
    ==271914== 85 (40 direct, 45 indirect) bytes in 1 blocks are definitely lost in loss record 5 of 13
    ==271914==    at 0x483FD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==271914==    by 0x5124FDF: __default_zero_allocate (allocator.c:62)
    ==271914==    by 0x512ECF3: rcutils_string_array_init (string_array.c:57)
    ==271914==    by 0x695BD08: rmw_dds_common::GraphCache::get_node_names(rcutils_string_array_t*, rcutils_string_array_t*, rcutils_string_array_t*, rcutils_allocator_t*) const (graph_cache.cpp:965)
    ==271914==    by 0x57364FE: rmw_fastrtps_shared_cpp::__rmw_get_node_names_with_enclaves(char const*, rmw_node_t const*, rcutils_string_array_t*, rcutils_string_array_t*, rcutils_string_array_t*) (rmw_node_names.cpp:99)
    ==271914==    by 0x50E13BB: rmw_get_node_names_with_enclaves (rmw_node_names.cpp:50)
    ==271914==    by 0x4864E76: rcl_get_node_names_with_enclaves (graph.c:386)
    ==271914==    by 0x182F3F: TestGetNodeNames__rmw_fastrtps_cpp_test_rcl_get_node_names_with_enclave_Test::TestBody() (test_get_node_names.cpp:256)
    ==271914==    by 0x1BE115: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2447)
    ==271914==    by 0x1B6986: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2483)
    ==271914==    by 0x192045: testing::Test::Run() (gtest.cc:2522)
    ==271914==    by 0x192A3E: testing::TestInfo::Run() (gtest.cc:2703)


    ```

    </p>
    </details>

- ./test_graph__rmw_[fastrtps/fastrtps_dynamic/cyclonedds]_cpp

    <details><summary> memory leak </summary>
    <p>

    ```shell
    ==279506== 10 (8 direct, 2 indirect) bytes in 1 blocks are definitely lost in loss record 2 of 24
    ==279506==    at 0x483FD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==279506==    by 0x50B8FDF: __default_zero_allocate (allocator.c:62)
    ==279506==    by 0x50C2CF3: rcutils_string_array_init (string_array.c:57)
    ==279506==    by 0x5957C9B: rmw_dds_common::GraphCache::get_node_names(rcutils_string_array_t*, rcutils_string_array_t*, rcutils_string_array_t*, rcutils_allocator_t*) const (graph_cache.cpp:956)
    ==279506==    by 0x518BC3E: rmw_get_node_names_with_enclaves (rmw_node.cpp:4070)
    ==279506==    by 0x4864E76: rcl_get_node_names_with_enclaves (graph.c:386)
    ==279506==    by 0x1B0392: TestGraphFixture__rmw_cyclonedds_cpp_test_bad_get_node_names_Test::TestBody() (test_graph.cpp:1555)
    ==279506==    by 0x1F8095: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2447)
    ==279506==    by 0x1F0AB6: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2483)
    ==279506==    by 0x1CC90D: testing::Test::Run() (gtest.cc:2522)
    ==279506==    by 0x1CD306: testing::TestInfo::Run() (gtest.cc:2703)
    ==279506==    by 0x1CD9F7: testing::TestCase::Run() (gtest.cc:2825)
    ==279506== 
    ==279506== 24 (8 direct, 16 indirect) bytes in 1 blocks are definitely lost in loss record 4 of 24
    ==279506==    at 0x483FD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==279506==    by 0x50B8FDF: __default_zero_allocate (allocator.c:62)
    ==279506==    by 0x50C2CF3: rcutils_string_array_init (string_array.c:57)
    ==279506==    by 0x5957C38: rmw_dds_common::GraphCache::get_node_names(rcutils_string_array_t*, rcutils_string_array_t*, rcutils_string_array_t*, rcutils_allocator_t*) const (graph_cache.cpp:948)
    ==279506==    by 0x518BC3E: rmw_get_node_names_with_enclaves (rmw_node.cpp:4070)
    ==279506==    by 0x4864E76: rcl_get_node_names_with_enclaves (graph.c:386)
    ==279506==    by 0x1B0392: TestGraphFixture__rmw_cyclonedds_cpp_test_bad_get_node_names_Test::TestBody() (test_graph.cpp:1555)
    ==279506==    by 0x1F8095: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2447)
    ==279506==    by 0x1F0AB6: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2483)
    ==279506==    by 0x1CC90D: testing::Test::Run() (gtest.cc:2522)
    ==279506==    by 0x1CD306: testing::TestInfo::Run() (gtest.cc:2703)
    ==279506==    by 0x1CD9F7: testing::TestCase::Run() (gtest.cc:2825)

    ```

    </p>
    </details>

- ./test_log_level

    <details><summary> memory leak </summary>
    <p>

    ```shell

    ==289041== 20 (16 direct, 4 indirect) bytes in 1 blocks are definitely lost in loss record 2 of 6
    ==289041==    at 0x483D7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==289041==    by 0x5106F06: __default_allocate (allocator.c:37)
    ==289041==    by 0x486AFA4: rcl_log_levels_copy (log_level.c:75)
    ==289041==    by 0x1832A8: TestLogLevel_logger_log_level_copy_Test::TestBody() (test_log_level.cpp:276)
    ==289041==    by 0x1BFAD3: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2447)
    ==289041==    by 0x1B8326: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2483)
    ==289041==    by 0x1938CF: testing::Test::Run() (gtest.cc:2522)
    ==289041==    by 0x1942C8: testing::TestInfo::Run() (gtest.cc:2703)
    ==289041==    by 0x1949B9: testing::TestCase::Run() (gtest.cc:2825)
    ==289041==    by 0x1A00A2: testing::internal::UnitTestImpl::RunAllTests() (gtest.cc:5216)
    ==289041==    by 0x1C0FCD: bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2447)
    ==289041==    by 0x1B943A: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2483)
    ```

    </p>
    </details>

- ./test_security

    <details><summary> memory leak </summary>
    <p>

    ```shell
    ==292051== 129 bytes in 1 blocks are definitely lost in loss record 4 of 6
    ==292051==    at 0x483D7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==292051==    by 0x510FF06: __default_allocate (allocator.c:37)
    ==292051==    by 0x5112EF5: rcutils_format_string_limit (format_string.c:58)
    ==292051==    by 0x5112759: rcutils_join_path (filesystem.c:166)
    ==292051==    by 0x487175B: exact_match_lookup (security.c:124)
    ==292051==    by 0x4871AFE: rcl_get_secure_root (security.c:188)
    ==292051==    by 0x4871264: rcl_get_security_options_from_environment (security.c:54)
    ==292051==    by 0x182CB8: TestGetSecureRoot_test_get_security_options_Test::TestBody() (test_security.cpp:252)
    ==292051==    by 0x1C48CB: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2447)
    ==292051==    by 0x1BD1E8: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2483)
    ==292051==    by 0x198E41: testing::Test::Run() (gtest.cc:2522)
    ==292051==    by 0x19983A: testing::TestInfo::Run() (gtest.cc:2703)


    ```

    </p>
    </details>

- ./test_service__rmw_[fastrtps/fastrtps_dynamic/cyclonedds]_cpp

    <details><summary> memory leak </summary>
    <p>

    ```shell
    ==294504== 1 bytes in 1 blocks are definitely lost in loss record 1 of 18
    ==294504==    at 0x483D7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
    ==294504==    by 0x5737E76: rosidl_runtime_c__String__init (string_functions.c:32)
    ==294504==    by 0x52CEE8F: test_msgs__srv__BasicTypes_Request__init (basic_types__functions.c:35)
    ==294504==    by 0x19461E: TestServiceFixture__rmw_cyclonedds_cpp_test_fail_take_request_with_info_Test::TestBody() (test_service.cpp:539)
    ==294504==    by 0x1E53DD: void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2447)
    ==294504==    by 0x1DDCCE: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2483)
    ==294504==    by 0x1B98A9: testing::Test::Run() (gtest.cc:2522)
    ==294504==    by 0x1BA2A2: testing::TestInfo::Run() (gtest.cc:2703)
    ==294504==    by 0x1BA993: testing::TestCase::Run() (gtest.cc:2825)
    ==294504==    by 0x1C607C: testing::internal::UnitTestImpl::RunAllTests() (gtest.cc:5216)
    ==294504==    by 0x1E68D7: bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2447)
    ==294504==    by 0x1DEDE2: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2483)


    ```

    </p>
    </details>

Signed-off-by: Chen Lihui <Lihui.Chen@sony.com>