### PR TITLE
Enable EXTRACT_ALL in Doxyfile to display documentation

### DIFF
--- a/rcl/Doxyfile
+++ b/rcl/Doxyfile
@@ -17,6 +17,7 @@ MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES
 PREDEFINED             += RCL_PUBLIC=
 PREDEFINED             += RCL_WARN_UNUSED=
+EXTRACT_ALL            = YES
 
 # Uncomment to generate internal documentation.
 ENABLED_SECTIONS       = INTERNAL

--- a/rcl_action/Doxyfile
+++ b/rcl_action/Doxyfile
@@ -17,6 +17,7 @@ MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES
 PREDEFINED             += RCL_PUBLIC=
 PREDEFINED             += RCL_WARN_UNUSED=
+EXTRACT_ALL            = YES
 
 # Uncomment to generate internal documentation.
 ENABLED_SECTIONS       = INTERNAL

--- a/rcl_lifecycle/Doxyfile
+++ b/rcl_lifecycle/Doxyfile
@@ -16,6 +16,7 @@ ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES
 PREDEFINED             += RCL_LIFECYCLE_PUBLIC=
+EXTRACT_ALL            = YES
 
 # Tag files that do not exist will produce a warning and cross-project linking will not work.
 TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"

--- a/rcl_yaml_param_parser/Doxyfile
+++ b/rcl_yaml_param_parser/Doxyfile
@@ -17,6 +17,7 @@ ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES
 PREDEFINED             += RCL_YAML_PARAM_PARSER_PUBLIC=
+EXTRACT_ALL            = YES
 
 # Tag files that do not exist will produce a warning and cross-project linking will not work.
 TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"


### PR DESCRIPTION
Currently, the documentation on https://docs.ros2.org/latest/api/rcl/index.html does not display anything besides the contents of the header file. This change was introduced in https://github.com/ros2/rcl/pull/712. This makes it difficult to use the documentation at all, because all information regarding how a function should be used is not displayed.

This change enables the previously removed EXTRACT_ALL to restore the documentation to its intended state.