### PR TITLE
[eloquent] Fix memory leak in rcl_subscription_init()/rcl_publisher_init() (#794)

### DIFF
--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -197,6 +197,15 @@ rcl_publisher_init(
   goto cleanup;
 fail:
   if (publisher->impl) {
+    if (publisher->impl->rmw_handle) {
+      rmw_ret_t rmw_fail_ret = rmw_destroy_publisher(
+        rcl_node_get_rmw_handle(node), publisher->impl->rmw_handle);
+      if (RMW_RET_OK != rmw_fail_ret) {
+        RCUTILS_SAFE_FWRITE_TO_STDERR_WITH_FORMAT_STRING(
+          "%s, at %s:%d\n", rmw_get_error_string().str, __FILE__, __LINE__);
+      }
+    }
+
     allocator->deallocate(publisher->impl, allocator->state);
   }
 

--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -201,8 +201,8 @@ fail:
       rmw_ret_t rmw_fail_ret = rmw_destroy_publisher(
         rcl_node_get_rmw_handle(node), publisher->impl->rmw_handle);
       if (RMW_RET_OK != rmw_fail_ret) {
-        RCUTILS_SAFE_FWRITE_TO_STDERR_WITH_FORMAT_STRING(
-          "%s, at %s:%d\n", rmw_get_error_string().str, __FILE__, __LINE__);
+        RCUTILS_SAFE_FWRITE_TO_STDERR(rmw_get_error_string().str);
+        RCUTILS_SAFE_FWRITE_TO_STDERR("\n");
       }
     }
 

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -193,6 +193,15 @@ rcl_subscription_init(
   goto cleanup;
 fail:
   if (subscription->impl) {
+    if (subscription->impl->rmw_handle) {
+      rmw_ret_t rmw_fail_ret = rmw_destroy_subscription(
+        rcl_node_get_rmw_handle(node), subscription->impl->rmw_handle);
+      if (RMW_RET_OK != rmw_fail_ret) {
+        RCUTILS_SAFE_FWRITE_TO_STDERR_WITH_FORMAT_STRING(
+          "%s, at %s:%d\n", rmw_get_error_string().str, __FILE__, __LINE__);
+      }
+    }
+
     allocator->deallocate(subscription->impl, allocator->state);
   }
   ret = fail_ret;

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -197,8 +197,8 @@ fail:
       rmw_ret_t rmw_fail_ret = rmw_destroy_subscription(
         rcl_node_get_rmw_handle(node), subscription->impl->rmw_handle);
       if (RMW_RET_OK != rmw_fail_ret) {
-        RCUTILS_SAFE_FWRITE_TO_STDERR_WITH_FORMAT_STRING(
-          "%s, at %s:%d\n", rmw_get_error_string().str, __FILE__, __LINE__);
+        RCUTILS_SAFE_FWRITE_TO_STDERR(rmw_get_error_string().str);
+        RCUTILS_SAFE_FWRITE_TO_STDERR("\n");
       }
     }
 


### PR DESCRIPTION
Backport #794 and #834 to Eloquent.