### PR TITLE
Add publishing instrumentation

### DIFF
--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -243,6 +243,7 @@ rcl_publish(
     return RCL_RET_PUBLISHER_INVALID;  // error already set
   }
   RCL_CHECK_ARGUMENT_FOR_NULL(ros_message, RCL_RET_INVALID_ARGUMENT);
+  TRACEPOINT(rcl_publish, (const void *)publisher, (const void *)ros_message);
   if (rmw_publish(publisher->impl->rmw_handle, ros_message, allocation) != RMW_RET_OK) {
     RCL_SET_ERROR_MSG(rmw_get_error_string().str);
     return RCL_RET_ERROR;


### PR DESCRIPTION
This adds publishing instrumentation, with the goal being to be able to track a message across all the layers.

Note that we're only supporting "normal," inter-process publishing for now.

Requires https://gitlab.com/ros-tracing/ros2_tracing/-/merge_requests/227

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>