### PR TITLE
rcl_yaml_param_parser: Rearrange test logic to avoid refererence to null

### DIFF
--- a/rcl_yaml_param_parser/test/test_parse_yaml.cpp
+++ b/rcl_yaml_param_parser/test/test_parse_yaml.cpp
@@ -80,11 +80,14 @@ TEST(test_parser, correct_syntax) {
     rcl_variant_t * param_value = rcl_yaml_node_struct_get("lidar_ns/lidar_2", "is_back", params);
     ASSERT_TRUE(NULL != param_value) << rcutils_get_error_string().str;
     ASSERT_TRUE(NULL != param_value->bool_value);
-    EXPECT_TRUE(*param_value->bool_value);
+    // Assigning to local to avoid clang analysis warning "Forming reference to null pointer"
+    bool bool_value = *param_value->bool_value;
+    EXPECT_TRUE(bool_value);
     res = rcl_parse_yaml_value("lidar_ns/lidar_2", "is_back", "false", params);
     EXPECT_TRUE(res) << rcutils_get_error_string().str;
     ASSERT_TRUE(NULL != param_value->bool_value);
-    EXPECT_FALSE(*param_value->bool_value);
+    bool_value = *param_value->bool_value;
+    EXPECT_FALSE(bool_value);
 
     param_value = rcl_yaml_node_struct_get("lidar_ns/lidar_2", "id", params);
     ASSERT_TRUE(NULL != param_value) << rcutils_get_error_string().str;


### PR DESCRIPTION
This is another theoretical issue flagged by scan-build. I don't think it's actually practically possible given the null checks above it. I suspect the issue is that `EXPECT_TRUE` captures its arguments by reference.


```
/home/brawner/workspace/ros2_master/src/ros2/rcl/rcl_yaml_param_parser/test/test_parse_yaml.cpp:83:5: warning: Forming reference to null pointer
    EXPECT_TRUE(*param_value->bool_value);
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/brawner/workspace/ros2_master/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:1969:3: note: expanded from macro 'EXPECT_TRUE'
  GTEST_TEST_BOOLEAN_(condition, #condition, false, true, \
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/brawner/workspace/ros2_master/install/gtest_vendor/src/gtest_vendor/include/gtest/internal/gtest-internal.h:1325:7: note: expanded from macro 'GTEST_TEST_BOOLEAN_'
      ::testing::AssertionResult(expression)) \
      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```

Signed-off-by: Stephen Brawner <brawner@gmail.com>