### PR TITLE
Put an argument list of 'void' where no arguments are expected.

### DIFF
--- a/rcl/include/rcl/logging.h
+++ b/rcl/include/rcl/logging.h
@@ -105,7 +105,7 @@ rcl_logging_configure_with_output_handler(
  */
 RCL_PUBLIC
 RCL_WARN_UNUSED
-rcl_ret_t rcl_logging_fini();
+rcl_ret_t rcl_logging_fini(void);
 
 /// See if logging rosout is enabled.
 /**
@@ -124,7 +124,7 @@ rcl_ret_t rcl_logging_fini();
  */
 RCL_PUBLIC
 RCL_WARN_UNUSED
-bool rcl_logging_rosout_enabled();
+bool rcl_logging_rosout_enabled(void);
 
 /// Default output handler used by rcl.
 /**

--- a/rcl/src/rcl/logging.c
+++ b/rcl/src/rcl/logging.c
@@ -122,7 +122,7 @@ rcl_logging_configure(const rcl_arguments_t * global_args, const rcl_allocator_t
     global_args, allocator, &rcl_logging_multiple_output_handler);
 }
 
-rcl_ret_t rcl_logging_fini()
+rcl_ret_t rcl_logging_fini(void)
 {
   rcl_ret_t status = RCL_RET_OK;
   rcutils_logging_set_output_handler(rcutils_logging_console_output_handler);
@@ -143,7 +143,7 @@ rcl_ret_t rcl_logging_fini()
   return status;
 }
 
-bool rcl_logging_rosout_enabled()
+bool rcl_logging_rosout_enabled(void)
 {
   return g_rcl_logging_rosout_enabled;
 }


### PR DESCRIPTION
That's because in C, an empty argument list means "take any
arguments whatsoever".

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>