### PR TITLE
Clarify storing of current_time.

### DIFF
--- a/rcl/src/rcl/time.c
+++ b/rcl/src/rcl/time.c
@@ -370,10 +370,10 @@ rcl_set_ros_time_override(
     }
     time_jump.delta.nanoseconds = time_value - current_time;
     rcl_clock_call_callbacks(clock, &time_jump, true);
-  }
-  rcutils_atomic_store(&(storage->current_time), time_value);
-  if (storage->active) {
+    rcutils_atomic_store(&(storage->current_time), time_value);
     rcl_clock_call_callbacks(clock, &time_jump, false);
+  } else {
+    rcutils_atomic_store(&(storage->current_time), time_value);
   }
   return RCL_RET_OK;
 }


### PR DESCRIPTION
clang static analysis (incorrectly) assumes that the value
of "storage->active" can change between the first and second
branch statements.  While we know that isn't actually true,
it is more clear and the same amount of code to just have
the branch once.  Rearrange the code here so that we collapse
all of the storage->active parts into one if block.

There should be no functional change with this.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>