### PR TITLE
[Backport Foxy] Add fault injection macros and unit tests to rcl_action (#730)

### DIFF
--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -194,6 +194,7 @@ rcl_subscription_init(
 fail:
   if (subscription->impl) {
     allocator->deallocate(subscription->impl, allocator->state);
+    subscription->impl = NULL;
   }
   ret = fail_ret;
   // Fall through to cleanup
@@ -229,6 +230,7 @@ rcl_subscription_fini(rcl_subscription_t * subscription, rcl_node_t * node)
       result = RCL_RET_ERROR;
     }
     allocator.deallocate(subscription->impl, allocator.state);
+    subscription->impl = NULL;
   }
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Subscription finalized");
   return result;
@@ -292,10 +294,6 @@ rcl_take_sequence(
   rmw_subscription_allocation_t * allocation
 )
 {
-  // Set the sizes to zero to indicate that there are no valid messages
-  message_sequence->size = 0u;
-  message_info_sequence->size = 0u;
-
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Subscription taking %zu messages", count);
   if (!rcl_subscription_is_valid(subscription)) {
     return RCL_RET_SUBSCRIPTION_INVALID;  // error message already set
@@ -312,6 +310,10 @@ rcl_take_sequence(
     RCL_SET_ERROR_MSG("Insufficient message info sequence capacity for requested count");
     return RCL_RET_INVALID_ARGUMENT;
   }
+
+  // Set the sizes to zero to indicate that there are no valid messages
+  message_sequence->size = 0u;
+  message_info_sequence->size = 0u;
 
   size_t taken = 0u;
   rmw_ret_t ret = rmw_take_sequence(
@@ -376,6 +378,7 @@ rcl_take_loaned_message(
   if (!rcl_subscription_is_valid(subscription)) {
     return RCL_RET_SUBSCRIPTION_INVALID;  // error already set
   }
+  RCL_CHECK_ARGUMENT_FOR_NULL(loaned_message, RCL_RET_INVALID_ARGUMENT);
   if (*loaned_message) {
     RCL_SET_ERROR_MSG("loaned message is already initialized");
     return RCL_RET_INVALID_ARGUMENT;

--- a/rcl_action/CMakeLists.txt
+++ b/rcl_action/CMakeLists.txt
@@ -81,6 +81,7 @@ if(BUILD_TESTING)
   # Gtests
   ament_add_gtest(test_action_client
     test/rcl_action/test_action_client.cpp
+    TIMEOUT 360
   )
   if(TARGET test_action_client)
     target_include_directories(test_action_client PUBLIC
@@ -95,6 +96,7 @@ if(BUILD_TESTING)
       "rcl"
       "test_msgs"
     )
+    target_compile_definitions(test_action_client PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
   endif()
 
   # get the rmw implementations ahead of time
@@ -107,7 +109,7 @@ if(BUILD_TESTING)
   function(custom_test_c target)
     ament_add_gtest(
       "${target}${target_suffix}" ${ARGN}
-      TIMEOUT 60
+      TIMEOUT 180
       ENV
       RCL_ASSERT_RMW_ID_MATCHES=${rmw_implementation}
       RMW_IMPLEMENTATION=${rmw_implementation}
@@ -115,6 +117,8 @@ if(BUILD_TESTING)
     if(TARGET ${target}${target_suffix})
       target_compile_definitions(${target}${target_suffix}
         PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
+        target_compile_definitions(${target}${target_suffix}
+          PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
       target_include_directories(${target}${target_suffix} PUBLIC
         include
       )
@@ -143,6 +147,7 @@ if(BUILD_TESTING)
 
   ament_add_gtest(test_action_server
     test/rcl_action/test_action_server.cpp
+    TIMEOUT 120
   )
   if(TARGET test_action_server)
     target_include_directories(test_action_server PUBLIC
@@ -157,6 +162,7 @@ if(BUILD_TESTING)
       "rcl"
       "test_msgs"
     )
+    target_compile_definitions(test_action_server PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
   endif()
   ament_add_gtest(test_goal_handle
     test/rcl_action/test_goal_handle.cpp

--- a/rcl_action/src/rcl_action/goal_handle.c
+++ b/rcl_action/src/rcl_action/goal_handle.c
@@ -42,6 +42,10 @@ rcl_action_goal_handle_init(
   const rcl_action_goal_info_t * goal_info,
   rcl_allocator_t allocator)
 {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RCL_RET_INVALID_ARGUMENT);
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RCL_RET_ALREADY_INIT);
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RCL_RET_BAD_ALLOC);
+
   RCL_CHECK_ARGUMENT_FOR_NULL(goal_handle, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(goal_info, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
@@ -103,6 +107,9 @@ rcl_action_goal_handle_get_info(
   const rcl_action_goal_handle_t * goal_handle,
   rcl_action_goal_info_t * goal_info)
 {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RCL_RET_ACTION_GOAL_HANDLE_INVALID);
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RCL_RET_INVALID_ARGUMENT);
+
   if (!rcl_action_goal_handle_is_valid(goal_handle)) {
     return RCL_RET_ACTION_GOAL_HANDLE_INVALID;  // error message is set
   }
@@ -117,6 +124,9 @@ rcl_action_goal_handle_get_status(
   const rcl_action_goal_handle_t * goal_handle,
   rcl_action_goal_state_t * status)
 {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RCL_RET_ACTION_GOAL_HANDLE_INVALID);
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RCL_RET_INVALID_ARGUMENT);
+
   if (!rcl_action_goal_handle_is_valid(goal_handle)) {
     return RCL_RET_ACTION_GOAL_HANDLE_INVALID;  // error message is set
   }

--- a/rcl_action/src/rcl_action/types.c
+++ b/rcl_action/src/rcl_action/types.c
@@ -19,6 +19,7 @@ extern "C"
 #include "rcl_action/types.h"
 
 #include "rcl/error_handling.h"
+#include "rcutils/macros.h"
 
 rcl_action_goal_info_t
 rcl_action_get_zero_initialized_goal_info(void)
@@ -96,6 +97,10 @@ rcl_action_cancel_response_init(
   const size_t num_goals_canceling,
   const rcl_allocator_t allocator)
 {
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RCL_RET_INVALID_ARGUMENT);
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RCL_RET_ALREADY_INIT);
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RCL_RET_BAD_ALLOC);
+
   RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(cancel_response, RCL_RET_INVALID_ARGUMENT);
   // Size of array to allocate must be greater than 0

--- a/rcl_action/test/rcl_action/test_action_communication.cpp
+++ b/rcl_action/test/rcl_action/test_action_communication.cpp
@@ -1106,3 +1106,71 @@ TEST_F(CLASSNAME(TestActionCommunication, RMW_IMPLEMENTATION), test_invalid_stat
   ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
   action_msgs__msg__GoalStatusArray__fini(&incoming_status_array);
 }
+
+TEST_F(CLASSNAME(TestActionCommunication, RMW_IMPLEMENTATION), test_valid_feedback_comm_maybe_fail)
+{
+  test_msgs__action__Fibonacci_FeedbackMessage outgoing_feedback;
+  test_msgs__action__Fibonacci_FeedbackMessage incoming_feedback;
+  test_msgs__action__Fibonacci_FeedbackMessage__init(&outgoing_feedback);
+  test_msgs__action__Fibonacci_FeedbackMessage__init(&incoming_feedback);
+
+  // Initialize feedback
+  ASSERT_TRUE(
+    rosidl_runtime_c__int32__Sequence__init(
+      &outgoing_feedback.feedback.sequence, 3));
+  outgoing_feedback.feedback.sequence.data[0] = 0;
+  outgoing_feedback.feedback.sequence.data[1] = 1;
+  outgoing_feedback.feedback.sequence.data[2] = 2;
+  init_test_uuid0(outgoing_feedback.goal_id.uuid);
+
+  RCUTILS_FAULT_INJECTION_TEST(
+  {
+    // Publish feedback with valid arguments
+    rcl_ret_t ret = rcl_action_publish_feedback(&this->action_server, &outgoing_feedback);
+    if (RCL_RET_OK != ret) {
+      // This isn't set in all cases, but reset anyway.
+      rcl_reset_error();
+      continue;
+    }
+
+    ret = rcl_action_wait_set_add_action_client(
+      &this->wait_set, &this->action_client, NULL, NULL);
+    if (RCL_RET_OK != ret) {
+      EXPECT_TRUE(rcl_error_is_set());
+      rcl_reset_error();
+      continue;
+    }
+
+    ret = rcl_wait(&this->wait_set, RCL_S_TO_NS(10));
+    if (RCL_RET_OK != ret) {
+      EXPECT_TRUE(rcl_error_is_set());
+      rcl_reset_error();
+      continue;
+    }
+
+    ret = rcl_action_client_wait_set_get_entities_ready(
+      &this->wait_set,
+      &this->action_client,
+      &this->is_feedback_ready,
+      &this->is_status_ready,
+      &this->is_goal_response_ready,
+      &this->is_cancel_response_ready,
+      &this->is_result_response_ready);
+    if (RCL_RET_OK != ret) {
+      EXPECT_TRUE(rcl_error_is_set());
+      rcl_reset_error();
+      continue;
+    }
+
+    // Take feedback with valid arguments
+    ret = rcl_action_take_feedback(&this->action_client, &incoming_feedback);
+    if (RCL_RET_OK != ret) {
+      EXPECT_TRUE(rcl_error_is_set());
+      rcl_reset_error();
+      continue;
+    }
+
+    test_msgs__action__Fibonacci_FeedbackMessage__fini(&incoming_feedback);
+    test_msgs__action__Fibonacci_FeedbackMessage__fini(&outgoing_feedback);
+  });
+}

--- a/rcl_action/test/rcl_action/test_graph.cpp
+++ b/rcl_action/test/rcl_action/test_graph.cpp
@@ -24,6 +24,7 @@
 
 #include "rcl/error_handling.h"
 #include "rcl/rcl.h"
+#include "rcutils/testing/fault_injection.h"
 
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 
@@ -592,4 +593,83 @@ TEST_F(TestActionGraphMultiNodeFixture, test_action_get_client_names_and_types_b
 
   ret = rcl_names_and_types_fini(&nat);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+}
+
+TEST_F(TestActionGraphMultiNodeFixture, get_names_and_types_maybe_fail)
+{
+  RCUTILS_FAULT_INJECTION_TEST(
+  {
+    rcl_names_and_types_t nat = rcl_get_zero_initialized_names_and_types();
+    rcl_ret_t ret = rcl_action_get_names_and_types(&this->node, &this->allocator, &nat);
+    if (RCL_RET_OK == ret) {
+      ret = rcl_names_and_types_fini(&nat);
+      if (RCL_RET_OK != ret) {
+        EXPECT_TRUE(rcutils_error_is_set());
+        rcutils_reset_error();
+        EXPECT_EQ(RCL_RET_OK, rcl_names_and_types_fini(&nat));
+      }
+    }
+  });
+}
+
+TEST_F(TestActionGraphMultiNodeFixture, action_client_init_maybe_fail)
+{
+  RCUTILS_FAULT_INJECTION_TEST(
+  {
+    const rosidl_action_type_support_t * action_typesupport = ROSIDL_GET_ACTION_TYPE_SUPPORT(
+      test_msgs, Fibonacci);
+
+    rcl_action_client_t action_client = rcl_action_get_zero_initialized_client();
+    rcl_action_client_options_t action_client_options = rcl_action_client_get_default_options();
+    rcl_ret_t ret = rcl_action_client_init(
+      &action_client,
+      &this->remote_node,
+      action_typesupport,
+      this->action_name,
+      &action_client_options);
+
+    if (RCL_RET_OK == ret) {
+      ret = rcl_action_client_fini(&action_client, &this->remote_node);
+      if (RCL_RET_OK != ret) {
+        // This isn't always set, but just in case reset anyway
+        rcutils_reset_error();
+      }
+    }
+  });
+}
+
+TEST_F(TestActionGraphMultiNodeFixture, rcl_get_client_names_and_types_by_node_maybe_fail)
+{
+  RCUTILS_FAULT_INJECTION_TEST(
+  {
+    rcl_names_and_types_t nat = rcl_get_zero_initialized_names_and_types();
+    rcl_ret_t ret = rcl_action_get_client_names_and_types_by_node(
+      &this->node, &this->allocator, this->test_graph_node_name, "", &nat);
+    if (RCL_RET_OK == ret) {
+      ret = rcl_names_and_types_fini(&nat);
+      if (ret != RCL_RET_OK) {
+        EXPECT_TRUE(rcutils_error_is_set());
+        rcutils_reset_error();
+        EXPECT_EQ(RCL_RET_OK, rcl_names_and_types_fini(&nat));
+      }
+    }
+  });
+}
+
+TEST_F(TestActionGraphMultiNodeFixture, rcl_get_server_names_and_types_by_node_maybe_fail)
+{
+  RCUTILS_FAULT_INJECTION_TEST(
+  {
+    rcl_names_and_types_t nat = rcl_get_zero_initialized_names_and_types();
+    rcl_ret_t ret = rcl_action_get_server_names_and_types_by_node(
+      &this->node, &this->allocator, this->test_graph_node_name, "", &nat);
+    if (RCL_RET_OK == ret) {
+      ret = rcl_names_and_types_fini(&nat);
+      if (ret != RCL_RET_OK) {
+        EXPECT_TRUE(rcutils_error_is_set());
+        rcutils_reset_error();
+        EXPECT_EQ(RCL_RET_OK, rcl_names_and_types_fini(&nat));
+      }
+    }
+  });
 }


### PR DESCRIPTION
* Add fault injection macros and unit tests to rcl_action

Signed-off-by: Stephen Brawner <brawner@gmail.com>

* Addressing  feedback

Signed-off-by: Stephen Brawner <brawner@gmail.com>

* PR Fixup

Signed-off-by: Stephen Brawner <brawner@gmail.com>

* PR Fixup

Signed-off-by: Stephen Brawner <brawner@gmail.com>