### PR TITLE
Add const to constant rcl_context functions

### DIFF
--- a/rcl/include/rcl/context.h
+++ b/rcl/include/rcl/context.h
@@ -239,7 +239,7 @@ rcl_context_get_init_options(const rcl_context_t * context);
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_context_instance_id_t
-rcl_context_get_instance_id(rcl_context_t * context);
+rcl_context_get_instance_id(const rcl_context_t * context);
 
 /// Returns the context domain id.
 /**

--- a/rcl/include/rcl/context.h
+++ b/rcl/include/rcl/context.h
@@ -287,7 +287,7 @@ rcl_context_get_domain_id(rcl_context_t * context, size_t * domain_id);
 RCL_PUBLIC
 RCL_WARN_UNUSED
 bool
-rcl_context_is_valid(rcl_context_t * context);
+rcl_context_is_valid(const rcl_context_t * context);
 
 /// Return pointer to the rmw context if the given context is currently valid, otherwise `NULL`.
 /**

--- a/rcl/src/rcl/context.c
+++ b/rcl/src/rcl/context.c
@@ -73,7 +73,7 @@ rcl_context_get_init_options(const rcl_context_t * context)
 }
 
 rcl_context_instance_id_t
-rcl_context_get_instance_id(rcl_context_t * context)
+rcl_context_get_instance_id(const rcl_context_t * context)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(context, 0);
   return rcutils_atomic_load_uint64_t((atomic_uint_least64_t *)(&context->instance_id_storage));

--- a/rcl/src/rcl/context.c
+++ b/rcl/src/rcl/context.c
@@ -91,7 +91,7 @@ rcl_context_get_domain_id(rcl_context_t * context, size_t * domain_id)
 }
 
 bool
-rcl_context_is_valid(rcl_context_t * context)
+rcl_context_is_valid(const rcl_context_t * context)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(context, false);
   return 0 != rcl_context_get_instance_id(context);


### PR DESCRIPTION
This pull request adds the `const` keyword to two functions in [rcl/include/rcl/context.h](rcl/include/rcl/context.h) and [rcl/include/rcl/context.c](rcl/include/rcl/context.c).

This change allows automated tools such as [rust-bindgen](https://github.com/rust-lang/rust-bindgen) to generate FFI bindings that have stricter mutability properties for bindings of `rcl_context_is_valid()` and `rcl_context_get_instance_id()`.