### PR TITLE
Make sure to always check return values.

### DIFF
--- a/rcl_action/src/rcl_action/graph.c
+++ b/rcl_action/src/rcl_action/graph.c
@@ -122,7 +122,10 @@ _filter_action_names(
   // Cleanup if there is an error
   if (RCL_RET_OK != ret) {
     rcl_ret_t fini_ret = rcl_names_and_types_fini(action_names_and_types);
-    (void)fini_ret;  // Error already set
+    if (RCL_RET_OK != fini_ret) {
+      RCUTILS_SAFE_FWRITE_TO_STDERR(
+        "Freeing names and types failed while handling a previous error. Leaking memory!");
+    }
   }
 
   return ret;
@@ -154,6 +157,10 @@ rcl_action_get_client_names_and_types_by_node(
   rcl_ret_t nat_fini_ret = rcl_names_and_types_fini(&topic_names_and_types);
   if (RCL_RET_OK != nat_fini_ret) {
     ret = rcl_names_and_types_fini(action_names_and_types);
+    if (RCL_RET_OK != ret) {
+      RCUTILS_SAFE_FWRITE_TO_STDERR(
+        "Freeing names and types failed while handling a previous error. Leaking memory!");
+    }
     return nat_fini_ret;
   }
   return ret;
@@ -185,6 +192,11 @@ rcl_action_get_server_names_and_types_by_node(
   rcl_ret_t nat_fini_ret = rcl_names_and_types_fini(&topic_names_and_types);
   if (RCL_RET_OK != nat_fini_ret) {
     ret = rcl_names_and_types_fini(action_names_and_types);
+    if (RCL_RET_OK != ret) {
+      RCUTILS_SAFE_FWRITE_TO_STDERR(
+        "Freeing names and types failed while handling a previous error. Leaking memory!");
+    }
+
     return nat_fini_ret;
   }
   return ret;
@@ -211,6 +223,10 @@ rcl_action_get_names_and_types(
   rcl_ret_t nat_fini_ret = rcl_names_and_types_fini(&topic_names_and_types);
   if (RCL_RET_OK != nat_fini_ret) {
     ret = rcl_names_and_types_fini(action_names_and_types);
+    if (RCL_RET_OK != ret) {
+      RCUTILS_SET_ERROR_MSG(
+        "Freeing names and types failed while handling a previous error. Leaking memory!");
+    }
     return nat_fini_ret;
   }
   return ret;

--- a/rcl_action/src/rcl_action/graph.c
+++ b/rcl_action/src/rcl_action/graph.c
@@ -124,7 +124,7 @@ _filter_action_names(
     rcl_ret_t fini_ret = rcl_names_and_types_fini(action_names_and_types);
     if (RCL_RET_OK != fini_ret) {
       RCUTILS_SAFE_FWRITE_TO_STDERR(
-        "Freeing names and types failed while handling a previous error. Leaking memory!");
+        "Freeing names and types failed while handling a previous error. Leaking memory!\n");
     }
   }
 
@@ -159,7 +159,7 @@ rcl_action_get_client_names_and_types_by_node(
     ret = rcl_names_and_types_fini(action_names_and_types);
     if (RCL_RET_OK != ret) {
       RCUTILS_SAFE_FWRITE_TO_STDERR(
-        "Freeing names and types failed while handling a previous error. Leaking memory!");
+        "Freeing names and types failed while handling a previous error. Leaking memory!\n");
     }
     return nat_fini_ret;
   }
@@ -194,7 +194,7 @@ rcl_action_get_server_names_and_types_by_node(
     ret = rcl_names_and_types_fini(action_names_and_types);
     if (RCL_RET_OK != ret) {
       RCUTILS_SAFE_FWRITE_TO_STDERR(
-        "Freeing names and types failed while handling a previous error. Leaking memory!");
+        "Freeing names and types failed while handling a previous error. Leaking memory!\n");
     }
 
     return nat_fini_ret;

--- a/rcl_action/src/rcl_action/graph.c
+++ b/rcl_action/src/rcl_action/graph.c
@@ -225,7 +225,7 @@ rcl_action_get_names_and_types(
     ret = rcl_names_and_types_fini(action_names_and_types);
     if (RCL_RET_OK != ret) {
       RCUTILS_SET_ERROR_MSG(
-        "Freeing names and types failed while handling a previous error. Leaking memory!");
+        "Freeing names and types failed while handling a previous error. Leaking memory!\n");
     }
     return nat_fini_ret;
   }

--- a/rcl_lifecycle/src/rcl_lifecycle.c
+++ b/rcl_lifecycle/src/rcl_lifecycle.c
@@ -216,6 +216,10 @@ rcl_lifecycle_state_machine_init(
       // init default state machine might have allocated memory,
       // so we have to call fini
       ret = rcl_lifecycle_state_machine_fini(state_machine, node_handle, allocator);
+      if (ret != RCL_RET_OK) {
+        RCUTILS_SAFE_FWRITE_TO_STDERR(
+          "Freeing state machine failed while handling a previous error. Leaking memory!");
+      }
       return RCL_RET_ERROR;
     }
   }

--- a/rcl_lifecycle/src/rcl_lifecycle.c
+++ b/rcl_lifecycle/src/rcl_lifecycle.c
@@ -218,7 +218,7 @@ rcl_lifecycle_state_machine_init(
       ret = rcl_lifecycle_state_machine_fini(state_machine, node_handle, allocator);
       if (ret != RCL_RET_OK) {
         RCUTILS_SAFE_FWRITE_TO_STDERR(
-          "Freeing state machine failed while handling a previous error. Leaking memory!");
+          "Freeing state machine failed while handling a previous error. Leaking memory!\n");
       }
       return RCL_RET_ERROR;
     }


### PR DESCRIPTION
Pointed out by clang static analysis, we should always
check these return values.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>