### PR TITLE
Avoid setting error message twice.

### DIFF
--- a/rcl_action/src/rcl_action/action_client.c
+++ b/rcl_action/src/rcl_action/action_client.c
@@ -32,6 +32,7 @@ extern "C"
 #include "rcl/types.h"
 #include "rcl/wait.h"
 
+#include "rcutils/error_handling.h"
 #include "rcutils/logging_macros.h"
 #include "rcutils/strdup.h"
 
@@ -98,12 +99,16 @@ _rcl_action_client_fini_impl(
   return ret;
 }
 
+// \internal Add a comment inside macro
+#define COMMENT_IN_MACRO(ignored)
+
 // \internal Initializes an action client specific service client.
 #define CLIENT_INIT(Type) \
   char * Type ## _service_name = NULL; \
   ret = rcl_action_get_ ## Type ## _service_name(action_name, allocator, &Type ## _service_name); \
   if (RCL_RET_OK != ret) { \
-    RCL_SET_ERROR_MSG("failed to get " #Type " service name"); \
+    COMMENT_IN_MACRO("error already set") \
+    RCUTILS_SAFE_FWRITE_TO_STDERR("failed to get " #Type " service name\n"); \
     if (RCL_RET_BAD_ALLOC == ret) { \
       ret = RCL_RET_BAD_ALLOC; \
     } else { \
@@ -138,7 +143,8 @@ _rcl_action_client_fini_impl(
   char * Type ## _topic_name = NULL; \
   ret = rcl_action_get_ ## Type ## _topic_name(action_name, allocator, &Type ## _topic_name); \
   if (RCL_RET_OK != ret) { \
-    RCL_SET_ERROR_MSG("failed to get " #Type " topic name"); \
+    COMMENT_IN_MACRO("error already set") \
+    RCUTILS_SAFE_FWRITE_TO_STDERR("failed to get " #Type " topic name\n"); \
     if (RCL_RET_BAD_ALLOC == ret) { \
       ret = RCL_RET_BAD_ALLOC; \
     } else { \

--- a/rcl_action/src/rcl_action/action_client.c
+++ b/rcl_action/src/rcl_action/action_client.c
@@ -32,7 +32,6 @@ extern "C"
 #include "rcl/types.h"
 #include "rcl/wait.h"
 
-#include "rcutils/error_handling.h"
 #include "rcutils/logging_macros.h"
 #include "rcutils/strdup.h"
 
@@ -99,16 +98,13 @@ _rcl_action_client_fini_impl(
   return ret;
 }
 
-// \internal Add a comment inside macro
-#define COMMENT_IN_MACRO(ignored)
-
 // \internal Initializes an action client specific service client.
 #define CLIENT_INIT(Type) \
   char * Type ## _service_name = NULL; \
   ret = rcl_action_get_ ## Type ## _service_name(action_name, allocator, &Type ## _service_name); \
   if (RCL_RET_OK != ret) { \
-    COMMENT_IN_MACRO("error already set") \
-    RCUTILS_SAFE_FWRITE_TO_STDERR("failed to get " #Type " service name\n"); \
+    rcl_reset_error(); \
+    RCL_SET_ERROR_MSG("failed to get " #Type " service name"); \
     if (RCL_RET_BAD_ALLOC == ret) { \
       ret = RCL_RET_BAD_ALLOC; \
     } else { \
@@ -143,8 +139,8 @@ _rcl_action_client_fini_impl(
   char * Type ## _topic_name = NULL; \
   ret = rcl_action_get_ ## Type ## _topic_name(action_name, allocator, &Type ## _topic_name); \
   if (RCL_RET_OK != ret) { \
-    COMMENT_IN_MACRO("error already set") \
-    RCUTILS_SAFE_FWRITE_TO_STDERR("failed to get " #Type " topic name\n"); \
+    rcl_reset_error(); \
+    RCL_SET_ERROR_MSG("failed to get " #Type " topic name"); \
     if (RCL_RET_BAD_ALLOC == ret) { \
       ret = RCL_RET_BAD_ALLOC; \
     } else { \


### PR DESCRIPTION
Just a minor fix.

```
$ ./build/rcl_action/test_action_client
...

>>> [rcutils|error_handling.c:108] rcutils_set_error_state()
This error state is being overwritten:

  'failed to allocate memory for action goal service name, at /home/chenlh/Projects/ROS2/ros2-master/src/ros2/rcl/rcl_action/src/rcl_action/names.c:46'

with this new error message:

  'failed to get goal service name, at /home/chenlh/Projects/ROS2/ros2-master/src/ros2/rcl/rcl_action/src/rcl_action/action_client.c:215'

rcutils_reset_error() should be called after error handling to avoid this.
...
```

There exist two methods to fix,

1. call `rcl_reset_error();` before `RCL_SET_ERROR_MSG`. (the old error message LOST)
2. use `RCUTILS_SAFE_FWRITE_TO_STDERR` instead of `RCL_SET_ERROR_MSG` if error already set. (Current PR)

Signed-off-by: Chen Lihui <Lihui.Chen@sony.com>