### PR TITLE
[dashing] Fix rcl_action test_graph (#504)

### DIFF
--- a/rcl_action/test/rcl_action/test_graph.cpp
+++ b/rcl_action/test/rcl_action/test_graph.cpp
@@ -131,12 +131,12 @@ TEST_F(
   // Invalid node name
   ret = rcl_action_get_client_names_and_types_by_node(
     &this->node, &this->allocator, "_!test_this_is_not_a_valid_name", "", &nat);
-  EXPECT_EQ(RCL_RET_NODE_INVALID_NAME, ret) << rcl_get_error_string().str;
+  EXPECT_EQ(RCL_RET_ERROR, ret) << rcl_get_error_string().str;
   rcl_reset_error();
   // Non-existent node
   ret = rcl_action_get_client_names_and_types_by_node(
     &this->node, &this->allocator, this->test_graph_unknown_node_name, "", &nat);
-  EXPECT_EQ(RCL_RET_NODE_NAME_NON_EXISTENT, ret) << rcl_get_error_string().str;
+  EXPECT_EQ(RCL_RET_ERROR, ret) << rcl_get_error_string().str;
   rcl_reset_error();
   // Invalid names and types
   ret = rcl_action_get_client_names_and_types_by_node(
@@ -184,12 +184,12 @@ TEST_F(
   // Invalid node name
   ret = rcl_action_get_server_names_and_types_by_node(
     &this->node, &this->allocator, "_!test_this_is_not_a_valid_name", "", &nat);
-  EXPECT_EQ(RCL_RET_NODE_INVALID_NAME, ret) << rcl_get_error_string().str;
+  EXPECT_EQ(RCL_RET_ERROR, ret) << rcl_get_error_string().str;
   rcl_reset_error();
   // Non-existent node
   ret = rcl_action_get_server_names_and_types_by_node(
     &this->node, &this->allocator, this->test_graph_unknown_node_name, "", &nat);
-  EXPECT_EQ(RCL_RET_NODE_NAME_NON_EXISTENT, ret) << rcl_get_error_string().str;
+  EXPECT_EQ(RCL_RET_ERROR, ret) << rcl_get_error_string().str;
   rcl_reset_error();
   // Invalid names and types
   ret = rcl_action_get_server_names_and_types_by_node(

--- a/rcl_action/test/rcl_action/test_graph.cpp
+++ b/rcl_action/test/rcl_action/test_graph.cpp
@@ -36,9 +36,6 @@
 # define CLASSNAME(NAME, SUFFIX) NAME
 #endif
 
-const bool is_opensplice =
-  std::string(rmw_get_implementation_identifier()).find("rmw_opensplice") == 0;
-
 class CLASSNAME (TestActionGraphFixture, RMW_IMPLEMENTATION) : public ::testing::Test
 {
 public:
@@ -51,6 +48,7 @@ public:
   rcl_node_t zero_node;
   const char * test_graph_node_name = "test_action_graph_node";
   const char * test_graph_old_node_name = "test_action_graph_old_node_name";
+  const char * test_graph_unknown_node_name = "test_action_graph_unknown_node_name";
 
   void SetUp()
   {
@@ -132,17 +130,14 @@ TEST_F(
   rcl_reset_error();
   // Invalid node name
   ret = rcl_action_get_client_names_and_types_by_node(
-    &this->node, &this->allocator, "_test_this_Isnot_a_valid_name", "", &nat);
-  EXPECT_EQ(RCL_RET_ERROR, ret) << rcl_get_error_string().str;
+    &this->node, &this->allocator, "_!test_this_is_not_a_valid_name", "", &nat);
+  EXPECT_EQ(RCL_RET_NODE_INVALID_NAME, ret) << rcl_get_error_string().str;
   rcl_reset_error();
   // Non-existent node
-  // Note, Opensplice successfully reports graph information about finalized nodes
-  if (!is_opensplice) {
-    ret = rcl_action_get_client_names_and_types_by_node(
-      &this->node, &this->allocator, this->test_graph_old_node_name, "", &nat);
-    EXPECT_EQ(RCL_RET_ERROR, ret) << rcl_get_error_string().str;
-    rcl_reset_error();
-  }
+  ret = rcl_action_get_client_names_and_types_by_node(
+    &this->node, &this->allocator, this->test_graph_unknown_node_name, "", &nat);
+  EXPECT_EQ(RCL_RET_NODE_NAME_NON_EXISTENT, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
   // Invalid names and types
   ret = rcl_action_get_client_names_and_types_by_node(
     &this->node, &this->allocator, this->test_graph_node_name, "", nullptr);
@@ -188,17 +183,14 @@ TEST_F(
   rcl_reset_error();
   // Invalid node name
   ret = rcl_action_get_server_names_and_types_by_node(
-    &this->node, &this->allocator, "_test_this_Isnot_a_valid_name", "", &nat);
-  EXPECT_EQ(RCL_RET_ERROR, ret) << rcl_get_error_string().str;
+    &this->node, &this->allocator, "_!test_this_is_not_a_valid_name", "", &nat);
+  EXPECT_EQ(RCL_RET_NODE_INVALID_NAME, ret) << rcl_get_error_string().str;
   rcl_reset_error();
   // Non-existent node
-  // Note, Opensplice successfully reports graph information about finalized nodes
-  if (!is_opensplice) {
-    ret = rcl_action_get_server_names_and_types_by_node(
-      &this->node, &this->allocator, this->test_graph_old_node_name, "", &nat);
-    EXPECT_EQ(RCL_RET_ERROR, ret) << rcl_get_error_string().str;
-    rcl_reset_error();
-  }
+  ret = rcl_action_get_server_names_and_types_by_node(
+    &this->node, &this->allocator, this->test_graph_unknown_node_name, "", &nat);
+  EXPECT_EQ(RCL_RET_NODE_NAME_NON_EXISTENT, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
   // Invalid names and types
   ret = rcl_action_get_server_names_and_types_by_node(
     &this->node, &this->allocator, this->test_graph_node_name, "", nullptr);


### PR DESCRIPTION
Backport #504 to Dashing.

I hoping this will clear up some similar test failures occurring in Dashing, e.g.:

- https://build.ros2.org/job/Dci__nightly-fastrtps-dynamic_ubuntu_bionic_amd64/444/testReport/
- https://build.ros2.org/job/Dci__nightly-release_ubuntu_bionic_amd64/448/testReport/