### PR TITLE
Fix memory leak in rcl_subscription_init()/rcl_publisher_init()

### DIFF
--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -28,7 +28,6 @@ extern "C"
 #include "rcl/remap.h"
 #include "rcutils/logging_macros.h"
 #include "rcutils/macros.h"
-#include "rcutils/strdup.h"
 #include "rmw/error_handling.h"
 #include "rmw/validate_full_topic_name.h"
 #include "tracetools/tracetools.h"
@@ -206,51 +205,13 @@ rcl_publisher_init(
   goto cleanup;
 fail:
   if (publisher->impl) {
-    // Used for concatenating error messages in the fail: block.
-    // The cause or error which leads to jump to fail:
-    char * fail_error_message = NULL;
-    // The error happens in fail:
-    char * fini_error_message = NULL;
-    rcl_allocator_t default_allocator = rcl_get_default_allocator();
-
-    if (rcl_error_is_set()) {
-      fail_error_message = rcutils_strdup(rcl_get_error_string().str, default_allocator);
-      rcl_reset_error();
-    }
-
     if (publisher->impl->rmw_handle) {
-      // If rmw_destroy_publisher fails, it will clobber the error string here.
-      // Concatenate the error strings if that happens
       if (rmw_destroy_publisher(
           rcl_node_get_rmw_handle(node),
-          publisher->impl->rmw_handle) == RMW_RET_ERROR)
+          publisher->impl->rmw_handle) != RMW_RET_OK)
       {
-        if (rcl_error_is_set()) {
-          fini_error_message = rcutils_strdup(rcl_get_error_string().str, default_allocator);
-          rcl_reset_error();
-        }
-
-        RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
-          "rmw_destroy_publisher failed while handling a previous error."
-          "\nOriginal error:\n\t%s\nError encountered in rmw_destroy_publisher():\n\t%s\n",
-          fail_error_message != NULL ?
-          fail_error_message : "Failed to duplicate error while init publisher !",
-          fini_error_message != NULL ?
-          fini_error_message : "Failed to duplicate error while destory rmw publisher !");
+        RCL_SET_ERROR_MSG(rmw_get_error_string().str);
       }
-    }
-
-    if (!rcl_error_is_set()) {
-      RCL_SET_ERROR_MSG(
-        (fail_error_message != NULL) ?
-        fail_error_message : "Unspecified error in rcl_publisher_init() !");
-    }
-
-    if (fail_error_message != NULL) {
-      default_allocator.deallocate(fail_error_message, default_allocator.state);
-    }
-    if (fini_error_message != NULL) {
-      default_allocator.deallocate(fini_error_message, default_allocator.state);
     }
 
     allocator->deallocate(publisher->impl, allocator->state);

--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -209,7 +209,8 @@ fail:
       rmw_ret_t rmw_fail_ret = rmw_destroy_publisher(
         rcl_node_get_rmw_handle(node), publisher->impl->rmw_handle);
       if (RMW_RET_OK != rmw_fail_ret) {
-        RCL_SET_ERROR_MSG(rmw_get_error_string().str);
+        RCUTILS_SAFE_FWRITE_TO_STDERR_WITH_FORMAT_STRING(
+          "%s, at %s:%d\n", rmw_get_error_string().str, __FILE__, __LINE__);
       }
     }
 

--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -206,10 +206,9 @@ rcl_publisher_init(
 fail:
   if (publisher->impl) {
     if (publisher->impl->rmw_handle) {
-      if (rmw_destroy_publisher(
-          rcl_node_get_rmw_handle(node),
-          publisher->impl->rmw_handle) != RMW_RET_OK)
-      {
+      rmw_ret_t rmw_fail_ret = rmw_destroy_publisher(
+        rcl_node_get_rmw_handle(node), publisher->impl->rmw_handle);
+      if (RMW_RET_OK != rmw_fail_ret) {
         RCL_SET_ERROR_MSG(rmw_get_error_string().str);
       }
     }

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -25,6 +25,7 @@ extern "C"
 #include "rcl/expand_topic_name.h"
 #include "rcl/remap.h"
 #include "rcutils/logging_macros.h"
+#include "rcutils/strdup.h"
 #include "rmw/error_handling.h"
 #include "rmw/validate_full_topic_name.h"
 #include "tracetools/tracetools.h"
@@ -193,6 +194,53 @@ rcl_subscription_init(
   goto cleanup;
 fail:
   if (subscription->impl) {
+    // Used for concatenating error messages in the fail: block.
+    // The cause or error which leads to jump to fail:
+    char * fail_error_message = NULL;
+    // The error happens in fail:
+    char * fini_error_message = NULL;
+    rcl_allocator_t default_allocator = rcl_get_default_allocator();
+
+    if (rcl_error_is_set()) {
+      fail_error_message = rcutils_strdup(rcl_get_error_string().str, default_allocator);
+      rcl_reset_error();
+    }
+
+    if (subscription->impl->rmw_handle) {
+      // If rmw_destroy_subscription fails, it will clobber the error string here.
+      // Concatenate the error strings if that happens
+      if (rmw_destroy_subscription(
+          rcl_node_get_rmw_handle(node),
+          subscription->impl->rmw_handle) == RMW_RET_ERROR)
+      {
+        if (rcl_error_is_set()) {
+          fini_error_message = rcutils_strdup(rcl_get_error_string().str, default_allocator);
+          rcl_reset_error();
+        }
+
+        RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
+          "rmw_destroy_subscription failed while handling a previous error."
+          "\nOriginal error:\n\t%s\nError encountered in rmw_destroy_subscription():\n\t%s\n",
+          fail_error_message != NULL ?
+          fail_error_message : "Failed to duplicate error while init subscription !",
+          fini_error_message != NULL ?
+          fini_error_message : "Failed to duplicate error while destory rmw subscription !");
+      }
+    }
+
+    if (!rcl_error_is_set()) {
+      RCL_SET_ERROR_MSG(
+        (fail_error_message != NULL) ?
+        fail_error_message : "Unspecified error in rcl_subscription_init() !");
+    }
+
+    if (fail_error_message != NULL) {
+      default_allocator.deallocate(fail_error_message, default_allocator.state);
+    }
+    if (fini_error_message != NULL) {
+      default_allocator.deallocate(fini_error_message, default_allocator.state);
+    }
+
     allocator->deallocate(subscription->impl, allocator->state);
     subscription->impl = NULL;
   }

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -197,7 +197,8 @@ fail:
       rmw_ret_t rmw_fail_ret = rmw_destroy_subscription(
         rcl_node_get_rmw_handle(node), subscription->impl->rmw_handle);
       if (RMW_RET_OK != rmw_fail_ret) {
-        RCL_SET_ERROR_MSG(rmw_get_error_string().str);
+        RCUTILS_SAFE_FWRITE_TO_STDERR_WITH_FORMAT_STRING(
+          "%s, at %s:%d\n", rmw_get_error_string().str, __FILE__, __LINE__);
       }
     }
 

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -194,10 +194,9 @@ rcl_subscription_init(
 fail:
   if (subscription->impl) {
     if (subscription->impl->rmw_handle) {
-      if (rmw_destroy_subscription(
-          rcl_node_get_rmw_handle(node),
-          subscription->impl->rmw_handle) != RMW_RET_OK)
-      {
+      rmw_ret_t rmw_fail_ret = rmw_destroy_subscription(
+        rcl_node_get_rmw_handle(node), subscription->impl->rmw_handle);
+      if (RMW_RET_OK != rmw_fail_ret) {
         RCL_SET_ERROR_MSG(rmw_get_error_string().str);
       }
     }

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -25,7 +25,6 @@ extern "C"
 #include "rcl/expand_topic_name.h"
 #include "rcl/remap.h"
 #include "rcutils/logging_macros.h"
-#include "rcutils/strdup.h"
 #include "rmw/error_handling.h"
 #include "rmw/validate_full_topic_name.h"
 #include "tracetools/tracetools.h"
@@ -194,51 +193,13 @@ rcl_subscription_init(
   goto cleanup;
 fail:
   if (subscription->impl) {
-    // Used for concatenating error messages in the fail: block.
-    // The cause or error which leads to jump to fail:
-    char * fail_error_message = NULL;
-    // The error happens in fail:
-    char * fini_error_message = NULL;
-    rcl_allocator_t default_allocator = rcl_get_default_allocator();
-
-    if (rcl_error_is_set()) {
-      fail_error_message = rcutils_strdup(rcl_get_error_string().str, default_allocator);
-      rcl_reset_error();
-    }
-
     if (subscription->impl->rmw_handle) {
-      // If rmw_destroy_subscription fails, it will clobber the error string here.
-      // Concatenate the error strings if that happens
       if (rmw_destroy_subscription(
           rcl_node_get_rmw_handle(node),
-          subscription->impl->rmw_handle) == RMW_RET_ERROR)
+          subscription->impl->rmw_handle) != RMW_RET_OK)
       {
-        if (rcl_error_is_set()) {
-          fini_error_message = rcutils_strdup(rcl_get_error_string().str, default_allocator);
-          rcl_reset_error();
-        }
-
-        RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
-          "rmw_destroy_subscription failed while handling a previous error."
-          "\nOriginal error:\n\t%s\nError encountered in rmw_destroy_subscription():\n\t%s\n",
-          fail_error_message != NULL ?
-          fail_error_message : "Failed to duplicate error while init subscription !",
-          fini_error_message != NULL ?
-          fini_error_message : "Failed to duplicate error while destory rmw subscription !");
+        RCL_SET_ERROR_MSG(rmw_get_error_string().str);
       }
-    }
-
-    if (!rcl_error_is_set()) {
-      RCL_SET_ERROR_MSG(
-        (fail_error_message != NULL) ?
-        fail_error_message : "Unspecified error in rcl_subscription_init() !");
-    }
-
-    if (fail_error_message != NULL) {
-      default_allocator.deallocate(fail_error_message, default_allocator.state);
-    }
-    if (fini_error_message != NULL) {
-      default_allocator.deallocate(fini_error_message, default_allocator.state);
     }
 
     allocator->deallocate(subscription->impl, allocator->state);


### PR DESCRIPTION
In rcl_subscription_init(), while rmw_subscription_get_actual_qos()
return failure, created rmw subscription handle isn't freed.
In rcl_publisher_init(), while rmw_publisher_get_actual_qos()
return failure, created rmw publisher handle isn't freed.

Signed-off-by: Barry Xu <barry.xu@sony.com>