### PR TITLE
Add a semicolon to RCUTILS_LOGGING_AUTOINIT.

### DIFF
--- a/rcl/src/rcl/logging.c
+++ b/rcl/src/rcl/logging.c
@@ -62,8 +62,8 @@ rcl_logging_configure_with_output_handler(
   RCL_CHECK_ARGUMENT_FOR_NULL(global_args, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ALLOCATOR_WITH_MSG(allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(output_handler, RCL_RET_INVALID_ARGUMENT);
-  RCUTILS_LOGGING_AUTOINIT
-    g_logging_allocator = *allocator;
+  RCUTILS_LOGGING_AUTOINIT;
+  g_logging_allocator = *allocator;
   int default_level = -1;
   rcl_log_levels_t * log_levels = &global_args->impl->log_levels;
   const char * config_file = global_args->impl->external_log_config_file;


### PR DESCRIPTION
This makes it look like a C statement.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

This goes along with https://github.com/ros2/rcutils/pull/290 ; see that PR for CI.