### PR TITLE
[rcl_lifecycle] Add warnings

### DIFF
--- a/rcl_lifecycle/CMakeLists.txt
+++ b/rcl_lifecycle/CMakeLists.txt
@@ -22,7 +22,10 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(
+    -Wall -Wextra -Wpedantic
+    -Wformat=2 -Wconversion -Wshadow -Wsign-conversion
+  )
 endif()
 
 set(rcl_lifecycle_sources

--- a/rcl_lifecycle/include/rcl_lifecycle/data_types.h
+++ b/rcl_lifecycle/include/rcl_lifecycle/data_types.h
@@ -32,7 +32,7 @@ typedef struct rcl_lifecycle_state_t
   /// String with state name: Unconfigured, Inactive, Active or Finalized
   const char * label;
   /// Identifier of the state
-  unsigned int id;
+  uint8_t id;
 
   /// Pointer to a struct with the valid transitions
   rcl_lifecycle_transition_t * valid_transitions;

--- a/rcl_lifecycle/include/rcl_lifecycle/rcl_lifecycle.h
+++ b/rcl_lifecycle/include/rcl_lifecycle/rcl_lifecycle.h
@@ -85,7 +85,7 @@ RCL_WARN_UNUSED
 rcl_ret_t
 rcl_lifecycle_state_init(
   rcl_lifecycle_state_t * state,
-  unsigned int id,
+  uint8_t id,
   const char * label,
   const rcl_allocator_t * allocator);
 

--- a/rcl_lifecycle/src/com_interface.c
+++ b/rcl_lifecycle/src/com_interface.c
@@ -250,9 +250,9 @@ rcl_lifecycle_com_interface_publish_notification(
   rcl_lifecycle_com_interface_t * com_interface,
   const rcl_lifecycle_state_t * start, const rcl_lifecycle_state_t * goal)
 {
-  msg.start_state.id = start->id;
+  msg.start_state.id = (uint8_t) start->id;
   rosidl_runtime_c__String__assign(&msg.start_state.label, start->label);
-  msg.goal_state.id = goal->id;
+  msg.goal_state.id = (uint8_t) goal->id;
   rosidl_runtime_c__String__assign(&msg.goal_state.label, goal->label);
 
   return rcl_publish(&com_interface->pub_transition_event, &msg, NULL);

--- a/rcl_lifecycle/src/com_interface.c
+++ b/rcl_lifecycle/src/com_interface.c
@@ -250,9 +250,9 @@ rcl_lifecycle_com_interface_publish_notification(
   rcl_lifecycle_com_interface_t * com_interface,
   const rcl_lifecycle_state_t * start, const rcl_lifecycle_state_t * goal)
 {
-  msg.start_state.id = (uint8_t) start->id;
+  msg.start_state.id = start->id;
   rosidl_runtime_c__String__assign(&msg.start_state.label, start->label);
-  msg.goal_state.id = (uint8_t) goal->id;
+  msg.goal_state.id = goal->id;
   rosidl_runtime_c__String__assign(&msg.goal_state.label, goal->label);
 
   return rcl_publish(&com_interface->pub_transition_event, &msg, NULL);

--- a/rcl_lifecycle/src/rcl_lifecycle.c
+++ b/rcl_lifecycle/src/rcl_lifecycle.c
@@ -50,7 +50,7 @@ rcl_lifecycle_get_zero_initialized_state()
 rcl_ret_t
 rcl_lifecycle_state_init(
   rcl_lifecycle_state_t * state,
-  unsigned int id,
+  uint8_t id,
   const char * label,
   const rcl_allocator_t * allocator)
 {

--- a/rcl_lifecycle/test/test_rcl_lifecycle.cpp
+++ b/rcl_lifecycle/test/test_rcl_lifecycle.cpp
@@ -47,7 +47,7 @@ TEST(TestRclLifecycle, lifecycle_state) {
   EXPECT_EQ(nullptr, state.label);
 
   rcl_allocator_t allocator = rcl_get_default_allocator();
-  unsigned int expected_id = 42;
+  uint8_t expected_id = 42;
   const char expected_label[] = "label";
   rcl_ret_t ret = rcl_lifecycle_state_init(&state, expected_id, &expected_label[0], nullptr);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);


### PR DESCRIPTION
This PR enables `-Wformat=2`, `-Wconversion`, `-Wshadow`, and `-Wsign-conversion` in `rcl_lifecycle`. This PR relies on using gtest v1.10.0, see https://github.com/ament/googletest/pull/8.