### PR TITLE
Several memory-related fixes for rcl_variant_t benchmarks

### DIFF
--- a/rcl_yaml_param_parser/test/benchmark/benchmark_variant.cpp
+++ b/rcl_yaml_param_parser/test/benchmark/benchmark_variant.cpp
@@ -224,7 +224,6 @@ BENCHMARK_F(PerformanceTest, array_string_copy_variant)(benchmark::State & st)
   {
     st.SkipWithError(rcutils_get_error_string().str);
   }
-  src_variant.string_array_value->size = kSize;
 
   for (size_t i = 0; i < kSize; i++) {
     src_variant.string_array_value->data[i] = rcutils_strdup("string", allocator);

--- a/rcl_yaml_param_parser/test/benchmark/benchmark_variant.cpp
+++ b/rcl_yaml_param_parser/test/benchmark/benchmark_variant.cpp
@@ -101,6 +101,11 @@ BENCHMARK_F(PerformanceTest, string_copy_variant)(benchmark::State & st)
 
   char * tmp_string = rcutils_strdup(data.c_str(), allocator);
   src_variant.string_value = tmp_string;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    rcl_yaml_variant_fini(&src_variant, allocator);
+    rcl_yaml_variant_fini(&dest_variant, allocator);
+  });
 
   reset_heap_counters();
 

--- a/rcl_yaml_param_parser/test/benchmark/benchmark_variant.cpp
+++ b/rcl_yaml_param_parser/test/benchmark/benchmark_variant.cpp
@@ -49,8 +49,8 @@ BENCHMARK_F(PerformanceTest, bool_copy_variant)(benchmark::State & st)
     if (!rcl_yaml_variant_copy(&dest_variant, &src_variant, allocator)) {
       st.SkipWithError(rcutils_get_error_string().str);
     }
+    rcl_yaml_variant_fini(&dest_variant, allocator);
   }
-  rcl_yaml_variant_fini(&dest_variant, allocator);
   src_variant.bool_value = nullptr;
 }
 
@@ -68,8 +68,8 @@ BENCHMARK_F(PerformanceTest, int_copy_variant)(benchmark::State & st)
     if (!rcl_yaml_variant_copy(&dest_variant, &src_variant, allocator)) {
       st.SkipWithError(rcutils_get_error_string().str);
     }
+    rcl_yaml_variant_fini(&dest_variant, allocator);
   }
-  rcl_yaml_variant_fini(&dest_variant, allocator);
   src_variant.integer_value = nullptr;
 }
 
@@ -87,8 +87,8 @@ BENCHMARK_F(PerformanceTest, double_copy_variant)(benchmark::State & st)
     if (!rcl_yaml_variant_copy(&dest_variant, &src_variant, allocator)) {
       st.SkipWithError(rcutils_get_error_string().str);
     }
+    rcl_yaml_variant_fini(&dest_variant, allocator);
   }
-  rcl_yaml_variant_fini(&dest_variant, allocator);
   src_variant.double_value = nullptr;
 }
 

--- a/rcl_yaml_param_parser/test/benchmark/benchmark_variant.cpp
+++ b/rcl_yaml_param_parser/test/benchmark/benchmark_variant.cpp
@@ -110,7 +110,6 @@ BENCHMARK_F(PerformanceTest, string_copy_variant)(benchmark::State & st)
     }
     rcl_yaml_variant_fini(&dest_variant, allocator);
   }
-  src_variant.string_value = nullptr;
 }
 
 BENCHMARK_F(PerformanceTest, array_bool_copy_variant)(benchmark::State & st)
@@ -129,8 +128,6 @@ BENCHMARK_F(PerformanceTest, array_bool_copy_variant)(benchmark::State & st)
   {
     rcl_yaml_variant_fini(&src_variant, allocator);
     rcl_yaml_variant_fini(&dest_variant, allocator);
-    src_variant.bool_array_value = nullptr;
-    dest_variant.bool_array_value = nullptr;
   });
   src_variant.bool_array_value->size = kSize;
 
@@ -141,7 +138,6 @@ BENCHMARK_F(PerformanceTest, array_bool_copy_variant)(benchmark::State & st)
       st.SkipWithError(rcutils_get_error_string().str);
     }
     rcl_yaml_variant_fini(&dest_variant, allocator);
-    dest_variant.double_array_value = nullptr;
   }
 }
 
@@ -161,8 +157,6 @@ BENCHMARK_F(PerformanceTest, array_int_copy_variant)(benchmark::State & st)
   {
     rcl_yaml_variant_fini(&src_variant, allocator);
     rcl_yaml_variant_fini(&dest_variant, allocator);
-    src_variant.integer_array_value = nullptr;
-    dest_variant.integer_array_value = nullptr;
   });
   src_variant.integer_array_value->size = kSize;
 
@@ -173,7 +167,6 @@ BENCHMARK_F(PerformanceTest, array_int_copy_variant)(benchmark::State & st)
       st.SkipWithError(rcutils_get_error_string().str);
     }
     rcl_yaml_variant_fini(&dest_variant, allocator);
-    dest_variant.double_array_value = nullptr;
   }
 }
 
@@ -193,8 +186,6 @@ BENCHMARK_F(PerformanceTest, array_double_copy_variant)(benchmark::State & st)
   {
     rcl_yaml_variant_fini(&src_variant, allocator);
     rcl_yaml_variant_fini(&dest_variant, allocator);
-    src_variant.double_array_value = nullptr;
-    dest_variant.double_array_value = nullptr;
   });
   src_variant.double_array_value->size = kSize;
 
@@ -205,7 +196,6 @@ BENCHMARK_F(PerformanceTest, array_double_copy_variant)(benchmark::State & st)
       st.SkipWithError(rcutils_get_error_string().str);
     }
     rcl_yaml_variant_fini(&dest_variant, allocator);
-    dest_variant.double_array_value = nullptr;
   }
 }
 
@@ -245,6 +235,5 @@ BENCHMARK_F(PerformanceTest, array_string_copy_variant)(benchmark::State & st)
       st.SkipWithError(rcutils_get_error_string().str);
     }
     rcl_yaml_variant_fini(&dest_variant, allocator);
-    dest_variant.double_array_value = nullptr;
   }
 }


### PR DESCRIPTION
See each commit for justification.

* Remove a bunch of redundant nullptr assignments
* Fix some memory leaks
* Ensure source string is deallocated
* Remove redundant array size assignment

Follow-up to #803 and #810