### PR TITLE
Address clang static analysis issues

### DIFF
--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -119,7 +119,6 @@ rcl_publisher_init(
     &publisher->impl->actual_qos);
   if (RMW_RET_OK != rmw_ret) {
     RCL_SET_ERROR_MSG(rmw_get_error_string().str);
-    ret = RCL_RET_ERROR;
     goto fail;
   }
   publisher->impl->actual_qos.avoid_ros_namespace_conventions =

--- a/rcl/src/rcl/remap.c
+++ b/rcl/src/rcl/remap.c
@@ -298,6 +298,7 @@ rcl_remap_node_name(
   RCUTILS_CAN_SET_MSG_AND_RETURN_WITH_ERROR_OF(RCL_RET_BAD_ALLOC);
   RCUTILS_CAN_SET_MSG_AND_RETURN_WITH_ERROR_OF(RCL_RET_ERROR);
 
+  RCL_CHECK_ARGUMENT_FOR_NULL(node_name, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "allocator is invalid", return RCL_RET_INVALID_ARGUMENT);
   return rcl_remap_name(
     local_arguments, global_arguments, RCL_NODENAME_REMAP, NULL, node_name, NULL, NULL,
@@ -317,6 +318,7 @@ rcl_remap_node_namespace(
   RCUTILS_CAN_SET_MSG_AND_RETURN_WITH_ERROR_OF(RCL_RET_BAD_ALLOC);
   RCUTILS_CAN_SET_MSG_AND_RETURN_WITH_ERROR_OF(RCL_RET_ERROR);
 
+  RCL_CHECK_ARGUMENT_FOR_NULL(node_name, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ALLOCATOR_WITH_MSG(&allocator, "allocator is invalid", return RCL_RET_INVALID_ARGUMENT);
   return rcl_remap_name(
     local_arguments, global_arguments, RCL_NAMESPACE_REMAP, NULL, node_name, NULL, NULL,

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -111,7 +111,6 @@ rcl_subscription_init(
     &subscription->impl->actual_qos);
   if (RMW_RET_OK != rmw_ret) {
     RCL_SET_ERROR_MSG(rmw_get_error_string().str);
-    ret = RCL_RET_ERROR;
     goto fail;
   }
   subscription->impl->actual_qos.avoid_ros_namespace_conventions =

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -1021,9 +1021,12 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_
   ASSERT_TRUE(NULL != param_value->bool_array_value);
   ASSERT_TRUE(NULL != param_value->bool_array_value->values);
   ASSERT_EQ(3U, param_value->bool_array_value->size);
-  EXPECT_TRUE(param_value->bool_array_value->values[0]);
-  EXPECT_FALSE(param_value->bool_array_value->values[1]);
-  EXPECT_FALSE(param_value->bool_array_value->values[2]);
+  bool bool_value = param_value->bool_array_value->values[0];
+  EXPECT_TRUE(bool_value);
+  bool_value = param_value->bool_array_value->values[1];
+  EXPECT_FALSE(bool_value);
+  bool_value = param_value->bool_array_value->values[2];
+  EXPECT_FALSE(bool_value);
 }
 
 TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_arguments_copy) {
@@ -1135,7 +1138,8 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_overrides
   param_value = rcl_yaml_node_struct_get("/**", "some.bool_param", params);
   ASSERT_TRUE(NULL != param_value);
   ASSERT_TRUE(NULL != param_value->bool_value);
-  EXPECT_FALSE(*(param_value->bool_value));
+  bool bool_value = *param_value->bool_value;
+  EXPECT_FALSE(bool_value);
 
   param_value = rcl_yaml_node_struct_get("some_node", "int_param", params);
   ASSERT_TRUE(NULL != param_value);


### PR DESCRIPTION
This addresses several issues found by clang static analysis. I'll add a couple of inline comments explaining what was happening. After this PR, `rcl` should pass scan-build without issue.

Signed-off-by: Stephen Brawner <brawner@gmail.com>