### PR TITLE
[rcl_yaml_param_parser] Add warnings

### DIFF
--- a/rcl_yaml_param_parser/CMakeLists.txt
+++ b/rcl_yaml_param_parser/CMakeLists.txt
@@ -13,7 +13,10 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
+  add_compile_options(
+    -Wall -Wextra -Wpedantic
+    -Wformat=2 -Wconversion -Wsign-conversion
+  )
 endif()
 
 set(rcl_yaml_parser_sources

--- a/rcl_yaml_param_parser/src/parse.c
+++ b/rcl_yaml_param_parser/src/parse.c
@@ -501,7 +501,7 @@ _validate_name(const char * name, rcutils_allocator_t allocator)
     }
   } else {
     // substring namespace including the last '/'
-    char * namespace_ = rcutils_strndup(name, separator_pos - name + 1, allocator);
+    char * namespace_ = rcutils_strndup(name, ((size_t) (separator_pos - name)) + 1, allocator);
     if (NULL == namespace_) {
       ret = RCUTILS_RET_BAD_ALLOC;
       goto clean;
@@ -534,7 +534,7 @@ _validate_name(const char * name, rcutils_allocator_t allocator)
       }
     } else {
       do {
-        size_t len = separator_pos - absolute_namespace - i;
+        size_t len = ((size_t) (separator_pos - absolute_namespace)) - i;
         char * namespace_ = rcutils_strndup(absolute_namespace + i, len, allocator);
         if (NULL == namespace_) {
           ret = RCUTILS_RET_BAD_ALLOC;


### PR DESCRIPTION
This PR enables `-Wformat=2`, `-Wconversion`, and `-Wsign-conversion` in `rcl_yaml_param_parser`. No source code was modified to enable these warnings. This PR relies on using gtest v1.10.0, see https://github.com/ament/googletest/pull/8.