### PR TITLE
Revert "Mark cyclonedds test_service test as flakey (#648)"

### DIFF
--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -244,9 +244,6 @@ function(test_target_function)
         PUBLIC "RMW_TIMESTAMPS_SUPPORTED=1")
       target_compile_definitions(test_service${target_suffix}
         PUBLIC "RMW_TIMESTAMPS_SUPPORTED=1")
-      # TODO(tfoote) Disable this tests on CI as it's being flakey
-      # This should be removed when https://github.com/ros2/rmw_cyclonedds/issues/185 is resolved.
-      ament_add_test_label(test_service${target_suffix} xfail)
     else()
       message(STATUS "Disabling message timestamp test for ${rmw_implementation}")
     endif()


### PR DESCRIPTION
This reverts commit 51886399ddc67e241521bad81975d365a4e330df. I've been unable to reproduce locally. 

Trying repeated CI:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14097)](http://ci.ros2.org/job/ci_linux/14097/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8913)](http://ci.ros2.org/job/ci_linux-aarch64/8913/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=11789)](http://ci.ros2.org/job/ci_osx/11789/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14197)](http://ci.ros2.org/job/ci_windows/14197/)
