### PR TITLE
Add option to skip mimick based tests

### DIFF
--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -3,11 +3,7 @@ find_package(launch_testing_ament_cmake REQUIRED)
 
 find_package(test_msgs REQUIRED)
 
-set(USE_MIMICK)
-if(NOT AMENT_IGNORE_MIMICK_TESTS)
-  find_package(mimick_vendor REQUIRED)
-  set(USE_MIMICK "USE_MIMICK")
-endif()
+find_package(mimick_vendor REQUIRED)
 
 find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
@@ -90,8 +86,9 @@ function(test_target_function)
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
     AMENT_DEPENDENCIES ${rmw_implementation}
-    ${USE_MIMICK}
   )
+  target_depend_mimick(test_context${target_suffix}
+    COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
   rcl_add_custom_gtest(test_get_node_names${target_suffix}
     SRCS rcl/test_get_node_names.cpp
@@ -156,15 +153,16 @@ function(test_target_function)
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
     AMENT_DEPENDENCIES ${rmw_implementation}
-    ${USE_MIMICK}
   )
+  target_depend_mimick(test_init${target_suffix}
+    COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
   # CentOS does not support mimick's inject_on_return functionality, which
   # causes test_node to segfault when it runs.  Since CentOS is not a Tier 1
   # platform, just disable the test since we are covering it elsewhere.
-  set(USE_MIMICK_test_node${target_suffix})
-  if(USE_MIMICK OR NOT "${DISTRIBUTION}" STREQUAL "\"centos\"")
-    set(USE_MIMICK_test_node${target_suffix} USE_MIMICK)
+  set(SKIP_MIMICK_test_node${target_suffix} OFF)
+  if("${DISTRIBUTION}" STREQUAL "\"centos\"")
+    set(SKIP_MIMICK_test_node${target_suffix} ON)
   endif()
   rcl_add_custom_gtest(test_node${target_suffix}
     SRCS rcl/test_node.cpp
@@ -173,8 +171,10 @@ function(test_target_function)
     LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp"
     TIMEOUT 240  # Large timeout to wait for fault injection tests
-    ${USE_MIMICK_test_node${target_suffix}}
   )
+  target_depend_mimick(test_node${target_suffix}
+    COMPILE_DEFINITION RCL_SKIP_MIMICK
+    SKIP_MIMICK ${SKIP_MIMICK_test_node${target_suffix}})
 
   rcl_add_custom_gtest(test_arguments${target_suffix}
     SRCS rcl/test_arguments.cpp
@@ -209,8 +209,9 @@ function(test_target_function)
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp"
-    ${USE_MIMICK}
   )
+  target_depend_mimick(test_guard_condition${target_suffix}
+    COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
   rcl_add_custom_gtest(test_publisher${target_suffix}
     SRCS rcl/test_publisher.cpp
@@ -219,8 +220,9 @@ function(test_target_function)
     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
     LIBRARIES ${PROJECT_NAME}
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
-    ${USE_MIMICK}
   )
+  target_depend_mimick(test_publisher${target_suffix}
+    COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
   rcl_add_custom_gtest(test_service${target_suffix}
     SRCS rcl/test_service.cpp rcl/wait_for_entity_helpers.cpp
@@ -228,8 +230,9 @@ function(test_target_function)
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME}
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
-    ${USE_MIMICK}
   )
+  target_depend_mimick(test_service${target_suffix}
+    COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
   rcl_add_custom_gtest(test_subscription${target_suffix}
     SRCS rcl/test_subscription.cpp rcl/wait_for_entity_helpers.cpp
@@ -237,8 +240,9 @@ function(test_target_function)
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME}
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
-    ${USE_MIMICK}
   )
+  target_depend_mimick(test_subscription${target_suffix}
+    COMPILE_DEFINITION RCL_SKIP_MIMICK)
   # TODO(asorbini) Enable message timestamp tests for rmw_connextdds on Windows
   # once clock incompatibilities are resolved.
   if(rmw_implementation STREQUAL "rmw_fastrtps_cpp" OR
@@ -276,8 +280,9 @@ function(test_target_function)
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME}
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp"
-    ${USE_MIMICK}
   )
+  target_depend_mimick(test_wait${target_suffix}
+    COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
   rcl_add_custom_gtest(test_logging_rosout${target_suffix}
     SRCS rcl/test_logging_rosout.cpp
@@ -301,8 +306,9 @@ function(test_target_function)
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME}
     AMENT_DEPENDENCIES ${rmw_implementation}
-    ${USE_MIMICK}
   )
+  target_depend_mimick(test_rmw_impl_id_check_func${target_suffix}
+    COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
   rcl_add_custom_gtest(test_network_flow_endpoints${target_suffix}
     SRCS rcl/test_network_flow_endpoints.cpp
@@ -311,8 +317,9 @@ function(test_target_function)
     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
     LIBRARIES ${PROJECT_NAME}
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
-    ${USE_MIMICK}
   )
+  target_depend_mimick(test_network_flow_endpoints${target_suffix}
+    COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
   # Launch tests
 
@@ -378,15 +385,17 @@ rcl_add_custom_gtest(test_validate_enclave_name
   SRCS rcl/test_validate_enclave_name.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
   LIBRARIES ${PROJECT_NAME}
-  ${USE_MIMICK}
 )
+target_depend_mimick(test_validate_enclave_name
+  COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
 rcl_add_custom_gtest(test_domain_id
   SRCS rcl/test_domain_id.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
   LIBRARIES ${PROJECT_NAME}
-  ${USE_MIMICK}
 )
+target_depend_mimick(test_domain_id
+  COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
 rcl_add_custom_gtest(test_localhost
   SRCS rcl/test_localhost.cpp
@@ -399,8 +408,9 @@ rcl_add_custom_gtest(test_logging
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
   LIBRARIES ${PROJECT_NAME}
   AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
-  ${USE_MIMICK}
 )
+target_depend_mimick(test_logging
+  COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
 rcl_add_custom_gtest(test_validate_topic_name
   SRCS rcl/test_validate_topic_name.cpp
@@ -412,16 +422,18 @@ rcl_add_custom_gtest(test_expand_topic_name
   SRCS rcl/test_expand_topic_name.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
   LIBRARIES ${PROJECT_NAME}
-  ${USE_MIMICK}
 )
+target_depend_mimick(test_expand_topic_name
+  COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
 rcl_add_custom_gtest(test_security
   SRCS rcl/test_security.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
   LIBRARIES ${PROJECT_NAME}
   AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
-  ${USE_MIMICK}
 )
+target_depend_mimick(test_security
+  COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
 rcl_add_custom_gtest(test_common
   SRCS rcl/test_common.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/common.c
@@ -435,5 +447,6 @@ rcl_add_custom_gtest(test_log_level
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
   LIBRARIES ${PROJECT_NAME}
   AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
-  ${USE_MIMICK}
 )
+target_depend_mimick(test_log_level
+  COMPILE_DEFINITION RCL_SKIP_MIMICK)

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 find_package(ament_cmake_gtest REQUIRED)
 find_package(launch_testing_ament_cmake REQUIRED)
 
+find_package(mimick_vendor REQUIRED)
 find_package(test_msgs REQUIRED)
 
 find_package(mimick_vendor REQUIRED)
@@ -84,11 +85,9 @@ function(test_target_function)
     SRCS rcl/test_context.cpp
     ENV ${rmw_implementation_env_var} ${memory_tools_ld_preload_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
+    LIBRARIES ${PROJECT_NAME} mimick_vendor::mimick osrf_testing_tools_cpp::memory_tools
     AMENT_DEPENDENCIES ${rmw_implementation}
   )
-  target_depend_mimick(test_context${target_suffix}
-    COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
   rcl_add_custom_gtest(test_get_node_names${target_suffix}
     SRCS rcl/test_get_node_names.cpp
@@ -151,30 +150,23 @@ function(test_target_function)
     SRCS rcl/test_init.cpp
     ENV ${rmw_implementation_env_var} ${memory_tools_ld_preload_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
+    LIBRARIES ${PROJECT_NAME} mimick_vendor::mimick osrf_testing_tools_cpp::memory_tools
     AMENT_DEPENDENCIES ${rmw_implementation}
   )
-  target_depend_mimick(test_init${target_suffix}
-    COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
   # CentOS does not support mimick's inject_on_return functionality, which
   # causes test_node to segfault when it runs.  Since CentOS is not a Tier 1
   # platform, just disable the test since we are covering it elsewhere.
-  set(SKIP_MIMICK_test_node${target_suffix} OFF)
-  if("${DISTRIBUTION}" STREQUAL "\"centos\"")
-    set(SKIP_MIMICK_test_node${target_suffix} ON)
+  if(NOT "${DISTRIBUTION}" STREQUAL "\"centos\"")
+    rcl_add_custom_gtest(test_node${target_suffix}
+      SRCS rcl/test_node.cpp
+      ENV ${rmw_implementation_env_var} ${memory_tools_ld_preload_env_var}
+      APPEND_LIBRARY_DIRS ${extra_lib_dirs}
+      LIBRARIES ${PROJECT_NAME} mimick_vendor::mimick osrf_testing_tools_cpp::memory_tools
+      AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp"
+      TIMEOUT 240  # Large timeout to wait for fault injection tests
+    )
   endif()
-  rcl_add_custom_gtest(test_node${target_suffix}
-    SRCS rcl/test_node.cpp
-    ENV ${rmw_implementation_env_var} ${memory_tools_ld_preload_env_var}
-    APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp"
-    TIMEOUT 240  # Large timeout to wait for fault injection tests
-  )
-  target_depend_mimick(test_node${target_suffix}
-    COMPILE_DEFINITION RCL_SKIP_MIMICK
-    SKIP_MIMICK ${SKIP_MIMICK_test_node${target_suffix}})
 
   rcl_add_custom_gtest(test_arguments${target_suffix}
     SRCS rcl/test_arguments.cpp
@@ -207,42 +199,34 @@ function(test_target_function)
     SRCS rcl/test_guard_condition.cpp
     ENV ${rmw_implementation_env_var} ${memory_tools_ld_preload_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
+    LIBRARIES ${PROJECT_NAME} mimick_vendor::mimick osrf_testing_tools_cpp::memory_tools
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp"
   )
-  target_depend_mimick(test_guard_condition${target_suffix}
-    COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
   rcl_add_custom_gtest(test_publisher${target_suffix}
     SRCS rcl/test_publisher.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
-    LIBRARIES ${PROJECT_NAME}
+    LIBRARIES ${PROJECT_NAME} mimick_vendor::mimick
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
   )
-  target_depend_mimick(test_publisher${target_suffix}
-    COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
   rcl_add_custom_gtest(test_service${target_suffix}
     SRCS rcl/test_service.cpp rcl/wait_for_entity_helpers.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME}
+    LIBRARIES ${PROJECT_NAME} mimick_vendor::mimick
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
   )
-  target_depend_mimick(test_service${target_suffix}
-    COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
   rcl_add_custom_gtest(test_subscription${target_suffix}
     SRCS rcl/test_subscription.cpp rcl/wait_for_entity_helpers.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME}
+    LIBRARIES ${PROJECT_NAME} mimick_vendor::mimick
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
   )
-  target_depend_mimick(test_subscription${target_suffix}
-    COMPILE_DEFINITION RCL_SKIP_MIMICK)
   # TODO(asorbini) Enable message timestamp tests for rmw_connextdds on Windows
   # once clock incompatibilities are resolved.
   if(rmw_implementation STREQUAL "rmw_fastrtps_cpp" OR
@@ -278,11 +262,9 @@ function(test_target_function)
     SRCS rcl/test_wait.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME}
+    LIBRARIES ${PROJECT_NAME} mimick_vendor::mimick
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp"
   )
-  target_depend_mimick(test_wait${target_suffix}
-    COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
   rcl_add_custom_gtest(test_logging_rosout${target_suffix}
     SRCS rcl/test_logging_rosout.cpp
@@ -304,22 +286,18 @@ function(test_target_function)
     SRCS rcl/test_rmw_impl_id_check_func.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME}
+    LIBRARIES ${PROJECT_NAME} mimick_vendor::mimick
     AMENT_DEPENDENCIES ${rmw_implementation}
   )
-  target_depend_mimick(test_rmw_impl_id_check_func${target_suffix}
-    COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
   rcl_add_custom_gtest(test_network_flow_endpoints${target_suffix}
     SRCS rcl/test_network_flow_endpoints.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
-    LIBRARIES ${PROJECT_NAME}
+    LIBRARIES ${PROJECT_NAME} mimick_vendor::mimick
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
   )
-  target_depend_mimick(test_network_flow_endpoints${target_suffix}
-    COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
   # Launch tests
 
@@ -384,18 +362,14 @@ call_for_each_rmw_implementation(test_target)
 rcl_add_custom_gtest(test_validate_enclave_name
   SRCS rcl/test_validate_enclave_name.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME}
+  LIBRARIES ${PROJECT_NAME} mimick_vendor::mimick
 )
-target_depend_mimick(test_validate_enclave_name
-  COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
 rcl_add_custom_gtest(test_domain_id
   SRCS rcl/test_domain_id.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME}
+  LIBRARIES ${PROJECT_NAME} mimick_vendor::mimick
 )
-target_depend_mimick(test_domain_id
-  COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
 rcl_add_custom_gtest(test_localhost
   SRCS rcl/test_localhost.cpp
@@ -406,11 +380,9 @@ rcl_add_custom_gtest(test_localhost
 rcl_add_custom_gtest(test_logging
   SRCS rcl/test_logging.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME}
+  LIBRARIES ${PROJECT_NAME} mimick_vendor::mimick
   AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
 )
-target_depend_mimick(test_logging
-  COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
 rcl_add_custom_gtest(test_validate_topic_name
   SRCS rcl/test_validate_topic_name.cpp
@@ -421,19 +393,15 @@ rcl_add_custom_gtest(test_validate_topic_name
 rcl_add_custom_gtest(test_expand_topic_name
   SRCS rcl/test_expand_topic_name.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME}
+  LIBRARIES ${PROJECT_NAME} mimick_vendor::mimick
 )
-target_depend_mimick(test_expand_topic_name
-  COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
 rcl_add_custom_gtest(test_security
   SRCS rcl/test_security.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME}
+  LIBRARIES ${PROJECT_NAME} mimick_vendor::mimick
   AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
 )
-target_depend_mimick(test_security
-  COMPILE_DEFINITION RCL_SKIP_MIMICK)
 
 rcl_add_custom_gtest(test_common
   SRCS rcl/test_common.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/common.c
@@ -445,8 +413,6 @@ rcl_add_custom_gtest(test_common
 rcl_add_custom_gtest(test_log_level
   SRCS rcl/test_log_level.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME}
+  LIBRARIES ${PROJECT_NAME} mimick_vendor::mimick
   AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
 )
-target_depend_mimick(test_log_level
-  COMPILE_DEFINITION RCL_SKIP_MIMICK)

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -1,10 +1,13 @@
 find_package(ament_cmake_gtest REQUIRED)
 find_package(launch_testing_ament_cmake REQUIRED)
 
-find_package(mimick_vendor REQUIRED)
 find_package(test_msgs REQUIRED)
 
-find_package(mimick_vendor REQUIRED)
+set(USE_MIMICK)
+if(NOT AMENT_IGNORE_MIMICK_TESTS)
+  find_package(mimick_vendor REQUIRED)
+  set(USE_MIMICK "USE_MIMICK")
+endif()
 
 find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
@@ -85,8 +88,9 @@ function(test_target_function)
     SRCS rcl/test_context.cpp
     ENV ${rmw_implementation_env_var} ${memory_tools_ld_preload_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME} mimick osrf_testing_tools_cpp::memory_tools
+    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
     AMENT_DEPENDENCIES ${rmw_implementation}
+    ${USE_MIMICK}
   )
 
   rcl_add_custom_gtest(test_get_node_names${target_suffix}
@@ -150,23 +154,27 @@ function(test_target_function)
     SRCS rcl/test_init.cpp
     ENV ${rmw_implementation_env_var} ${memory_tools_ld_preload_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME} mimick osrf_testing_tools_cpp::memory_tools
+    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
     AMENT_DEPENDENCIES ${rmw_implementation}
+    ${USE_MIMICK}
   )
 
   # CentOS does not support mimick's inject_on_return functionality, which
   # causes test_node to segfault when it runs.  Since CentOS is not a Tier 1
   # platform, just disable the test since we are covering it elsewhere.
-  if(NOT "${DISTRIBUTION}" STREQUAL "\"centos\"")
-    rcl_add_custom_gtest(test_node${target_suffix}
-      SRCS rcl/test_node.cpp
-      ENV ${rmw_implementation_env_var} ${memory_tools_ld_preload_env_var}
-      APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-      LIBRARIES ${PROJECT_NAME} mimick osrf_testing_tools_cpp::memory_tools
-      AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp"
-      TIMEOUT 240  # Large timeout to wait for fault injection tests
-    )
+  set(USE_MIMICK_test_node${target_suffix})
+  if(USE_MIMICK OR NOT "${DISTRIBUTION}" STREQUAL "\"centos\"")
+    set(USE_MIMICK_test_node${target_suffix} USE_MIMICK)
   endif()
+  rcl_add_custom_gtest(test_node${target_suffix}
+    SRCS rcl/test_node.cpp
+    ENV ${rmw_implementation_env_var} ${memory_tools_ld_preload_env_var}
+    APPEND_LIBRARY_DIRS ${extra_lib_dirs}
+    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
+    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp"
+    TIMEOUT 240  # Large timeout to wait for fault injection tests
+    ${USE_MIMICK_test_node${target_suffix}}
+  )
 
   rcl_add_custom_gtest(test_arguments${target_suffix}
     SRCS rcl/test_arguments.cpp
@@ -199,8 +207,9 @@ function(test_target_function)
     SRCS rcl/test_guard_condition.cpp
     ENV ${rmw_implementation_env_var} ${memory_tools_ld_preload_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME} mimick osrf_testing_tools_cpp::memory_tools
+    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp"
+    ${USE_MIMICK}
   )
 
   rcl_add_custom_gtest(test_publisher${target_suffix}
@@ -208,24 +217,27 @@ function(test_target_function)
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
-    LIBRARIES ${PROJECT_NAME} mimick
+    LIBRARIES ${PROJECT_NAME}
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
+    ${USE_MIMICK}
   )
 
   rcl_add_custom_gtest(test_service${target_suffix}
     SRCS rcl/test_service.cpp rcl/wait_for_entity_helpers.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME} mimick
+    LIBRARIES ${PROJECT_NAME}
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
+    ${USE_MIMICK}
   )
 
   rcl_add_custom_gtest(test_subscription${target_suffix}
     SRCS rcl/test_subscription.cpp rcl/wait_for_entity_helpers.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME} mimick
+    LIBRARIES ${PROJECT_NAME}
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
+    ${USE_MIMICK}
   )
   # TODO(asorbini) Enable message timestamp tests for rmw_connextdds on Windows
   # once clock incompatibilities are resolved.
@@ -262,8 +274,9 @@ function(test_target_function)
     SRCS rcl/test_wait.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME} mimick
+    LIBRARIES ${PROJECT_NAME}
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp"
+    ${USE_MIMICK}
   )
 
   rcl_add_custom_gtest(test_logging_rosout${target_suffix}
@@ -286,8 +299,9 @@ function(test_target_function)
     SRCS rcl/test_rmw_impl_id_check_func.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME} mimick
+    LIBRARIES ${PROJECT_NAME}
     AMENT_DEPENDENCIES ${rmw_implementation}
+    ${USE_MIMICK}
   )
 
   rcl_add_custom_gtest(test_network_flow_endpoints${target_suffix}
@@ -295,8 +309,9 @@ function(test_target_function)
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
-    LIBRARIES ${PROJECT_NAME} mimick
+    LIBRARIES ${PROJECT_NAME}
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
+    ${USE_MIMICK}
   )
 
   # Launch tests
@@ -362,13 +377,15 @@ call_for_each_rmw_implementation(test_target)
 rcl_add_custom_gtest(test_validate_enclave_name
   SRCS rcl/test_validate_enclave_name.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME} mimick
+  LIBRARIES ${PROJECT_NAME}
+  ${USE_MIMICK}
 )
 
 rcl_add_custom_gtest(test_domain_id
   SRCS rcl/test_domain_id.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME} mimick
+  LIBRARIES ${PROJECT_NAME}
+  ${USE_MIMICK}
 )
 
 rcl_add_custom_gtest(test_localhost
@@ -380,8 +397,9 @@ rcl_add_custom_gtest(test_localhost
 rcl_add_custom_gtest(test_logging
   SRCS rcl/test_logging.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME} mimick
+  LIBRARIES ${PROJECT_NAME}
   AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
+  ${USE_MIMICK}
 )
 
 rcl_add_custom_gtest(test_validate_topic_name
@@ -393,14 +411,16 @@ rcl_add_custom_gtest(test_validate_topic_name
 rcl_add_custom_gtest(test_expand_topic_name
   SRCS rcl/test_expand_topic_name.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME} mimick
+  LIBRARIES ${PROJECT_NAME}
+  ${USE_MIMICK}
 )
 
 rcl_add_custom_gtest(test_security
   SRCS rcl/test_security.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME} mimick
+  LIBRARIES ${PROJECT_NAME}
   AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
+  ${USE_MIMICK}
 )
 
 rcl_add_custom_gtest(test_common
@@ -413,6 +433,7 @@ rcl_add_custom_gtest(test_common
 rcl_add_custom_gtest(test_log_level
   SRCS rcl/test_log_level.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME} mimick
+  LIBRARIES ${PROJECT_NAME}
   AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
+  ${USE_MIMICK}
 )

--- a/rcl/test/cmake/rcl_add_custom_gtest.cmake
+++ b/rcl/test/cmake/rcl_add_custom_gtest.cmake
@@ -48,8 +48,8 @@ set(rcl_add_custom_gtest_INCLUDED TRUE)
 #
 macro(rcl_add_custom_gtest target)
   cmake_parse_arguments(_ARG
-    "SKIP_TEST;TRACE;USE_MIMICK"
-    "TIMEOUT;"
+    "SKIP_TEST;TRACE"
+    "TIMEOUT"
     "SRCS;ENV;APPEND_ENV;APPEND_LIBRARY_DIRS;INCLUDE_DIRS;LIBRARIES;AMENT_DEPENDENCIES"
     ${ARGN})
   if(_ARG_UNPARSED_ARGUMENTS)
@@ -90,9 +90,6 @@ macro(rcl_add_custom_gtest target)
     endif()
     # Add extra link libraries, if any.
     if(_ARG_LIBRARIES)
-      if(_ARG_USE_MIMICK)
-        list(APPEND _ARG_LIBRARIES mimick)
-      endif()
       if(_ARG_TRACE)
         message(STATUS "  rcl_add_custom_gtest() LIBRARIES: ${_ARG_LIBRARIES}")
       endif()
@@ -105,11 +102,7 @@ macro(rcl_add_custom_gtest target)
       endif()
       ament_target_dependencies(${target} ${_ARG_AMENT_DEPENDENCIES})
     endif()
-    set(_compile_definitions "RMW_IMPLEMENTATION=${rmw_implementation}")
-    if(NOT _ARG_USE_MIMICK)
-      list(APPEND _compile_definitions "RCL_SKIP_MIMICK=1")
-    endif()
     target_compile_definitions(${target}
-      PUBLIC ${_compile_definitions})
+      PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
   endif()
 endmacro()

--- a/rcl/test/cmake/rcl_add_custom_gtest.cmake
+++ b/rcl/test/cmake/rcl_add_custom_gtest.cmake
@@ -48,8 +48,8 @@ set(rcl_add_custom_gtest_INCLUDED TRUE)
 #
 macro(rcl_add_custom_gtest target)
   cmake_parse_arguments(_ARG
-    "SKIP_TEST;TRACE"
-    "TIMEOUT"
+    "SKIP_TEST;TRACE;USE_MIMICK"
+    "TIMEOUT;"
     "SRCS;ENV;APPEND_ENV;APPEND_LIBRARY_DIRS;INCLUDE_DIRS;LIBRARIES;AMENT_DEPENDENCIES"
     ${ARGN})
   if(_ARG_UNPARSED_ARGUMENTS)
@@ -90,6 +90,9 @@ macro(rcl_add_custom_gtest target)
     endif()
     # Add extra link libraries, if any.
     if(_ARG_LIBRARIES)
+      if(_ARG_USE_MIMICK)
+        list(APPEND _ARG_LIBRARIES mimick)
+      endif()
       if(_ARG_TRACE)
         message(STATUS "  rcl_add_custom_gtest() LIBRARIES: ${_ARG_LIBRARIES}")
       endif()
@@ -102,7 +105,11 @@ macro(rcl_add_custom_gtest target)
       endif()
       ament_target_dependencies(${target} ${_ARG_AMENT_DEPENDENCIES})
     endif()
+    set(_compile_definitions "RMW_IMPLEMENTATION=${rmw_implementation}")
+    if(NOT _ARG_USE_MIMICK)
+      list(APPEND _compile_definitions "RCL_SKIP_MIMICK=1")
+    endif()
     target_compile_definitions(${target}
-      PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
+      PUBLIC ${_compile_definitions})
   endif()
 endmacro()

--- a/rcl/test/mocking_utils/patch.hpp
+++ b/rcl/test/mocking_utils/patch.hpp
@@ -503,47 +503,6 @@ MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(va_list, ==)
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(va_list, !=)
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(va_list, <)
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(va_list, >)
-#endif
-#else  // RCL_SKIP_MIMICK
-
-namespace mocking_utils
-{
-// Empty prototypes, for when mimick is not available.
-
-struct Patch
-{
-  // This method is sometime used in tests, we need to provide it.
-  template<typename SignatureT>
-  Patch & then_call(SignatureT)
-  {
-    return *this;
-  }
-  // we add a nontrivial destructor on purpose, so the compiler does not complain
-  // about an unused `Patch` instance.
-  ~Patch() {}
-};
-
-template<typename SignatureT>
-auto make_patch(const std::string &, std::function<SignatureT>)
-{
-  return Patch{};
-}
-
-#define prepare_patch(scope, function) make_patch<decltype(function)>(scope, function)
-
-// then_call here isn't doing anything, it's just to avoid an unused variable warning
-#define patch(scope, function, replacement) prepare_patch(scope, function).then_call(replacement)
-
-// same trick here, abusing the template argument a bit
-#define patch_and_return(scope, function, return_code) \
-  prepare_patch(scope, function).then_call(return_code)
-
-#define patch_to_fail(scope, function, error_message, return_code) \
-  prepare_patch(scope, function).then_call(error_message).then_call(return_code)
-
-#define inject_on_return(scope, function, return_code) \
-  prepare_patch(scope, function).then_call(return_code)
-
-}  // namespace mocking_utils
+#endif  // MOCKING_UTILS_SUPPORT_VA_LIST
 #endif  // RCL_SKIP_MIMICK
 #endif  // MOCKING_UTILS__PATCH_HPP_

--- a/rcl/test/mocking_utils/patch.hpp
+++ b/rcl/test/mocking_utils/patch.hpp
@@ -35,7 +35,7 @@
 #include <type_traits>
 #include <utility>
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
 #include "mimick/mimick.h"
 #endif
 
@@ -54,7 +54,7 @@
     return false; \
   }
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
 namespace mocking_utils
 {
 
@@ -504,5 +504,5 @@ MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(va_list, !=)
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(va_list, <)
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(va_list, >)
 #endif  // MOCKING_UTILS_SUPPORT_VA_LIST
-#endif  // RCL_SKIP_MIMICK
+#endif  // SKIP_MIMICK
 #endif  // MOCKING_UTILS__PATCH_HPP_

--- a/rcl/test/rcl/test_context.cpp
+++ b/rcl/test/rcl/test_context.cpp
@@ -178,7 +178,7 @@ TEST_F(CLASSNAME(TestContextFixture, RMW_IMPLEMENTATION), bad_fini) {
   ret = rcl_shutdown(&context);
   EXPECT_EQ(ret, RCL_RET_OK);
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   {
     auto mock = mocking_utils::inject_on_return(
       "lib:rcl", rmw_context_fini, RMW_RET_ERROR);

--- a/rcl/test/rcl/test_context.cpp
+++ b/rcl/test/rcl/test_context.cpp
@@ -178,10 +178,12 @@ TEST_F(CLASSNAME(TestContextFixture, RMW_IMPLEMENTATION), bad_fini) {
   ret = rcl_shutdown(&context);
   EXPECT_EQ(ret, RCL_RET_OK);
 
+#ifndef RCL_SKIP_MIMICK
   {
     auto mock = mocking_utils::inject_on_return(
       "lib:rcl", rmw_context_fini, RMW_RET_ERROR);
     EXPECT_EQ(RCL_RET_ERROR, rcl_context_fini(&context));
     rcl_reset_error();
   }
+#endif
 }

--- a/rcl/test/rcl/test_domain_id.cpp
+++ b/rcl/test/rcl/test_domain_id.cpp
@@ -53,7 +53,7 @@ TEST(TestGetDomainId, test_nominal) {
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_get_default_domain_id(nullptr));
 }
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
 TEST(TestGetDomainId, test_mock_get_default_domain_id) {
   auto mock = mocking_utils::patch_and_return(
     "lib:rcl", rcutils_get_env, "argument env_name is null");
@@ -63,4 +63,4 @@ TEST(TestGetDomainId, test_mock_get_default_domain_id) {
   EXPECT_TRUE(rcl_error_is_set());
   rcl_reset_error();
 }
-#endif  // RCL_SKIP_MIMICK
+#endif  // SKIP_MIMICK

--- a/rcl/test/rcl/test_domain_id.cpp
+++ b/rcl/test/rcl/test_domain_id.cpp
@@ -53,6 +53,7 @@ TEST(TestGetDomainId, test_nominal) {
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_get_default_domain_id(nullptr));
 }
 
+#ifndef RCL_SKIP_MIMICK
 TEST(TestGetDomainId, test_mock_get_default_domain_id) {
   auto mock = mocking_utils::patch_and_return(
     "lib:rcl", rcutils_get_env, "argument env_name is null");
@@ -62,3 +63,4 @@ TEST(TestGetDomainId, test_mock_get_default_domain_id) {
   EXPECT_TRUE(rcl_error_is_set());
   rcl_reset_error();
 }
+#endif  // RCL_SKIP_MIMICK

--- a/rcl/test/rcl/test_expand_topic_name.cpp
+++ b/rcl/test/rcl/test_expand_topic_name.cpp
@@ -144,7 +144,7 @@ TEST(test_expand_topic_name, invalid_arguments) {
   ASSERT_EQ(RCL_RET_OK, ret);
 }
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
 
 // Define dummy comparison operators for rcutils_allocator_t type
 // to use with the Mimick mocking library

--- a/rcl/test/rcl/test_expand_topic_name.cpp
+++ b/rcl/test/rcl/test_expand_topic_name.cpp
@@ -144,6 +144,8 @@ TEST(test_expand_topic_name, invalid_arguments) {
   ASSERT_EQ(RCL_RET_OK, ret);
 }
 
+#ifndef RCL_SKIP_MIMICK
+
 // Define dummy comparison operators for rcutils_allocator_t type
 // to use with the Mimick mocking library
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, ==)
@@ -226,10 +228,10 @@ TEST(test_expand_topic_name, internal_error) {
     EXPECT_TRUE(rcl_error_is_set());
     rcl_reset_error();
   }
-
   ret = rcutils_string_map_fini(&subs);
   ASSERT_EQ(RCL_RET_OK, ret);
 }
+#endif
 
 TEST(test_expand_topic_name, various_valid_topics) {
   rcl_ret_t ret;

--- a/rcl/test/rcl/test_guard_condition.cpp
+++ b/rcl/test/rcl/test_guard_condition.cpp
@@ -192,7 +192,7 @@ TEST_F(
   ASSERT_EQ(RCL_RET_BAD_ALLOC, ret) << "Expected RCL_RET_BAD_ALLOC";
   ASSERT_TRUE(rcl_error_is_set());
   rcl_reset_error();
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   // Try init but force an internal error.
   {
     auto mock = mocking_utils::patch_to_fail(
@@ -217,7 +217,7 @@ TEST_F(
   ret = rcl_guard_condition_fini(&guard_condition);
   EXPECT_EQ(RCL_RET_OK, ret);
   // Try normal init and fini, but force an internal error on first try.
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   {
     auto mock = mocking_utils::inject_on_return(
       "lib:rcl", rmw_destroy_guard_condition, RMW_RET_ERROR);

--- a/rcl/test/rcl/test_guard_condition.cpp
+++ b/rcl/test/rcl/test_guard_condition.cpp
@@ -192,6 +192,7 @@ TEST_F(
   ASSERT_EQ(RCL_RET_BAD_ALLOC, ret) << "Expected RCL_RET_BAD_ALLOC";
   ASSERT_TRUE(rcl_error_is_set());
   rcl_reset_error();
+#ifndef RCL_SKIP_MIMICK
   // Try init but force an internal error.
   {
     auto mock = mocking_utils::patch_to_fail(
@@ -200,6 +201,7 @@ TEST_F(
     EXPECT_EQ(RCL_RET_ERROR, ret);
     rcl_reset_error();
   }
+#endif
 
   // Try fini with invalid arguments.
   ret = rcl_guard_condition_fini(nullptr);
@@ -215,6 +217,7 @@ TEST_F(
   ret = rcl_guard_condition_fini(&guard_condition);
   EXPECT_EQ(RCL_RET_OK, ret);
   // Try normal init and fini, but force an internal error on first try.
+#ifndef RCL_SKIP_MIMICK
   {
     auto mock = mocking_utils::inject_on_return(
       "lib:rcl", rmw_destroy_guard_condition, RMW_RET_ERROR);
@@ -226,6 +229,7 @@ TEST_F(
   }
   ret = rcl_guard_condition_fini(&guard_condition);
   EXPECT_EQ(RCL_RET_OK, ret);
+#endif
   // Try repeated init and fini calls.
   ret = rcl_guard_condition_init(&guard_condition, &context, default_options);
   EXPECT_EQ(RCL_RET_OK, ret);

--- a/rcl/test/rcl/test_init.cpp
+++ b/rcl/test/rcl/test_init.cpp
@@ -332,7 +332,7 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_init_internal_err
   FakeTestArgv test_args;
   rcl_context_t context = rcl_get_zero_initialized_context();
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   {
     auto mock = mocking_utils::patch_to_fail(
       "lib:rcl", rmw_init, "internal error", RMW_RET_ERROR);
@@ -366,7 +366,7 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_init_internal_err
 
 /* Tests rcl_shutdown() deals with internal errors correctly.
  */
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
 TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_shutdown_internal_error) {
   rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
   rcl_ret_t ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
@@ -532,7 +532,7 @@ MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, <)
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, >)
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, !=)
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
 // Tests rcl_init_options_init() mocked to fail
 TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_mocked_rcl_init_options_ini) {
   rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();

--- a/rcl/test/rcl/test_init.cpp
+++ b/rcl/test/rcl/test_init.cpp
@@ -332,6 +332,7 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_init_internal_err
   FakeTestArgv test_args;
   rcl_context_t context = rcl_get_zero_initialized_context();
 
+#ifndef RCL_SKIP_MIMICK
   {
     auto mock = mocking_utils::patch_to_fail(
       "lib:rcl", rmw_init, "internal error", RMW_RET_ERROR);
@@ -341,6 +342,7 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_init_internal_err
     rcl_reset_error();
     EXPECT_FALSE(rcl_context_is_valid(&context));
   }
+#endif
 
   RCUTILS_FAULT_INJECTION_TEST(
   {
@@ -364,6 +366,7 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_init_internal_err
 
 /* Tests rcl_shutdown() deals with internal errors correctly.
  */
+#ifndef RCL_SKIP_MIMICK
 TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_shutdown_internal_error) {
   rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
   rcl_ret_t ret = rcl_init_options_init(&init_options, rcl_get_default_allocator());
@@ -388,6 +391,7 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_shutdown_internal
   EXPECT_EQ(RCL_RET_ERROR, rcl_shutdown(&context));
   rcl_reset_error();
 }
+#endif
 
 /* Tests the rcl_get_instance_id() function.
  */
@@ -528,6 +532,7 @@ MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, <)
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, >)
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, !=)
 
+#ifndef RCL_SKIP_MIMICK
 // Tests rcl_init_options_init() mocked to fail
 TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_mocked_rcl_init_options_ini) {
   rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
@@ -574,3 +579,4 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_init_options_copy
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_init_options_copy(&init_options, &init_options_dst));
   rcl_reset_error();
 }
+#endif

--- a/rcl/test/rcl/test_logging.cpp
+++ b/rcl/test/rcl/test_logging.cpp
@@ -149,6 +149,7 @@ TEST(TestLogging, test_failing_external_logging_configure) {
     EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&global_arguments)) << rcl_get_error_string().str;
   });
 
+#ifndef RCL_SKIP_MIMICK
   {
     auto mock = mocking_utils::patch_to_fail(
       "lib:rcl", rcl_logging_external_initialize, "some error", RCL_LOGGING_RET_ERROR);
@@ -168,6 +169,7 @@ TEST(TestLogging, test_failing_external_logging_configure) {
 
     EXPECT_EQ(RCL_RET_OK, rcl_logging_fini()) << rcl_get_error_string().str;
   }
+#endif  // RCL_SKIP_TESTS
 }
 
 TEST(TestLogging, test_failing_logger_level_configure) {
@@ -183,7 +185,7 @@ TEST(TestLogging, test_failing_logger_level_configure) {
   {
     EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&global_arguments)) << rcl_get_error_string().str;
   });
-
+#ifndef RCL_SKIP_MIMICK
   {
     auto mock = mocking_utils::patch_to_fail(
       "lib:rcl", rcutils_logging_set_logger_level, "failed to allocate", RCUTILS_RET_ERROR);
@@ -193,8 +195,10 @@ TEST(TestLogging, test_failing_logger_level_configure) {
 
     EXPECT_EQ(RCL_RET_OK, rcl_logging_fini()) << rcl_get_error_string().str;
   }
+#endif  // RCL_SKIP_TESTS
 }
 
+#ifndef RCL_SKIP_MIMICK
 TEST(TestLogging, test_failing_external_logging) {
   const char * argv[] = {
     "test_logging", RCL_ROS_ARGS_FLAG,
@@ -266,7 +270,7 @@ TEST(TestLogging, test_failing_external_logging) {
       "Expected '" << stderr_message << "' within '" << stderr_sstream.str() << "'";
     stderr_sstream.str("");
   }
-#endif
+#endif  // MOCKING_UTILS_SUPPORT_VA_LIST
 
   {
     auto mock = mocking_utils::patch_to_fail(
@@ -300,3 +304,4 @@ TEST(TestLogging, test_failing_external_logging) {
     stderr_sstream.str("");
   }
 }
+#endif  // RCL_SKIP_TESTS

--- a/rcl/test/rcl/test_logging.cpp
+++ b/rcl/test/rcl/test_logging.cpp
@@ -149,7 +149,7 @@ TEST(TestLogging, test_failing_external_logging_configure) {
     EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&global_arguments)) << rcl_get_error_string().str;
   });
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   {
     auto mock = mocking_utils::patch_to_fail(
       "lib:rcl", rcl_logging_external_initialize, "some error", RCL_LOGGING_RET_ERROR);
@@ -185,7 +185,7 @@ TEST(TestLogging, test_failing_logger_level_configure) {
   {
     EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&global_arguments)) << rcl_get_error_string().str;
   });
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   {
     auto mock = mocking_utils::patch_to_fail(
       "lib:rcl", rcutils_logging_set_logger_level, "failed to allocate", RCUTILS_RET_ERROR);
@@ -198,7 +198,7 @@ TEST(TestLogging, test_failing_logger_level_configure) {
 #endif  // RCL_SKIP_TESTS
 }
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
 TEST(TestLogging, test_failing_external_logging) {
   const char * argv[] = {
     "test_logging", RCL_ROS_ARGS_FLAG,

--- a/rcl/test/rcl/test_network_flow_endpoints.cpp
+++ b/rcl/test/rcl/test_network_flow_endpoints.cpp
@@ -14,7 +14,6 @@
 
 #include <gtest/gtest.h>
 
-#include "mimick/mimick.h"
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcl/error_handling.h"
 #include "rcl/network_flow_endpoints.h"
@@ -24,7 +23,6 @@
 #include "test_msgs/msg/basic_types.h"
 
 #include "./allocator_testing_utils.h"
-#include "../mocking_utils/patch.hpp"
 
 #ifdef RMW_IMPLEMENTATION
 # define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -480,7 +480,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_init_with_i
   EXPECT_EQ(RCL_RET_BAD_ALLOC, ret) << "Expected RCL_RET_BAD_ALLOC";
   ASSERT_TRUE(rcl_error_is_set());
   rcl_reset_error();
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   // Try init but force internal errors.
   {
     auto mock = mocking_utils::patch_and_return("lib:rcl", rmw_create_node, nullptr);
@@ -521,7 +521,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_init_with_i
     EXPECT_EQ(RCL_RET_ERROR, ret);
     rcl_reset_error();
   }
-#endif  // RCL_SKIP_MIMICK
+#endif  // SKIP_MIMICK
 
   // Battle test node init.
   RCUTILS_FAULT_INJECTION_TEST(

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -480,6 +480,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_init_with_i
   EXPECT_EQ(RCL_RET_BAD_ALLOC, ret) << "Expected RCL_RET_BAD_ALLOC";
   ASSERT_TRUE(rcl_error_is_set());
   rcl_reset_error();
+#ifndef RCL_SKIP_MIMICK
   // Try init but force internal errors.
   {
     auto mock = mocking_utils::patch_and_return("lib:rcl", rmw_create_node, nullptr);
@@ -520,6 +521,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_init_with_i
     EXPECT_EQ(RCL_RET_ERROR, ret);
     rcl_reset_error();
   }
+#endif  // RCL_SKIP_MIMICK
 
   // Battle test node init.
   RCUTILS_FAULT_INJECTION_TEST(
@@ -944,7 +946,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_resolve_nam
   options.arguments = local_arguments;  // transfer ownership
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
   {
-    rcl_node_options_fini(&options);
+    ASSERT_EQ(RCL_RET_OK, rcl_node_options_fini(&options));
   });
   ret = rcl_node_init(&node, "node", "/ns", &context, &options);
   ASSERT_EQ(RCL_RET_OK, ret);

--- a/rcl/test/rcl/test_publisher.cpp
+++ b/rcl/test/rcl/test_publisher.cpp
@@ -541,7 +541,7 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_invalid_publish
 
 // Mocking rmw_publisher_count_matched_subscriptions to make
 // rcl_publisher_get_subscription_count fail
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
 TEST_F(
   CLASSNAME(TestPublisherFixtureInit, RMW_IMPLEMENTATION),
   test_mock_publisher_get_subscription_count)
@@ -825,4 +825,4 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_mock_publisher_
   ret = rcl_publisher_fini(&publisher, this->node_ptr);
   EXPECT_EQ(RCL_RET_ERROR, ret) << rcl_get_error_string().str;
 }
-#endif  // RCL_SKIP_MIMICK
+#endif  // SKIP_MIMICK

--- a/rcl/test/rcl/test_publisher.cpp
+++ b/rcl/test/rcl/test_publisher.cpp
@@ -21,7 +21,6 @@
 #include "test_msgs/msg/strings.h"
 #include "rosidl_runtime_c/string_functions.h"
 
-#include "mimick/mimick.h"
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcl/error_handling.h"
 #include "rmw/validate_full_topic_name.h"
@@ -542,6 +541,7 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_invalid_publish
 
 // Mocking rmw_publisher_count_matched_subscriptions to make
 // rcl_publisher_get_subscription_count fail
+#ifndef RCL_SKIP_MIMICK
 TEST_F(
   CLASSNAME(TestPublisherFixtureInit, RMW_IMPLEMENTATION),
   test_mock_publisher_get_subscription_count)
@@ -825,3 +825,4 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_mock_publisher_
   ret = rcl_publisher_fini(&publisher, this->node_ptr);
   EXPECT_EQ(RCL_RET_ERROR, ret) << rcl_get_error_string().str;
 }
+#endif  // RCL_SKIP_MIMICK

--- a/rcl/test/rcl/test_rmw_impl_id_check_func.cpp
+++ b/rcl/test/rcl/test_rmw_impl_id_check_func.cpp
@@ -81,6 +81,7 @@ MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, <)
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, >)
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, !=)
 
+#ifndef RCL_SKIP_MIMICK
 // Mock internal calls to external libraries to fail
 TEST(TestRmwCheck, test_mock_rmw_impl_check) {
   {
@@ -155,3 +156,4 @@ TEST(TestRmwCheck, test_mock_rmw_impl_check) {
     rcl_reset_error();
   }
 }
+#endif  // RCL_SKIP_MIMICK

--- a/rcl/test/rcl/test_rmw_impl_id_check_func.cpp
+++ b/rcl/test/rcl/test_rmw_impl_id_check_func.cpp
@@ -81,7 +81,7 @@ MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, <)
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, >)
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, !=)
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
 // Mock internal calls to external libraries to fail
 TEST(TestRmwCheck, test_mock_rmw_impl_check) {
   {
@@ -156,4 +156,4 @@ TEST(TestRmwCheck, test_mock_rmw_impl_check) {
     rcl_reset_error();
   }
 }
-#endif  // RCL_SKIP_MIMICK
+#endif  // SKIP_MIMICK

--- a/rcl/test/rcl/test_security.cpp
+++ b/rcl/test/rcl/test_security.cpp
@@ -263,7 +263,7 @@ TEST_F(TestGetSecureRoot, test_get_security_options) {
 TEST_F(TestGetSecureRoot, test_rcl_security_enabled) {
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_security_enabled(nullptr));
   rcl_reset_error();
-
+#ifndef RCL_SKIP_MIMICK
   {
     bool use_security;
     auto mock = mocking_utils::patch_and_return(
@@ -271,6 +271,7 @@ TEST_F(TestGetSecureRoot, test_rcl_security_enabled) {
     EXPECT_EQ(RCL_RET_ERROR, rcl_security_enabled(&use_security));
     rcl_reset_error();
   }
+#endif  // RCL_SKIP_MIMICK
 
   {
     bool use_security = false;
@@ -307,6 +308,7 @@ TEST_F(TestGetSecureRoot, test_rcl_get_enforcement_policy) {
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_get_enforcement_policy(nullptr));
   rcl_reset_error();
 
+#ifndef RCL_SKIP_MIMICK
   {
     rmw_security_enforcement_policy_t policy;
     auto mock = mocking_utils::patch_and_return(
@@ -314,6 +316,7 @@ TEST_F(TestGetSecureRoot, test_rcl_get_enforcement_policy) {
     EXPECT_EQ(RCL_RET_ERROR, rcl_get_enforcement_policy(&policy));
     rcl_reset_error();
   }
+#endif  // RCL_SKIP_MIMICK
 
   {
     rmw_security_enforcement_policy_t policy = RMW_SECURITY_ENFORCEMENT_PERMISSIVE;
@@ -362,6 +365,7 @@ TEST_F(TestGetSecureRoot, test_rcl_get_secure_root_with_bad_arguments) {
   rcl_reset_error();
 }
 
+#ifndef RCL_SKIP_MIMICK
 TEST_F(TestGetSecureRoot, test_rcl_get_secure_root_with_internal_errors) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_allocator_t failing_allocator = get_time_bombed_allocator();
@@ -404,3 +408,4 @@ TEST_F(TestGetSecureRoot, test_rcl_get_secure_root_with_internal_errors) {
   EXPECT_TRUE(rcl_error_is_set());
   rcl_reset_error();
 }
+#endif  // RCL_SKIP_MIMICK

--- a/rcl/test/rcl/test_security.cpp
+++ b/rcl/test/rcl/test_security.cpp
@@ -263,7 +263,7 @@ TEST_F(TestGetSecureRoot, test_get_security_options) {
 TEST_F(TestGetSecureRoot, test_rcl_security_enabled) {
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_security_enabled(nullptr));
   rcl_reset_error();
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   {
     bool use_security;
     auto mock = mocking_utils::patch_and_return(
@@ -271,7 +271,7 @@ TEST_F(TestGetSecureRoot, test_rcl_security_enabled) {
     EXPECT_EQ(RCL_RET_ERROR, rcl_security_enabled(&use_security));
     rcl_reset_error();
   }
-#endif  // RCL_SKIP_MIMICK
+#endif  // SKIP_MIMICK
 
   {
     bool use_security = false;
@@ -308,7 +308,7 @@ TEST_F(TestGetSecureRoot, test_rcl_get_enforcement_policy) {
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_get_enforcement_policy(nullptr));
   rcl_reset_error();
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   {
     rmw_security_enforcement_policy_t policy;
     auto mock = mocking_utils::patch_and_return(
@@ -316,7 +316,7 @@ TEST_F(TestGetSecureRoot, test_rcl_get_enforcement_policy) {
     EXPECT_EQ(RCL_RET_ERROR, rcl_get_enforcement_policy(&policy));
     rcl_reset_error();
   }
-#endif  // RCL_SKIP_MIMICK
+#endif  // SKIP_MIMICK
 
   {
     rmw_security_enforcement_policy_t policy = RMW_SECURITY_ENFORCEMENT_PERMISSIVE;
@@ -365,7 +365,7 @@ TEST_F(TestGetSecureRoot, test_rcl_get_secure_root_with_bad_arguments) {
   rcl_reset_error();
 }
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
 TEST_F(TestGetSecureRoot, test_rcl_get_secure_root_with_internal_errors) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_allocator_t failing_allocator = get_time_bombed_allocator();
@@ -408,4 +408,4 @@ TEST_F(TestGetSecureRoot, test_rcl_get_secure_root_with_internal_errors) {
   EXPECT_TRUE(rcl_error_is_set());
   rcl_reset_error();
 }
-#endif  // RCL_SKIP_MIMICK
+#endif  // SKIP_MIMICK

--- a/rcl/test/rcl/test_service.cpp
+++ b/rcl/test/rcl/test_service.cpp
@@ -430,6 +430,7 @@ MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, <)
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, >)
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, !=)
 
+#ifndef RCL_SKIP_MIMICK
 /* Test failed service initialization using mocks
  */
 TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_fail_ini_mocked) {
@@ -493,6 +494,7 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_fail_ini_mocked) 
     rcl_reset_error();
   }
 }
+#endif  // RCL_SKIP_TESTS
 
 /* Test failed service finalization using mocks
  */
@@ -510,12 +512,14 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_fail_fini_mocked)
   ret = rcl_service_fini(&empty_service, this->node_ptr);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
+#ifndef RCL_SKIP_MIMICK
   auto mock = mocking_utils::inject_on_return(
     "lib:rcl", rmw_destroy_service, RMW_RET_ERROR);
   ret = rcl_service_fini(&service, this->node_ptr);
   EXPECT_EQ(RCL_RET_ERROR, ret) << rcl_get_error_string().str;
   EXPECT_TRUE(rcl_error_is_set());
   rcl_reset_error();
+#endif  // RCL_SKIP_TESTS
 }
 
 /* Test failed service take_request_with_info using mocks and nullptrs
@@ -557,7 +561,7 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_fail_take_request
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
   EXPECT_TRUE(rcl_error_is_set());
   rcl_reset_error();
-
+#ifndef RCL_SKIP_MIMICK
   {
     auto mock = mocking_utils::patch_and_return(
       "lib:rcl", rmw_take_request, RMW_RET_ERROR);
@@ -584,6 +588,7 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_fail_take_request
     ret = rcl_take_request_with_info(&service, &header, &service_request);
     EXPECT_EQ(RCL_RET_SERVICE_TAKE_FAILED, ret);
   }
+#endif  // RCL_SKIP_TESTS
 }
 
 /* Test failed service send_response using mocks and nullptrs
@@ -621,6 +626,7 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_fail_send_respons
   ret = rcl_send_response(&service, &header.request_id, nullptr);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
 
+#ifndef RCL_SKIP_MIMICK
   {
     auto mock = mocking_utils::patch_and_return(
       "lib:rcl", rmw_send_response, RMW_RET_ERROR);
@@ -629,4 +635,5 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_fail_send_respons
     EXPECT_TRUE(rcl_error_is_set());
     rcl_reset_error();
   }
+#endif  // RCL_SKIP_TESTS
 }

--- a/rcl/test/rcl/test_service.cpp
+++ b/rcl/test/rcl/test_service.cpp
@@ -430,7 +430,7 @@ MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, <)
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, >)
 MOCKING_UTILS_BOOL_OPERATOR_RETURNS_FALSE(rcutils_allocator_t, !=)
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
 /* Test failed service initialization using mocks
  */
 TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_fail_ini_mocked) {
@@ -512,7 +512,7 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_fail_fini_mocked)
   ret = rcl_service_fini(&empty_service, this->node_ptr);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   auto mock = mocking_utils::inject_on_return(
     "lib:rcl", rmw_destroy_service, RMW_RET_ERROR);
   ret = rcl_service_fini(&service, this->node_ptr);
@@ -561,7 +561,7 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_fail_take_request
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
   EXPECT_TRUE(rcl_error_is_set());
   rcl_reset_error();
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   {
     auto mock = mocking_utils::patch_and_return(
       "lib:rcl", rmw_take_request, RMW_RET_ERROR);
@@ -626,7 +626,7 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_fail_send_respons
   ret = rcl_send_response(&service, &header.request_id, nullptr);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   {
     auto mock = mocking_utils::patch_and_return(
       "lib:rcl", rmw_send_response, RMW_RET_ERROR);

--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -188,7 +188,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
   EXPECT_EQ(RCL_RET_TOPIC_NAME_INVALID, ret) << rcl_get_error_string().str;
   rcl_reset_error();
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   {
     rcutils_ret_t rcutils_string_map_init_returns = RCUTILS_RET_BAD_ALLOC;
     auto mock = mocking_utils::patch_and_return(
@@ -240,7 +240,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
     EXPECT_EQ(RCL_RET_ERROR, ret);
     rcl_reset_error();
   }
-#endif  // RCL_SKIP_MIMICK
+#endif  // SKIP_MIMICK
   ret = rcl_subscription_init(&subscription, this->node_ptr, ts, topic, &subscription_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   ASSERT_TRUE(rcl_subscription_is_valid(&subscription));
@@ -255,7 +255,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
   EXPECT_EQ(RCL_RET_NODE_INVALID, rcl_subscription_fini(&subscription, &invalid_node));
   rcl_reset_error();
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   {
     auto mock =
       mocking_utils::inject_on_return("lib:rcl", rmw_destroy_subscription, RMW_RET_ERROR);
@@ -635,7 +635,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
   }
 }
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
 /* Basic test for subscription loan functions
  */
 TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription_loaned) {
@@ -716,7 +716,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   }
 }
-#endif  // RCL_SKIP_MIMICK
+#endif  // SKIP_MIMICK
 
 /* Test for all failure modes in subscription take with loaned messages function.
  */
@@ -753,7 +753,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_bad_take_loa
   rcl_reset_error();
   loaned_message = nullptr;
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   {
     rmw_ret_t rmw_take_loaned_message_with_info_returns = RMW_RET_OK;
     auto mock = mocking_utils::patch(
@@ -786,7 +786,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_bad_take_loa
         &subscription, type_erased_loaned_message_pointer, message_info, allocation));
     rcl_reset_error();
   }
-#endif  // RCL_SKIP_MIMICK
+#endif  // SKIP_MIMICK
 
   EXPECT_EQ(
     RCL_RET_OK,
@@ -827,7 +827,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_bad_return_l
     RCL_RET_INVALID_ARGUMENT, rcl_return_loaned_message_from_subscription(&subscription, nullptr));
   rcl_reset_error();
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   {
     rmw_ret_t rmw_return_loaned_message_from_subscription_returns = RMW_RET_OK;
     auto mock = mocking_utils::patch_and_return(
@@ -850,7 +850,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_bad_return_l
       RCL_RET_ERROR, rcl_return_loaned_message_from_subscription(&subscription, loaned_message));
     rcl_reset_error();
   }
-#endif  // RCL_SKIP_MIMICK
+#endif  // SKIP_MIMICK
 
   EXPECT_EQ(
     RCL_RET_OK,
@@ -896,7 +896,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixtureInit, RMW_IMPLEMENTATION), test_subscrip
     RCL_RET_SUBSCRIPTION_INVALID, rcl_take(&subscription_zero_init, &msg, &message_info, nullptr));
   rcl_reset_error();
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   rmw_ret_t rmw_take_with_info_returns = RMW_RET_OK;
   auto mock = mocking_utils::patch(
     "lib:rcl", rmw_take_with_info,
@@ -918,7 +918,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixtureInit, RMW_IMPLEMENTATION), test_subscrip
   EXPECT_EQ(
     RCL_RET_ERROR, rcl_take(&subscription, &msg, &message_info, nullptr));
   rcl_reset_error();
-#endif  // RCL_SKIP_MIMICK
+#endif  // SKIP_MIMICK
 }
 
 /* bad take_serialized
@@ -952,7 +952,7 @@ TEST_F(
     rcl_take_serialized_message(&subscription, nullptr, message_info, allocation));
   rcl_reset_error();
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   rmw_ret_t rmw_take_serialized_message_with_info_returns = RMW_RET_OK;
   auto mock = mocking_utils::patch(
     "lib:rcl", rmw_take_serialized_message_with_info,
@@ -977,7 +977,7 @@ TEST_F(
     RCL_RET_ERROR,
     rcl_take_serialized_message(&subscription, &serialized_msg, message_info, allocation));
   rcl_reset_error();
-#endif  // RCL_SKIP_MIMICK
+#endif  // SKIP_MIMICK
 }
 
 /* Bad arguments take_sequence
@@ -1036,7 +1036,7 @@ TEST_F(
     rcl_take_sequence(&subscription, seq_size, &messages, nullptr, allocation));
   rcl_reset_error();
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   rmw_ret_t rmw_take_sequence_returns = RMW_RET_OK;
   auto mock = mocking_utils::patch(
     "lib:rcl", rmw_take_sequence,
@@ -1061,7 +1061,7 @@ TEST_F(
     RCL_RET_ERROR,
     rcl_take_sequence(&subscription, seq_size, &messages, &message_infos, allocation));
   rcl_reset_error();
-#endif  // RCL_SKIP_MIMICK
+#endif  // SKIP_MIMICK
 }
 
 /* Test for all failure modes in subscription get_publisher_count function.
@@ -1083,7 +1083,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixtureInit, RMW_IMPLEMENTATION), test_bad_get_
     rcl_subscription_get_publisher_count(&subscription, nullptr));
   rcl_reset_error();
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   auto mock = mocking_utils::patch_and_return(
     "lib:rcl", rmw_subscription_count_matched_publishers, RMW_RET_ERROR);
   EXPECT_EQ(

--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -188,6 +188,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
   EXPECT_EQ(RCL_RET_TOPIC_NAME_INVALID, ret) << rcl_get_error_string().str;
   rcl_reset_error();
 
+#ifndef RCL_SKIP_MIMICK
   {
     rcutils_ret_t rcutils_string_map_init_returns = RCUTILS_RET_BAD_ALLOC;
     auto mock = mocking_utils::patch_and_return(
@@ -239,7 +240,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
     EXPECT_EQ(RCL_RET_ERROR, ret);
     rcl_reset_error();
   }
-
+#endif  // RCL_SKIP_MIMICK
   ret = rcl_subscription_init(&subscription, this->node_ptr, ts, topic, &subscription_options);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   ASSERT_TRUE(rcl_subscription_is_valid(&subscription));
@@ -254,13 +255,16 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
   EXPECT_EQ(RCL_RET_NODE_INVALID, rcl_subscription_fini(&subscription, &invalid_node));
   rcl_reset_error();
 
-  auto mock =
-    mocking_utils::inject_on_return("lib:rcl", rmw_destroy_subscription, RMW_RET_ERROR);
-  EXPECT_EQ(RCL_RET_ERROR, rcl_subscription_fini(&subscription, this->node_ptr));
-  rcl_reset_error();
+#ifndef RCL_SKIP_MIMICK
+  {
+    auto mock =
+      mocking_utils::inject_on_return("lib:rcl", rmw_destroy_subscription, RMW_RET_ERROR);
+    EXPECT_EQ(RCL_RET_ERROR, rcl_subscription_fini(&subscription, this->node_ptr));
+    rcl_reset_error();
+  }
+#endif
 
-  // Make sure finalization completed anyways.
-  ASSERT_EQ(NULL, subscription.impl);
+  EXPECT_EQ(RCL_RET_OK, rcl_subscription_fini(&subscription, this->node_ptr));
 }
 
 /* Basic nominal test of a subscription
@@ -631,6 +635,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
   }
 }
 
+#ifndef RCL_SKIP_MIMICK
 /* Basic test for subscription loan functions
  */
 TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription_loaned) {
@@ -711,6 +716,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   }
 }
+#endif  // RCL_SKIP_MIMICK
 
 /* Test for all failure modes in subscription take with loaned messages function.
  */
@@ -747,6 +753,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_bad_take_loa
   rcl_reset_error();
   loaned_message = nullptr;
 
+#ifndef RCL_SKIP_MIMICK
   {
     rmw_ret_t rmw_take_loaned_message_with_info_returns = RMW_RET_OK;
     auto mock = mocking_utils::patch(
@@ -779,6 +786,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_bad_take_loa
         &subscription, type_erased_loaned_message_pointer, message_info, allocation));
     rcl_reset_error();
   }
+#endif  // RCL_SKIP_MIMICK
 
   EXPECT_EQ(
     RCL_RET_OK,
@@ -819,6 +827,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_bad_return_l
     RCL_RET_INVALID_ARGUMENT, rcl_return_loaned_message_from_subscription(&subscription, nullptr));
   rcl_reset_error();
 
+#ifndef RCL_SKIP_MIMICK
   {
     rmw_ret_t rmw_return_loaned_message_from_subscription_returns = RMW_RET_OK;
     auto mock = mocking_utils::patch_and_return(
@@ -841,6 +850,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_bad_return_l
       RCL_RET_ERROR, rcl_return_loaned_message_from_subscription(&subscription, loaned_message));
     rcl_reset_error();
   }
+#endif  // RCL_SKIP_MIMICK
 
   EXPECT_EQ(
     RCL_RET_OK,
@@ -886,6 +896,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixtureInit, RMW_IMPLEMENTATION), test_subscrip
     RCL_RET_SUBSCRIPTION_INVALID, rcl_take(&subscription_zero_init, &msg, &message_info, nullptr));
   rcl_reset_error();
 
+#ifndef RCL_SKIP_MIMICK
   rmw_ret_t rmw_take_with_info_returns = RMW_RET_OK;
   auto mock = mocking_utils::patch(
     "lib:rcl", rmw_take_with_info,
@@ -907,13 +918,15 @@ TEST_F(CLASSNAME(TestSubscriptionFixtureInit, RMW_IMPLEMENTATION), test_subscrip
   EXPECT_EQ(
     RCL_RET_ERROR, rcl_take(&subscription, &msg, &message_info, nullptr));
   rcl_reset_error();
+#endif  // RCL_SKIP_MIMICK
 }
 
 /* bad take_serialized
 */
 TEST_F(
   CLASSNAME(TestSubscriptionFixtureInit, RMW_IMPLEMENTATION),
-  test_subscription_bad_take_serialized) {
+  test_subscription_bad_take_serialized)
+{
   rcl_serialized_message_t serialized_msg = rmw_get_zero_initialized_serialized_message();
   size_t initial_serialization_capacity = 0u;
   ASSERT_EQ(
@@ -939,6 +952,7 @@ TEST_F(
     rcl_take_serialized_message(&subscription, nullptr, message_info, allocation));
   rcl_reset_error();
 
+#ifndef RCL_SKIP_MIMICK
   rmw_ret_t rmw_take_serialized_message_with_info_returns = RMW_RET_OK;
   auto mock = mocking_utils::patch(
     "lib:rcl", rmw_take_serialized_message_with_info,
@@ -963,6 +977,7 @@ TEST_F(
     RCL_RET_ERROR,
     rcl_take_serialized_message(&subscription, &serialized_msg, message_info, allocation));
   rcl_reset_error();
+#endif  // RCL_SKIP_MIMICK
 }
 
 /* Bad arguments take_sequence
@@ -1021,6 +1036,7 @@ TEST_F(
     rcl_take_sequence(&subscription, seq_size, &messages, nullptr, allocation));
   rcl_reset_error();
 
+#ifndef RCL_SKIP_MIMICK
   rmw_ret_t rmw_take_sequence_returns = RMW_RET_OK;
   auto mock = mocking_utils::patch(
     "lib:rcl", rmw_take_sequence,
@@ -1045,6 +1061,7 @@ TEST_F(
     RCL_RET_ERROR,
     rcl_take_sequence(&subscription, seq_size, &messages, &message_infos, allocation));
   rcl_reset_error();
+#endif  // RCL_SKIP_MIMICK
 }
 
 /* Test for all failure modes in subscription get_publisher_count function.
@@ -1066,12 +1083,14 @@ TEST_F(CLASSNAME(TestSubscriptionFixtureInit, RMW_IMPLEMENTATION), test_bad_get_
     rcl_subscription_get_publisher_count(&subscription, nullptr));
   rcl_reset_error();
 
+#ifndef RCL_SKIP_MIMICK
   auto mock = mocking_utils::patch_and_return(
     "lib:rcl", rmw_subscription_count_matched_publishers, RMW_RET_ERROR);
   EXPECT_EQ(
     RCL_RET_ERROR,
     rcl_subscription_get_publisher_count(&subscription, &publisher_count));
   rcl_reset_error();
+#endif
 }
 
 /* Using bad arguments subscription methods

--- a/rcl/test/rcl/test_validate_enclave_name.cpp
+++ b/rcl/test/rcl/test_validate_enclave_name.cpp
@@ -54,6 +54,7 @@ TEST(TestValidateEnclaveName, test_validate) {
     rcl_validate_enclave_name("/foo/bar", &validation_result, &invalid_index));
   EXPECT_EQ(RCL_ENCLAVE_NAME_VALID, validation_result);
 
+#ifndef RCL_SKIP_MIMICK
   {
     auto mock = mocking_utils::patch(
       "lib:rcl", rmw_validate_namespace_with_size,
@@ -72,12 +73,14 @@ TEST(TestValidateEnclaveName, test_validate) {
       rcl_validate_enclave_name("/foo/baz", &validation_result, &invalid_index));
     EXPECT_EQ(RCL_ENCLAVE_NAME_VALID, validation_result);
   }
+#endif  // RCL_SKIP_TESTS
 }
 
-TEST(TestValidateEnclaveName, test_validate_on_internal_error) {
+#ifndef RCL_SKIP_MIMICK
+TEST(TestValidateEnclaveName, test_validate_on_internal_error)
+{
   int validation_result;
   size_t invalid_index;
-
   {
     auto mock = mocking_utils::patch_to_fail(
       "lib:rcl", rmw_validate_namespace_with_size, "internal error", RMW_RET_ERROR);
@@ -88,7 +91,6 @@ TEST(TestValidateEnclaveName, test_validate_on_internal_error) {
     EXPECT_TRUE(rcl_error_is_set());
     rcl_reset_error();
   }
-
   {
     auto mock = mocking_utils::patch(
       "lib:rcl", rmw_validate_namespace_with_size,
@@ -107,6 +109,7 @@ TEST(TestValidateEnclaveName, test_validate_on_internal_error) {
     rcl_reset_error();
   }
 }
+#endif  // RCL_SKIP_TESTS
 
 TEST(TestValidateEnclaveName, test_validation_string) {
   struct enclave_case

--- a/rcl/test/rcl/test_validate_enclave_name.cpp
+++ b/rcl/test/rcl/test_validate_enclave_name.cpp
@@ -54,7 +54,7 @@ TEST(TestValidateEnclaveName, test_validate) {
     rcl_validate_enclave_name("/foo/bar", &validation_result, &invalid_index));
   EXPECT_EQ(RCL_ENCLAVE_NAME_VALID, validation_result);
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
   {
     auto mock = mocking_utils::patch(
       "lib:rcl", rmw_validate_namespace_with_size,
@@ -76,7 +76,7 @@ TEST(TestValidateEnclaveName, test_validate) {
 #endif  // RCL_SKIP_TESTS
 }
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
 TEST(TestValidateEnclaveName, test_validate_on_internal_error)
 {
   int validation_result;

--- a/rcl/test/rcl/test_wait.cpp
+++ b/rcl/test/rcl/test_wait.cpp
@@ -708,6 +708,7 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), wait_set_get_allocator
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 }
 
+#ifndef RCL_SKIP_MIMICK
 // Test wait set init failure cases using mocks
 TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), wait_set_failed_init) {
   rcl_wait_set_t wait_set = rcl_get_zero_initialized_wait_set();
@@ -736,6 +737,7 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), wait_set_failed_fini) 
     rcl_reset_error();
   }
 }
+#endif  // RCL_SKIP_MIMICK
 
 // Test proper error handling with a fault injection test
 TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), wait_set_test_maybe_init_fail) {

--- a/rcl/test/rcl/test_wait.cpp
+++ b/rcl/test/rcl/test_wait.cpp
@@ -708,7 +708,7 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), wait_set_get_allocator
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 }
 
-#ifndef RCL_SKIP_MIMICK
+#ifndef SKIP_MIMICK
 // Test wait set init failure cases using mocks
 TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), wait_set_failed_init) {
   rcl_wait_set_t wait_set = rcl_get_zero_initialized_wait_set();
@@ -737,7 +737,7 @@ TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), wait_set_failed_fini) 
     rcl_reset_error();
   }
 }
-#endif  // RCL_SKIP_MIMICK
+#endif  // SKIP_MIMICK
 
 // Test proper error handling with a fault injection test
 TEST_F(CLASSNAME(WaitSetTestFixture, RMW_IMPLEMENTATION), wait_set_test_maybe_init_fail) {


### PR DESCRIPTION
Mimick is a really platform dependent library.
e.g. Android has its own ABI for arm, so the library doesn't compile there.

That makes imposible to crosscompile ROS 2 to android, which is something that rcljava was testing.

Depends on https://github.com/ros2/mimick_vendor/pull/21.