### PR TITLE
Fix up documentation build for rcl_action when using rosdoc2

### DIFF
--- a/rcl_action/Doxyfile
+++ b/rcl_action/Doxyfile
@@ -15,7 +15,7 @@ GENERATE_LATEX         = NO
 ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES
-PREDEFINED             += RCL_PUBLIC=
+PREDEFINED             += RCL_ACTION_PUBLIC=
 PREDEFINED             += RCL_WARN_UNUSED=
 
 # Uncomment to generate internal documentation.

--- a/rcl_action/include/rcl_action/action_client.h
+++ b/rcl_action/include/rcl_action/action_client.h
@@ -27,17 +27,17 @@ extern "C"
 
 
 /// Internal action client implementation struct.
-struct rcl_action_client_impl_t;
+typedef struct rcl_action_client_impl_s rcl_action_client_impl_t;
 
 /// Structure which encapsulates a ROS action client.
-typedef struct rcl_action_client_t
+typedef struct rcl_action_client_s
 {
   /// Pointer to the action client implementation
-  struct rcl_action_client_impl_t * impl;
+  rcl_action_client_impl_t * impl;
 } rcl_action_client_t;
 
 /// Options available for a rcl_action_client_t.
-typedef struct rcl_action_client_options_t
+typedef struct rcl_action_client_options_s
 {
   /// Middleware quality of service settings for the action client.
   /// Goal service quality of service

--- a/rcl_action/include/rcl_action/action_server.h
+++ b/rcl_action/include/rcl_action/action_server.h
@@ -30,17 +30,17 @@ extern "C"
 #include "rosidl_runtime_c/action_type_support_struct.h"
 
 /// Internal rcl_action implementation struct.
-struct rcl_action_server_impl_t;
+typedef struct rcl_action_server_impl_s rcl_action_server_impl_t;
 
 /// Structure which encapsulates a ROS Action Server.
-typedef struct rcl_action_server_t
+typedef struct rcl_action_server_s
 {
   /// Pointer to the action server implementation
-  struct rcl_action_server_impl_t * impl;
+  rcl_action_server_impl_t * impl;
 } rcl_action_server_t;
 
 /// Options available for a rcl_action_server_t.
-typedef struct rcl_action_server_options_t
+typedef struct rcl_action_server_options_s
 {
   /// Middleware quality of service settings for the action server.
   /// Goal service quality of service

--- a/rcl_action/include/rcl_action/goal_handle.h
+++ b/rcl_action/include/rcl_action/goal_handle.h
@@ -27,13 +27,13 @@ extern "C"
 
 
 /// Internal rcl action goal implementation struct.
-struct rcl_action_goal_handle_impl_t;
+typedef struct rcl_action_goal_handle_impl_s rcl_action_goal_handle_impl_t;
 
 /// Goal handle for an action.
-typedef struct rcl_action_goal_handle_t
+typedef struct rcl_action_goal_handle_s
 {
   /// Pointer to the action goal handle implementation
-  struct rcl_action_goal_handle_impl_t * impl;
+  rcl_action_goal_handle_impl_t * impl;
 } rcl_action_goal_handle_t;
 
 /// Return a rcl_action_goal_handle_t struct with members set to `NULL`.

--- a/rcl_action/include/rcl_action/types.h
+++ b/rcl_action/include/rcl_action/types.h
@@ -59,14 +59,11 @@ extern "C"
 #define zerouuid (uint8_t[UUID_SIZE]) {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 #define uuidcmpzero(uuid) uuidcmp(uuid, (zerouuid))
 
-// Forward declare
-typedef struct rcl_action_server_t rcl_action_server_t;
-
 // Typedef generated messages for convenience
 typedef action_msgs__msg__GoalInfo rcl_action_goal_info_t;
 typedef action_msgs__msg__GoalStatus rcl_action_goal_status_t;
 /// Struct with the action goal status array
-typedef struct rcl_action_goal_status_array_t
+typedef struct rcl_action_goal_status_array_s
 {
   /// Goal status array message
   action_msgs__msg__GoalStatusArray msg;
@@ -75,7 +72,7 @@ typedef struct rcl_action_goal_status_array_t
 } rcl_action_goal_status_array_t;
 typedef action_msgs__srv__CancelGoal_Request rcl_action_cancel_request_t;
 /// Struct with the action cancel response
-typedef struct rcl_action_cancel_response_t
+typedef struct rcl_action_cancel_response_s
 {
   /// Cancel goal response message
   action_msgs__srv__CancelGoal_Response msg;
@@ -103,7 +100,7 @@ extern const char * goal_state_descriptions[];
 extern const char * goal_event_descriptions[];
 
 /// Goal state transition events
-typedef enum rcl_action_goal_event_t
+typedef enum rcl_action_goal_event_e
 {
   GOAL_EVENT_EXECUTE = 0,
   GOAL_EVENT_CANCEL_GOAL,

--- a/rcl_action/src/rcl_action/action_client_impl.h
+++ b/rcl_action/src/rcl_action/action_client_impl.h
@@ -18,7 +18,7 @@
 #include "rcl_action/types.h"
 #include "rcl/rcl.h"
 
-typedef struct rcl_action_client_impl_t
+typedef struct rcl_action_client_impl_s
 {
   rcl_client_t goal_client;
   rcl_client_t cancel_client;

--- a/rcl_action/src/rcl_action/action_server_impl.h
+++ b/rcl_action/src/rcl_action/action_server_impl.h
@@ -19,7 +19,7 @@
 #include "rcl/rcl.h"
 
 /// Internal rcl_action implementation struct.
-typedef struct rcl_action_server_impl_t
+typedef struct rcl_action_server_impl_s
 {
   rcl_service_t goal_service;
   rcl_service_t cancel_service;

--- a/rcl_action/src/rcl_action/goal_handle.c
+++ b/rcl_action/src/rcl_action/goal_handle.c
@@ -22,7 +22,7 @@ extern "C"
 #include "rcl/rcl.h"
 #include "rcl/error_handling.h"
 
-typedef struct rcl_action_goal_handle_impl_t
+typedef struct rcl_action_goal_handle_impl_s
 {
   rcl_action_goal_info_t info;
   rcl_action_goal_state_t state;


### PR DESCRIPTION
Similar to #932. 

CI above `rcl_action`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=15255)](http://ci.ros2.org/job/ci_linux/15255/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9974)](http://ci.ros2.org/job/ci_linux-aarch64/9974/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12939)](http://ci.ros2.org/job/ci_osx/12939/)
* Windows [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=15508)](https://ci.ros2.org/job/ci_windows/15508/)