### PR TITLE
rename variable to fix name shadowing warning

### DIFF
--- a/rcl_lifecycle/src/default_state_machine.c
+++ b/rcl_lifecycle/src/default_state_machine.c
@@ -657,7 +657,7 @@ rcl_ret_t
 rcl_lifecycle_init_default_state_machine(
   rcl_lifecycle_state_machine_t * state_machine, const rcutils_allocator_t * allocator)
 {
-  rcl_ret_t ret = RCL_RET_ERROR;
+  rcl_ret_t fcn_ret = RCL_RET_ERROR;
   // Used for concatenating error messages in the fail: block.
   // The cause or error which leads to jump to fail:
   char * fail_error_message = NULL;
@@ -668,24 +668,24 @@ rcl_lifecycle_init_default_state_machine(
   // ***************************
   // register all primary states
   // ***************************
-  ret = _register_primary_states(&state_machine->transition_map, allocator);
-  if (ret != RCL_RET_OK) {
+  fcn_ret = _register_primary_states(&state_machine->transition_map, allocator);
+  if (fcn_ret != RCL_RET_OK) {
     goto fail;
   }
 
   // ******************************
   // register all transition states
   // ******************************
-  ret = _register_transition_states(&state_machine->transition_map, allocator);
-  if (ret != RCL_RET_OK) {
+  fcn_ret = _register_transition_states(&state_machine->transition_map, allocator);
+  if (fcn_ret != RCL_RET_OK) {
     goto fail;
   }
 
   // ************************
   // register all transitions
   // ************************
-  ret = _register_transitions(&state_machine->transition_map, allocator);
-  if (ret != RCL_RET_OK) {
+  fcn_ret = _register_transitions(&state_machine->transition_map, allocator);
+  if (fcn_ret != RCL_RET_OK) {
     goto fail;
   }
 
@@ -695,7 +695,7 @@ rcl_lifecycle_init_default_state_machine(
   state_machine->current_state = rcl_lifecycle_get_state(
     &state_machine->transition_map, lifecycle_msgs__msg__State__PRIMARY_STATE_UNCONFIGURED);
 
-  return ret;
+  return fcn_ret;
 
 fail:
   // If rcl_lifecycle_transition_map_fini() fails, it will clobber the error string here.

--- a/rcl_lifecycle/src/rcl_lifecycle.c
+++ b/rcl_lifecycle/src/rcl_lifecycle.c
@@ -360,9 +360,9 @@ _trigger_transition(
   state_machine->current_state = transition->goal;
 
   if (publish_notification) {
-    rcl_ret_t ret = rcl_lifecycle_com_interface_publish_notification(
+    rcl_ret_t fcn_ret = rcl_lifecycle_com_interface_publish_notification(
       &state_machine->com_interface, transition->start, state_machine->current_state);
-    if (ret != RCL_RET_OK) {
+    if (fcn_ret != RCL_RET_OK) {
       rcl_error_string_t error_string = rcl_get_error_string();
       rcutils_reset_error();
       RCL_SET_ERROR_MSG_WITH_FORMAT_STRING("Could not publish transition: %s", error_string.str);


### PR DESCRIPTION
Fixes the following warning

```
_ws/src/ros2/rcl/rcl_lifecycle/src/rcl_lifecycle.c:368:7: warning: declaration of 'ret' shadows a previous local [-Wshadow]
       RCL_SET_ERROR_MSG_WITH_FORMAT_STRING("Could not publish transition: %s", error_string.str);
       ^

_ws/src/ros2/rcl/rcl_lifecycle/src/rcl_lifecycle.c:363:15: note: shadowed declaration is here
     rcl_ret_t ret = rcl_lifecycle_com_interface_publish_notification(

_ws/src/ros2/rcl/rcl_lifecycle/src/default_state_machine.c:715:5: warning: declaration of 'ret' shadows a previous local [-Wshadow]
     RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
     ^
_ws/src/ros2/rcl/rcl_lifecycle/src/default_state_machine.c:660:13: note: shadowed declaration is here
   rcl_ret_t ret = RCL_RET_ERROR;

```


Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>