### PR TITLE
Allow forward slashes within a parameter name rule in argument parsing

### DIFF
--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -149,10 +149,14 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), check_known_vs_unkno
   EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "rostopic:///rosservice:=rostopic"}));
   EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "rostopic:///foo/bar:=baz"}));
   EXPECT_TRUE(are_known_ros_args({"--ros-args", "-p", "foo:=bar"}));
+  // TODO(ivanpauno): Currently, we're accepting `/`, as they're being accepted by qos overrides.
+  //                  We might need to revisit qos overrides parameters names if ROS 2 URIs get
+  //                  modified.
+  EXPECT_TRUE(are_known_ros_args(
+    {"--ros-args", "-p", "qos_overrides./foo/bar.publisher.history:=keep_last"}));
   // TODO(hidmic): restore tests (and drop the following ones) when parameter names
   //               are standardized to use slashes in lieu of dots.
   // EXPECT_TRUE(are_known_ros_args({"--ros-args", "-p", "~/foo:=~/bar"}));
-  // EXPECT_TRUE(are_known_ros_args({"--ros-args", "-p", "/foo/bar:=bar"}));
   // EXPECT_TRUE(are_known_ros_args({"--ros-args", "-p", "foo:=/bar"}));
   // EXPECT_TRUE(are_known_ros_args({"--ros-args", "-p", "/foo123:=/bar123"}));
   EXPECT_TRUE(are_known_ros_args({"--ros-args", "-p", "foo.bar:=bar"}));

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -152,8 +152,9 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), check_known_vs_unkno
   // TODO(ivanpauno): Currently, we're accepting `/`, as they're being accepted by qos overrides.
   //                  We might need to revisit qos overrides parameters names if ROS 2 URIs get
   //                  modified.
-  EXPECT_TRUE(are_known_ros_args(
-    {"--ros-args", "-p", "qos_overrides./foo/bar.publisher.history:=keep_last"}));
+  EXPECT_TRUE(
+    are_known_ros_args(
+      {"--ros-args", "-p", "qos_overrides./foo/bar.publisher.history:=keep_last"}));
   // TODO(hidmic): restore tests (and drop the following ones) when parameter names
   //               are standardized to use slashes in lieu of dots.
   // EXPECT_TRUE(are_known_ros_args({"--ros-args", "-p", "~/foo:=~/bar"}));


### PR DESCRIPTION
While implementing a demo for https://github.com/ros2/design/pull/300, https://github.com/ros2/rclcpp/pull/1408, I found that though parameter names containing forward slashes are valid and you can set them from a parameter file, you cannot set them with a command line parameter rule.

e.g.:
```
ros2 run quality_of_service_demo_cpp qos_overrides_listener --ros-args -p qos_overrides./qos_overrides_chatter.subscription.depth:=11
```
doesn't work without this PR while
```yaml
qos_overrides_listener:  # node name
  ros__parameters:  # All parameters are nested in this key
    qos_overrides:  # Parameter group for all qos overrides
      /qos_overrides_chatter:  # Parameter group for the topic
        subscription:  # Profile for subscriptions in the topic
        # subscription_custom_identifier:  # Subscription with override id="custom_identifier"
          reliability: reliable
          depth: 11
```

does work.