### PR TITLE
[Foxy backport] Topic fix rcl lifecycle test issue (#715)

### DIFF
--- a/rcl_lifecycle/test/test_rcl_lifecycle.cpp
+++ b/rcl_lifecycle/test/test_rcl_lifecycle.cpp
@@ -133,14 +133,23 @@ TEST(TestRclLifecycle, lifecycle_transition) {
 
   ret = rcl_lifecycle_transition_init(
     &transition, expected_id, &expected_label[0], nullptr, nullptr, &allocator);
-  EXPECT_EQ(ret, RCL_RET_OK);
+  EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+  rcutils_reset_error();
+  ret = rcl_lifecycle_transition_fini(&transition, &allocator);
+  EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
   rcutils_reset_error();
 
   ret = rcl_lifecycle_transition_init(
     &transition, expected_id, &expected_label[0], start, nullptr, &allocator);
-  EXPECT_EQ(ret, RCL_RET_OK);
+  EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+  rcutils_reset_error();
+  ret = rcl_lifecycle_transition_fini(&transition, &allocator);
+  EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
   rcutils_reset_error();
 
+  start = reinterpret_cast<rcl_lifecycle_state_t *>(
+    allocator.allocate(sizeof(rcl_lifecycle_state_t), allocator.state));
+  *start = rcl_lifecycle_get_zero_initialized_state();
   rcl_allocator_t bad_allocator = rcl_get_default_allocator();
   bad_allocator.allocate = bad_malloc;
   bad_allocator.reallocate = bad_realloc;
@@ -190,14 +199,15 @@ TEST(TestRclLifecycle, state_machine) {
   ret = rcl_init(0, nullptr, &init_options, &context);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
 
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
-  {
-    ASSERT_EQ(RCL_RET_OK, rcl_shutdown(&context));
-    ASSERT_EQ(RCL_RET_OK, rcl_context_fini(&context));
-  });
-
   ret = rcl_node_init(&node, "node", "namespace", &context, &options);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    ASSERT_EQ(RCL_RET_OK, rcl_node_fini(&node)) << rcl_get_error_string().str;
+    ASSERT_EQ(RCL_RET_OK, rcl_shutdown(&context)) << rcl_get_error_string().str;
+    ASSERT_EQ(RCL_RET_OK, rcl_context_fini(&context)) << rcl_get_error_string().str;
+  });
 
   const rosidl_message_type_support_t * pn =
     ROSIDL_GET_MSG_TYPE_SUPPORT(lifecycle_msgs, msg, TransitionEvent);
@@ -326,6 +336,7 @@ TEST(TestRclLifecycle, state_machine) {
   // Node is null
   ret = rcl_lifecycle_state_machine_fini(&state_machine, nullptr, &allocator);
   EXPECT_EQ(ret, RCL_RET_ERROR);
+  rcutils_reset_error();
 }
 
 TEST(TestRclLifecycle, state_transitions) {
@@ -348,14 +359,15 @@ TEST(TestRclLifecycle, state_transitions) {
   ret = rcl_init(0, nullptr, &init_options, &context);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
 
-  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
-  {
-    ASSERT_EQ(RCL_RET_OK, rcl_shutdown(&context));
-    ASSERT_EQ(RCL_RET_OK, rcl_context_fini(&context));
-  });
-
   ret = rcl_node_init(&node, "node", "namespace", &context, &options);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    ASSERT_EQ(RCL_RET_OK, rcl_node_fini(&node)) << rcl_get_error_string().str;
+    ASSERT_EQ(RCL_RET_OK, rcl_shutdown(&context)) << rcl_get_error_string().str;
+    ASSERT_EQ(RCL_RET_OK, rcl_context_fini(&context)) << rcl_get_error_string().str;
+  });
 
   const rosidl_message_type_support_t * pn =
     ROSIDL_GET_MSG_TYPE_SUPPORT(lifecycle_msgs, msg, TransitionEvent);


### PR DESCRIPTION
Backports to fix flaky test in Foxy CI debug CI jobs: http://build.ros2.org/job/Fci__nightly-debug_ubuntu_focal_amd64/181/testReport/junit/(root)/projectroot/test_rcl_lifecycle/

Without this backport, I'm able to reproduce the test crashing consistently with a few dozen attempts. With this backport I was not able to reproduce the test failure with `--retest-until-fail 1000`

Backports #715