### PR TITLE
Don't expect RCL_RET_TIMEOUT to set an error string

### DIFF
--- a/rcl_action/test/rcl_action/test_action_communication.cpp
+++ b/rcl_action/test/rcl_action/test_action_communication.cpp
@@ -1148,8 +1148,11 @@ TEST_F(CLASSNAME(TestActionCommunication, RMW_IMPLEMENTATION), test_valid_feedba
 
     ret = rcl_wait(&this->wait_set, RCL_S_TO_NS(10));
     if (RCL_RET_OK != ret) {
-      EXPECT_TRUE(rcl_error_is_set());
-      rcl_reset_error();
+      // All non-OK retcodes should set an error string, except RCL_RET_TIMEOUT.
+      if (RCL_RET_TIMEOUT != ret) {
+        EXPECT_TRUE(rcl_error_is_set());
+        rcl_reset_error();
+      }
       continue;
     }
 


### PR DESCRIPTION
Unit test `TestActionCommunication::test_valid_feedback_comm_maybe_fail` from `rcl_action/test_action_communication.cpp` expects an error string to always be set if the call to `rcl_wait()` returns anything other than `RCL_RET_OK`, including `RCL_RET_TIMEOUT`.

This causes the test to fail if an injected error causes the call to timeout. I have run into this occurrence while testing `rmw_connextdds` (see for example [this recent test regression](https://ci.ros2.org/job/ci_linux/13921/testReport/(root)/projectroot/test_action_communication__rmw_connextdds/)).

I had previously "solved" this failure by adding a call to `RMW_SET_ERROR_MSG()` in `rmw_wait()` when `RMW_RET_TIMEOUT` was returned. The test regression was caused by my recent decision of reverting this change, because generating an error string on every timeout caused a quite intrusive (and misleadingly worrisome) error message to be printed on what is really not an erroneous situation.

I'm not sure about the expectations in the ROS2 API, but assuming they are similar to those of the DDS API, I would suggest treating `RCL_RET_TIMEOUT` as a "special" non-OK return code, which doesn't signal an error, at the very least in the context of a `WaitSet::wait()`.

The changes in this PR are required to make progress on [rticommunity/rmw_connextdds#9](https://github.com/rticommunity/rmw_connextdds/issues/9) with "all green" CI tests.

