### PR TITLE
Return OK when finalizing zero-initialized contexts

### DIFF
--- a/rcl/include/rcl/context.h
+++ b/rcl/include/rcl/context.h
@@ -154,8 +154,9 @@ rcl_get_zero_initialized_context(void);
 /**
  * The context to be finalized must have been previously initialized with
  * `rcl_init()`, and then later invalidated with `rcl_shutdown()`.
+ * A zero-initialized context that has not been initialized can be finalized.
  * If context is `NULL`, then `RCL_RET_INVALID_ARGUMENT` is returned.
- * If context is zero-initialized, then `RCL_RET_INVALID_ARGUMENT` is returned.
+ * If context is zero-initialized, then `RCL_RET_OK` is returned.
  * If context is initialized and valid (`rcl_shutdown()` was not called on it),
  * then `RCL_RET_INVALID_ARGUMENT` is returned.
  *

--- a/rcl/src/rcl/context.c
+++ b/rcl/src/rcl/context.c
@@ -49,8 +49,10 @@ rcl_ret_t
 rcl_context_fini(rcl_context_t * context)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(context, RCL_RET_INVALID_ARGUMENT);
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    context->impl, "context is zero-initialized", return RCL_RET_INVALID_ARGUMENT);
+  if (!context->impl) {
+    // Context is zero-initialized
+    return RCL_RET_OK;
+  }
   if (rcl_context_is_valid(context)) {
     RCL_SET_ERROR_MSG("rcl_shutdown() not called on the given context");
     return RCL_RET_INVALID_ARGUMENT;

--- a/rcl/test/rcl/test_context.cpp
+++ b/rcl/test/rcl/test_context.cpp
@@ -164,6 +164,10 @@ TEST_F(CLASSNAME(TestContextFixture, RMW_IMPLEMENTATION), bad_fini) {
   });
 
   rcl_context_t context = rcl_get_zero_initialized_context();
+
+  ret = rcl_context_fini(&context);
+  EXPECT_EQ(RCL_RET_OK, ret);
+
   ret = rcl_init(0, nullptr, &init_options, &context);
   EXPECT_EQ(RCL_RET_OK, ret);
 


### PR DESCRIPTION
Resolves #814

This is consistent behavior with finalizing other types of zero-initialized objects.