### PR TITLE
[foxy backport] Tweaks to client.c and subscription.c for cleaner init/fini (#728)

### DIFF
--- a/rcl/src/rcl/client.c
+++ b/rcl/src/rcl/client.c
@@ -189,6 +189,7 @@ rcl_client_init(
 fail:
   if (client->impl) {
     allocator->deallocate(client->impl, allocator->state);
+    client->impl = NULL;
   }
   ret = fail_ret;
   // Fall through to cleanup
@@ -223,6 +224,7 @@ rcl_client_fini(rcl_client_t * client, rcl_node_t * node)
       result = RCL_RET_ERROR;
     }
     allocator.deallocate(client->impl, allocator.state);
+    client->impl = NULL;
   }
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Client finalized");
   return result;

--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -236,6 +236,7 @@ rcl_publisher_fini(rcl_publisher_t * publisher, rcl_node_t * node)
       result = RCL_RET_ERROR;
     }
     allocator.deallocate(publisher->impl, allocator.state);
+    publisher->impl = NULL;
   }
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Publisher finalized");
   return result;

--- a/rcl/src/rcl/service.c
+++ b/rcl/src/rcl/service.c
@@ -193,6 +193,7 @@ rcl_service_init(
 fail:
   if (service->impl) {
     allocator->deallocate(service->impl, allocator->state);
+    service->impl = NULL;
   }
   ret = fail_ret;
   // Fall through to clean up
@@ -228,6 +229,7 @@ rcl_service_fini(rcl_service_t * service, rcl_node_t * node)
       result = RCL_RET_ERROR;
     }
     allocator.deallocate(service->impl, allocator.state);
+    service->impl = NULL;
   }
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Service finalized");
   return result;


### PR DESCRIPTION
This backports #728 for `rcl`

Signed-off-by: Stephen Brawner <brawner@gmail.com>