### PR TITLE
Update build.ros2.org links

### DIFF
--- a/rcl_action/QUALITY_DECLARATION.md
+++ b/rcl_action/QUALITY_DECLARATION.md
@@ -72,7 +72,7 @@ The license for `rcl_action` is Apache 2.0, and a summary is in each source file
 
 There is an automated test which runs a linter that ensures each file has a license statement.
 
-The most recent test results can be found [here](http://build.ros2.org/view/Fpr/job/Fpr__rcl_action__ubuntu_focal_amd64/lastCompletedBuild/testReport/rcl_action).
+The most recent test results can be found [here](http://build.ros2.org/view/Fpr/job/Fpr__rcl__ubuntu_focal_amd64/lastCompletedBuild/testReport/rcl_action).
 
 ### Copyright Statements [3.iv]
 
@@ -80,7 +80,7 @@ The copyright holders each provide a statement of copyright in each source code 
 
 There is an automated test which runs a linter that ensures each file has at least one copyright statement.
 
-The results of the test can be found [here](http://build.ros2.org/view/Fpr/job/Fpr__rcl_action__ubuntu_focal_amd64/lastCompletedBuild/testReport/rcl_action/copyright/).
+The results of the test can be found [here](http://build.ros2.org/view/Fpr/job/Fpr__rcl__ubuntu_focal_amd64/lastCompletedBuild/testReport/rcl_action/copyright/).
 
 ## Testing [4]
 
@@ -126,7 +126,7 @@ Changes that introduce regressions in performance must be adequately justified i
 
 `rcl_action` uses and passes all the standard linters and static analysis tools for a C package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
 
-Results of the nightly linter tests can be found [here](http://build.ros2.org/view/Fpr/job/Fpr__rcl_action__ubuntu_focal_amd64/lastCompletedBuild/testReport/rcl_action).
+Results of the nightly linter tests can be found [here](http://build.ros2.org/view/Fpr/job/Fpr__rcl__ubuntu_focal_amd64/lastCompletedBuild/testReport/rcl_action).
 
 ## Dependencies [5]
 

--- a/rcl_lifecycle/QUALITY_DECLARATION.md
+++ b/rcl_lifecycle/QUALITY_DECLARATION.md
@@ -72,7 +72,7 @@ The license for `rcl_lifecycle` is Apache 2.0, and a summary is in each source f
 
 There is an automated test which runs a linter that ensures each file has a license statement.
 
-The most recent test results can be found [here](http://build.ros2.org/view/Fpr/job/Fpr__rcl_lifecycle__ubuntu_focal_amd64/lastCompletedBuild/testReport/rcl_lifecycle).
+The most recent test results can be found [here](http://build.ros2.org/view/Fpr/job/Fpr__rcl__ubuntu_focal_amd64/lastCompletedBuild/testReport/rcl_lifecycle).
 
 ### Copyright Statements [3.iv]
 
@@ -80,7 +80,7 @@ The copyright holders each provide a statement of copyright in each source code 
 
 There is an automated test which runs a linter that ensures each file has at least one copyright statement.
 
-The results of the test can be found [here](http://build.ros2.org/view/Fpr/job/Fpr__rcl_lifecycle__ubuntu_focal_amd64/lastCompletedBuild/testReport/rcl_lifecycle).
+The results of the test can be found [here](http://build.ros2.org/view/Fpr/job/Fpr__rcl__ubuntu_focal_amd64/lastCompletedBuild/testReport/rcl_lifecycle).
 
 ## Testing [4]
 
@@ -126,7 +126,7 @@ Changes that introduce regressions in performance must be adequately justified i
 
 `rcl_lifecycle` uses and passes all the standard linters and static analysis tools for a C package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
 
-Results of the nightly linter tests can be found [here](http://build.ros2.org/view/Fpr/job/Fpr__rcl_lifecycle__ubuntu_focal_amd64/lastCompletedBuild/testReport/rcl_lifecycle).
+Results of the nightly linter tests can be found [here](http://build.ros2.org/view/Fpr/job/Fpr__rcl__ubuntu_focal_amd64/lastCompletedBuild/testReport/rcl_lifecycle).
 
 ## Dependencies [5]
 

--- a/rcl_yaml_param_parser/QUALITY_DECLARATION.md
+++ b/rcl_yaml_param_parser/QUALITY_DECLARATION.md
@@ -73,7 +73,7 @@ The license for `rcl_yaml_param_parser` is Apache 2.0, and a summary is in each 
 
 There is an automated test which runs a linter that ensures each file has a license statement.
 
-The most recent test results can be found [here](http://build.ros2.org/view/Fpr/job/Fpr__rcl_yaml_param_parser__ubuntu_focal_amd64/lastCompletedBuild/testReport/rcl_yaml_param_parser).
+The most recent test results can be found [here](http://build.ros2.org/view/Fpr/job/Fpr__rcl__ubuntu_focal_amd64/lastCompletedBuild/testReport/rcl_yaml_param_parser).
 
 ### Copyright Statements [3.iv]
 
@@ -81,7 +81,7 @@ The copyright holders each provide a statement of copyright in each source code 
 
 There is an automated test which runs a linter that ensures each file has at least one copyright statement.
 
-The results of the test can be found [here](http://build.ros2.org/view/Fpr/job/Fpr__rcl_yaml_param_parser__ubuntu_focal_amd64/lastCompletedBuild/testReport/rcl_yaml_param_parser/copyright/).
+The results of the test can be found [here](http://build.ros2.org/view/Fpr/job/Fpr__rcl__ubuntu_focal_amd64/lastCompletedBuild/testReport/rcl_yaml_param_parser/copyright/).
 
 ## Testing [4]
 
@@ -128,7 +128,7 @@ Changes that introduce regressions in performance must be adequately justified i
 
 `rcl_yaml_param_parser` uses and passes all the standard linters and static analysis tools for a C package as described in the [ROS 2 Developer Guide](https://index.ros.org/doc/ros2/Contributing/Developer-Guide/#linters).
 
-Results of the nightly linter tests can be found [here](http://build.ros2.org/view/Fpr/job/Fpr__rcl_yaml_param_parser__ubuntu_focal_amd64/lastCompletedBuild/testReport/rcl_yaml_param_parser).
+Results of the nightly linter tests can be found [here](http://build.ros2.org/view/Fpr/job/Fpr__rcl__ubuntu_focal_amd64/lastCompletedBuild/testReport/rcl_yaml_param_parser).
 
 ## Dependencies [5]
 


### PR DESCRIPTION
I think I made this mistake in a couple of places. Checking over things

@nuclearsandwich Without build.ros2.org, can you confirm?

Signed-off-by: Stephen Brawner <brawner@gmail.com>