### PR TITLE
Use valid clock in case of issue in rcl_timer_init

### DIFF
--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -175,8 +175,8 @@ rcl_action_server_init(
 
 // Initialize Timer
   ret = rcl_timer_init(
-    &action_server->impl->expire_timer, &action_server->impl->clock, node->context, options->result_timeout.nanoseconds,
-    NULL, allocator);
+    &action_server->impl->expire_timer, &action_server->impl->clock, node->context,
+    options->result_timeout.nanoseconds, NULL, allocator);
   if (RCL_RET_OK != ret) {
     goto fail;
   }
@@ -185,7 +185,7 @@ rcl_action_server_init(
   if (RCL_RET_OK != ret) {
     goto fail;
   }
-  
+
   // Copy action name
   action_server->impl->action_name = rcutils_strdup(action_name, allocator);
   if (NULL == action_server->impl->action_name) {

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -170,9 +170,12 @@ rcl_action_server_init(
   PUBLISHER_INIT(feedback);
   PUBLISHER_INIT(status);
 
-  // Initialize Timer
+  // Copy clock
+  action_server->impl->clock = *clock;
+
+// Initialize Timer
   ret = rcl_timer_init(
-    &action_server->impl->expire_timer, clock, node->context, options->result_timeout.nanoseconds,
+    &action_server->impl->expire_timer, &action_server->impl->clock, node->context, options->result_timeout.nanoseconds,
     NULL, allocator);
   if (RCL_RET_OK != ret) {
     goto fail;
@@ -182,10 +185,7 @@ rcl_action_server_init(
   if (RCL_RET_OK != ret) {
     goto fail;
   }
-
-  // Copy clock
-  action_server->impl->clock = *clock;
-
+  
   // Copy action name
   action_server->impl->action_name = rcutils_strdup(action_name, allocator);
   if (NULL == action_server->impl->action_name) {


### PR DESCRIPTION
This clock needs to be copied before rcl_timer_init in the case that `rcl_timer_init` fails. Previously, if it failed before it was copied, `rcl_timer_fini` would be called in `rcl_action_server_fini` that would try to access a pointer owned and already free'd by `rclcpp::Node`.
 
Signed-off-by: Stephen Brawner <brawner@gmail.com>