### PR TITLE
Remove redundant error formatting

### DIFF
--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -209,8 +209,8 @@ fail:
       rmw_ret_t rmw_fail_ret = rmw_destroy_publisher(
         rcl_node_get_rmw_handle(node), publisher->impl->rmw_handle);
       if (RMW_RET_OK != rmw_fail_ret) {
-        RCUTILS_SAFE_FWRITE_TO_STDERR_WITH_FORMAT_STRING(
-          "%s, at %s:%d\n", rmw_get_error_string().str, __FILE__, __LINE__);
+        RCUTILS_SAFE_FWRITE_TO_STDERR(rmw_get_error_string().str);
+        RCUTILS_SAFE_FWRITE_TO_STDERR("\n");
       }
     }
 

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -197,8 +197,8 @@ fail:
       rmw_ret_t rmw_fail_ret = rmw_destroy_subscription(
         rcl_node_get_rmw_handle(node), subscription->impl->rmw_handle);
       if (RMW_RET_OK != rmw_fail_ret) {
-        RCUTILS_SAFE_FWRITE_TO_STDERR_WITH_FORMAT_STRING(
-          "%s, at %s:%d\n", rmw_get_error_string().str, __FILE__, __LINE__);
+        RCUTILS_SAFE_FWRITE_TO_STDERR(rmw_get_error_string().str);
+        RCUTILS_SAFE_FWRITE_TO_STDERR("\n");
       }
     }
 


### PR DESCRIPTION
Follow-up to #794.
rmw_get_error_string already formats the error with the file and line number.