### PR TITLE
Make sure to initialize the end_mark for yaml_event_t.

### DIFF
--- a/rcl_yaml_param_parser/test/test_parse.cpp
+++ b/rcl_yaml_param_parser/test/test_parse.cpp
@@ -32,6 +32,7 @@ TEST(TestParse, parse_value) {
   yaml_event_t event;
   event.type = YAML_NO_EVENT;
   event.start_mark = {0u, 0u, 0u};
+  event.end_mark = {0u, 0u, 0u};
   event.data.scalar = {NULL, NULL, NULL, 1u, 0, 0, YAML_ANY_SCALAR_STYLE};
 
   bool is_seq = false;
@@ -120,6 +121,7 @@ TEST(TestParse, parse_value_sequence) {
   yaml_event_t event;
   event.type = YAML_NO_EVENT;
   event.start_mark = {0u, 0u, 0u};
+  event.end_mark = {0u, 0u, 0u};
   event.data.scalar = {NULL, NULL, NULL, 1u, 0, 0, YAML_ANY_SCALAR_STYLE};
 
   bool is_seq = true;
@@ -280,6 +282,7 @@ TEST(TestParse, parse_value_bad_args) {
   yaml_event_t event;
   event.type = YAML_NO_EVENT;
   event.start_mark = {0u, 0u, 0u};
+  event.end_mark = {0u, 0u, 0u};
   event.data.scalar = {NULL, NULL, NULL, 1u, 0, 0, YAML_ANY_SCALAR_STYLE};
 
   bool is_seq = false;
@@ -356,6 +359,7 @@ TEST(TestParse, parse_key_bad_args)
   yaml_event_t event;
   event.type = YAML_NO_EVENT;
   event.start_mark = {0u, 0u, 0u};
+  event.end_mark = {0u, 0u, 0u};
 
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
   uint32_t map_level = MAP_NODE_NAME_LVL;


### PR DESCRIPTION
This just clears out some warnings from clang static analysis.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>