### PR TITLE
Change destruction behaviour

### DIFF
--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -183,7 +183,7 @@ rcl_publisher_fini(rcl_publisher_t * publisher, rcl_node_t * node)
       rmw_destroy_publisher(rmw_node, publisher->impl->rmw_handle);
     if (ret != RMW_RET_OK) {
       RCL_SET_ERROR_MSG(rmw_get_error_string().str);
-      result = RCL_RET_ERROR;
+      return RCL_RET_ERROR;
     }
     allocator.deallocate(publisher->impl, allocator.state);
     publisher->impl = NULL;

--- a/rcl/test/rcl/test_publisher.cpp
+++ b/rcl/test/rcl/test_publisher.cpp
@@ -820,8 +820,13 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_mock_publisher_
     &publisher, this->node_ptr, ts, topic_name, &publisher_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
-  // Internal rmw failure destroying publisher
-  auto mock = mocking_utils::patch_and_return("lib:rcl", rmw_destroy_publisher, RMW_RET_ERROR);
+  {
+    // Internal rmw failure destroying publisher
+    auto mock = mocking_utils::patch_and_return("lib:rcl", rmw_destroy_publisher, RMW_RET_ERROR);
+    ret = rcl_publisher_fini(&publisher, this->node_ptr);
+    EXPECT_EQ(RCL_RET_ERROR, ret) << rcl_get_error_string().str;
+  }
+
   ret = rcl_publisher_fini(&publisher, this->node_ptr);
-  EXPECT_EQ(RCL_RET_ERROR, ret) << rcl_get_error_string().str;
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 }


### PR DESCRIPTION
Change RCL Entities destruction behavior in failure.

RCL Entities do not stop the destruction when a failure occurs (it could happen because they destroy lower entities during the process).
With this approach the destruction will stop before deallocate the entity memory and return an error in case the lower entity (rmw) fails in destruction.

NOTE: This is a first approach to show a possible design.


Signed-off-by: jparisu <javierparis@eprosima.com>