### PR TITLE
Add support for rmw_connextdds

### DIFF
--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -73,12 +73,20 @@ function(test_target_function)
     AMENT_DEPENDENCIES ${rmw_implementation}
   )
 
+  # TODO(asorbini): Remove these exceptions once ros2/rmw_connext is deprecated.
+  set(AMENT_GTEST_ARGS "")
+  if(rmw_implementation MATCHES "rmw_connext(.*)_cpp")
+    message(STATUS "Skipping test_timer${target_suffix} test.")
+    set(AMENT_GTEST_ARGS "SKIP_TEST")
+  endif()
+
   rcl_add_custom_gtest(test_timer${target_suffix}
     SRCS rcl/test_timer.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
     AMENT_DEPENDENCIES ${rmw_implementation}
+    ${AMENT_GTEST_ARGS}
   )
 
   rcl_add_custom_gtest(test_context${target_suffix}
@@ -113,6 +121,16 @@ function(test_target_function)
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp"
   )
 
+  # TODO(asorbini): Remove these exceptions once ros2/rmw_connext is deprecated.
+  set(AMENT_GTEST_ARGS "")
+  if(rmw_implementation STREQUAL "rmw_connext_dynamic_cpp")
+    message(STATUS "Skipping test_graph${target_suffix} test.")
+    set(AMENT_GTEST_ARGS "SKIP_TEST")
+  elseif(rmw_implementation STREQUAL "rmw_connext_cpp")
+    message(STATUS "Increasing test_graph${target_suffix} test timeout.")
+    set(AMENT_GTEST_ARGS TIMEOUT 180)
+  endif()
+
   rcl_add_custom_gtest(test_graph${target_suffix}
     SRCS rcl/test_graph.cpp
     ENV ${rmw_implementation_env_var}
@@ -120,7 +138,15 @@ function(test_target_function)
     LIBRARIES ${PROJECT_NAME}
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
     TIMEOUT 120
+    ${AMENT_GTEST_ARGS}
   )
+
+  # TODO(asorbini): Remove these exceptions once ros2/rmw_connext is deprecated.
+  set(AMENT_GTEST_ARGS "")
+  if(rmw_implementation MATCHES "rmw_connext(.*)_cpp")
+    message(STATUS "Increasing test_info_by_topic${target_suffix} test timeout.")
+    set(AMENT_GTEST_ARGS TIMEOUT 120)
+  endif()
 
   rcl_add_custom_gtest(test_info_by_topic${target_suffix}
     SRCS rcl/test_info_by_topic.cpp rcl/wait_for_entity_helpers.cpp

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -73,21 +73,12 @@ function(test_target_function)
     AMENT_DEPENDENCIES ${rmw_implementation}
   )
 
-  # TODO(hidmic): re-enable timer tests against RTI Connext once
-  #               https://github.com/ros2/rcl/issues/687 is resolved
-  set(AMENT_GTEST_ARGS "")
-  if(rmw_implementation STREQUAL "rmw_connext_cpp")
-    message(STATUS "Skipping test_timer${target_suffix} test.")
-    set(AMENT_GTEST_ARGS "SKIP_TEST")
-  endif()
-
   rcl_add_custom_gtest(test_timer${target_suffix}
     SRCS rcl/test_timer.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
     AMENT_DEPENDENCIES ${rmw_implementation}
-    ${AMENT_GTEST_ARGS}
   )
 
   rcl_add_custom_gtest(test_context${target_suffix}
@@ -122,16 +113,6 @@ function(test_target_function)
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp"
   )
 
-  set(AMENT_GTEST_ARGS "")
-  # TODO(wjwwood): remove this when the graph API works properly for connext dynamic
-  if(rmw_implementation STREQUAL "rmw_connext_dynamic_cpp")
-    message(STATUS "Skipping test_graph${target_suffix} test.")
-    set(AMENT_GTEST_ARGS "SKIP_TEST")
-  # TODO(mm318): why rmw_connext tests run much slower than rmw_fastrtps and rmw_opensplice tests
-  elseif(rmw_implementation STREQUAL "rmw_connext_cpp")
-    message(STATUS "Increasing test_graph${target_suffix} test timeout.")
-    set(AMENT_GTEST_ARGS TIMEOUT 180)
-  endif()
   rcl_add_custom_gtest(test_graph${target_suffix}
     SRCS rcl/test_graph.cpp
     ENV ${rmw_implementation_env_var}
@@ -139,22 +120,14 @@ function(test_target_function)
     LIBRARIES ${PROJECT_NAME}
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
     TIMEOUT 120
-    ${AMENT_GTEST_ARGS}
   )
 
-  set(AMENT_GTEST_ARGS "")
-  # TODO(mm318): why rmw_connext tests run much slower than rmw_fastrtps and rmw_opensplice tests
-  if(rmw_implementation STREQUAL "rmw_connext_cpp")
-    message(STATUS "Increasing test_info_by_topic${target_suffix} test timeout.")
-    set(AMENT_GTEST_ARGS TIMEOUT 120)
-  endif()
   rcl_add_custom_gtest(test_info_by_topic${target_suffix}
     SRCS rcl/test_info_by_topic.cpp rcl/wait_for_entity_helpers.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME}
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
-    ${AMENT_GTEST_ARGS}
   )
 
   rcl_add_custom_gtest(test_count_matched${target_suffix}
@@ -254,8 +227,11 @@ function(test_target_function)
     LIBRARIES ${PROJECT_NAME} mimick
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
   )
+  # TODO(asorbini) Enable message timestamp tests for rmw_connextdds on Windows
+  # once clock incompatibilities are resolved.
   if(rmw_implementation STREQUAL "rmw_fastrtps_cpp" OR
-    rmw_implementation STREQUAL "rmw_fastrtps_dynamic_cpp")
+    rmw_implementation STREQUAL "rmw_fastrtps_dynamic_cpp" OR
+    (rmw_implementation STREQUAL "rmw_connextdds" AND NOT WIN32))
     message(STATUS "Enabling message timestamp test for ${rmw_implementation}")
     target_compile_definitions(test_subscription${target_suffix}
       PUBLIC "RMW_TIMESTAMPS_SUPPORTED=1" "RMW_RECEIVED_TIMESTAMP_SUPPORTED=1")

--- a/rcl/test/rcl/test_events.cpp
+++ b/rcl/test/rcl/test_events.cpp
@@ -606,7 +606,6 @@ TEST_F(TestEventFixture, test_pubsub_liveliness_kill_pub)
 
 /*
  * Basic test of publisher and subscriber incompatible qos callback events.
- * Only implemented in opensplice at the moment.
  */
 TEST_P(TestEventFixture, test_pubsub_incompatible_qos)
 {

--- a/rcl/test/rcl/test_get_actual_qos.cpp
+++ b/rcl/test/rcl/test_get_actual_qos.cpp
@@ -429,6 +429,40 @@ get_parameters(bool for_publisher)
         "system_default_publisher_qos"
       });
     }
+  } else {
+    // TODO(asorbini): Remove this block once ros2/rmw_connext is deprecated.
+    if (rmw_implementation_str == "rmw_connext_cpp" ||
+      rmw_implementation_str == "rmw_connext_dynamic_cpp")
+    {
+      /*
+       * Test with non-default settings.
+       */
+      parameters.push_back(
+      {
+        nondefault_qos_profile(),
+        expected_nondefault_qos_profile(),
+        "nondefault_qos"
+      });
+
+      /*
+       * Test with system default settings.
+       */
+      if (for_publisher) {
+        parameters.push_back(
+        {
+          rmw_qos_profile_system_default,
+          expected_system_default_publisher_qos_profile(),
+          "system_default_publisher_qos"
+        });
+      } else {
+        parameters.push_back(
+        {
+          rmw_qos_profile_system_default,
+          expected_system_default_subscription_qos_profile(),
+          "system_default_publisher_qos"
+        });
+      }
+    }
   }
 #endif
 

--- a/rcl/test/rcl/test_get_actual_qos.cpp
+++ b/rcl/test/rcl/test_get_actual_qos.cpp
@@ -430,10 +430,7 @@ get_parameters(bool for_publisher)
       });
     }
   } else {
-    if (rmw_implementation_str == "rmw_connext_cpp" ||
-      rmw_implementation_str == "rmw_connext_dynamic_cpp" ||
-      rmw_implementation_str == "rmw_opensplice_cpp")
-    {
+    if (rmw_implementation_str == "rmw_opensplice_cpp") {
       /*
        * Test with non-default settings.
        */

--- a/rcl/test/rcl/test_get_actual_qos.cpp
+++ b/rcl/test/rcl/test_get_actual_qos.cpp
@@ -429,37 +429,6 @@ get_parameters(bool for_publisher)
         "system_default_publisher_qos"
       });
     }
-  } else {
-    if (rmw_implementation_str == "rmw_opensplice_cpp") {
-      /*
-       * Test with non-default settings.
-       */
-      parameters.push_back(
-      {
-        nondefault_qos_profile(),
-        expected_nondefault_qos_profile(),
-        "nondefault_qos"
-      });
-
-      /*
-       * Test with system default settings.
-       */
-      if (for_publisher) {
-        parameters.push_back(
-        {
-          rmw_qos_profile_system_default,
-          expected_system_default_publisher_qos_profile(),
-          "system_default_publisher_qos"
-        });
-      } else {
-        parameters.push_back(
-        {
-          rmw_qos_profile_system_default,
-          expected_system_default_subscription_qos_profile(),
-          "system_default_publisher_qos"
-        });
-      }
-    }
   }
 #endif
 

--- a/rcl/test/rcl/test_graph.cpp
+++ b/rcl/test/rcl/test_graph.cpp
@@ -51,9 +51,6 @@
 bool is_connext =
   std::string(rmw_get_implementation_identifier()).find("rmw_connext") == 0;
 
-bool is_opensplice =
-  std::string(rmw_get_implementation_identifier()).find("rmw_opensplice") == 0;
-
 class CLASSNAME (TestGraphFixture, RMW_IMPLEMENTATION) : public ::testing::Test
 {
 public:

--- a/rcl_action/test/rcl_action/test_graph.cpp
+++ b/rcl_action/test/rcl_action/test_graph.cpp
@@ -358,6 +358,14 @@ public:
       ret = rcl_get_node_names(&this->remote_node, allocator, &node_names, &node_namespaces);
       ++attempts;
       ASSERT_LE(attempts, max_attempts) << "Unable to attain all required nodes";
+      if (node_names.size < 3u) {
+        ret = rcutils_string_array_fini(&node_names);
+        ASSERT_EQ(RCUTILS_RET_OK, ret);
+        ret = rcutils_string_array_fini(&node_namespaces);
+        ASSERT_EQ(RCUTILS_RET_OK, ret);
+        node_names = rcutils_get_zero_initialized_string_array();
+        node_namespaces = rcutils_get_zero_initialized_string_array();
+      }
     }
   }
 


### PR DESCRIPTION
This PR removes all references to `rmw_connext_cpp` (and `rmw_connext_dynamic_cpp`), and replaces them with `rmw_connextdds` where necessary.

The changes re-enable several test cases which were previously disabled for Connext:

* Graph API tests (`test_graph.cpp`).

* Timer tests (`test_timer.cpp`).

* Message timestamps tests (multiple source): these tests remain disabled on Windows, because the clock used by Connext (provided via `_ftime()`), does not support the resolution expected by ROS2 (which uses `GetSystemTimePreciseAsFileTime()`).

The PR also includes a fix for `TestActionGraphFixture` (in `test_graph.cpp`), which did not properly reset the arguments passed to `rcl_get_node_names()` when waiting for nodes to become available.

See [rticommunity/rmw_connextdds #9](https://github.com/rticommunity/rmw_connextdds/issues/9) for a list of related PRs, and an overview of all the changes required to replace [ros2/rmw_connext](https://github.com/ros2/rmw_connext) (`rmw_connext_cpp`) with [rticommunity/rmw_connextdds](https://github.com/rticommunity/rmw_connextdds) in the ROS2 source tree.