### PR TITLE
Fix memory leak on serialized message in test_publisher/subscription.cpp

### DIFF
--- a/rcl/test/rcl/test_publisher.cpp
+++ b/rcl/test/rcl/test_publisher.cpp
@@ -603,6 +603,9 @@ TEST_F(
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
   {
     test_msgs__msg__Strings__fini(&msg);
+    ASSERT_EQ(
+      RCUTILS_RET_OK,
+      rmw_serialized_message_fini(&serialized_msg)) << rcl_get_error_string().str;
   });
 
   ASSERT_TRUE(rosidl_runtime_c__String__assign(&msg.string_value, test_string));

--- a/rcl/test/rcl/test_publisher.cpp
+++ b/rcl/test/rcl/test_publisher.cpp
@@ -604,7 +604,7 @@ TEST_F(
   {
     test_msgs__msg__Strings__fini(&msg);
     ASSERT_EQ(
-      RCUTILS_RET_OK,
+      RMW_RET_OK,
       rmw_serialized_message_fini(&serialized_msg)) << rcl_get_error_string().str;
   });
 

--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -571,6 +571,10 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
   {
     ret = rcl_subscription_fini(&subscription, this->node_ptr);
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+
+    test_msgs__msg__Strings__fini(&msg);
+    ret = rmw_serialized_message_fini(&serialized_msg);
+    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcl_get_error_string().str;
   });
   rcl_reset_error();
 
@@ -595,6 +599,10 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
     ASSERT_EQ(RMW_RET_OK, ret);
     ASSERT_EQ(
       std::string(test_string), std::string(msg_rcv.string_value.data, msg_rcv.string_value.size));
+
+    test_msgs__msg__Strings__fini(&msg_rcv);
+    ret = rmw_serialized_message_fini(&serialized_msg_rcv);
+    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   }
 }
 

--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -573,8 +573,9 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
     test_msgs__msg__Strings__fini(&msg);
-    ret = rmw_serialized_message_fini(&serialized_msg);
-    ASSERT_EQ(RMW_RET_OK, ret) << rcl_get_error_string().str;
+    ASSERT_EQ(
+      RMW_RET_OK,
+      rmw_serialized_message_fini(&serialized_msg)) << rcl_get_error_string().str;
   });
   rcl_reset_error();
 
@@ -601,8 +602,9 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
       std::string(test_string), std::string(msg_rcv.string_value.data, msg_rcv.string_value.size));
 
     test_msgs__msg__Strings__fini(&msg_rcv);
-    ret = rmw_serialized_message_fini(&serialized_msg_rcv);
-    ASSERT_EQ(RMW_RET_OK, ret) << rcl_get_error_string().str;
+    ASSERT_EQ(
+      RMW_RET_OK,
+      rmw_serialized_message_fini(&serialized_msg_rcv)) << rcl_get_error_string().str;
   }
 }
 

--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -574,7 +574,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
 
     test_msgs__msg__Strings__fini(&msg);
     ret = rmw_serialized_message_fini(&serialized_msg);
-    ASSERT_EQ(RCUTILS_RET_OK, ret) << rcl_get_error_string().str;
+    ASSERT_EQ(RMW_RET_OK, ret) << rcl_get_error_string().str;
   });
   rcl_reset_error();
 
@@ -602,7 +602,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
 
     test_msgs__msg__Strings__fini(&msg_rcv);
     ret = rmw_serialized_message_fini(&serialized_msg_rcv);
-    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+    ASSERT_EQ(RMW_RET_OK, ret) << rcl_get_error_string().str;
   }
 }
 


### PR DESCRIPTION
This memory leak issue was found in #721.  

Related test:
- test_subscription__rmw_cyclonedds_cpp
- test_subscription__rmw_fastrtps_cpp 
- test_subscription__rmw_fastrtps_dynamic_cpp 
- test_publisher__rmw_cyclonedds_cpp
- test_publisher__rmw_fastrtps_cpp
- test_publisher__rmw_fastrtps_dynamic_cpp