### PR TITLE
Add lifecycle node state transition instrumentation

### DIFF
--- a/rcl_lifecycle/CMakeLists.txt
+++ b/rcl_lifecycle/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(rcl REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rosidl_runtime_c REQUIRED)
+find_package(tracetools REQUIRED)
 
 # Default to C11
 if(NOT CMAKE_C_STANDARD)
@@ -49,6 +50,7 @@ ament_target_dependencies(rcl_lifecycle
   "rcl"
   "rcutils"
   "rosidl_runtime_c"
+  "tracetools"
 )
 
 rcl_set_symbol_visibility_hidden(${PROJECT_NAME} LANGUAGE "C")
@@ -129,6 +131,7 @@ ament_export_dependencies(lifecycle_msgs)
 ament_export_dependencies(rcl)
 ament_export_dependencies(rcutils)
 ament_export_dependencies(rosidl_runtime_c)
+ament_export_dependencies(tracetools)
 ament_package()
 
 install(

--- a/rcl_lifecycle/package.xml
+++ b/rcl_lifecycle/package.xml
@@ -17,12 +17,14 @@
   <build_depend>rcutils</build_depend>
   <build_depend>rmw</build_depend>
   <build_depend>rosidl_runtime_c</build_depend>
+  <build_depend>tracetools</build_depend>
 
   <exec_depend>lifecycle_msgs</exec_depend>
   <exec_depend>rcl</exec_depend>
   <exec_depend>rcutils</exec_depend>
   <exec_depend>rmw</exec_depend>
   <exec_depend>rosidl_runtime_c</exec_depend>
+  <exec_depend>tracetools</exec_depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rcl_lifecycle/src/rcl_lifecycle.c
+++ b/rcl_lifecycle/src/rcl_lifecycle.c
@@ -29,6 +29,7 @@ extern "C"
 #include "rcutils/logging_macros.h"
 #include "rcutils/macros.h"
 #include "rcutils/strdup.h"
+#include "tracetools/tracetools.h"
 
 #include "rcl_lifecycle/default_state_machine.h"
 #include "rcl_lifecycle/transition_map.h"
@@ -219,6 +220,10 @@ rcl_lifecycle_state_machine_init(
     }
   }
 
+  TRACEPOINT(
+    rcl_lifecycle_state_machine_init,
+    (const void *)node_handle,
+    (const void *)state_machine);
   return RCL_RET_OK;
 }
 
@@ -339,6 +344,11 @@ _trigger_transition(
     }
   }
 
+  TRACEPOINT(
+    rcl_lifecycle_transition,
+    (const void *)state_machine,
+    transition->start->label,
+    state_machine->current_state->label);
   return RCL_RET_OK;
 }
 


### PR DESCRIPTION
This instrumentation is used to track state transitions of lifecycle nodes.

Requires https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing/-/merge_requests/199

For an example of processed/output data, see https://gitlab.com/micro-ROS/ros_tracing/tracetools_analysis/-/merge_requests/83