### PR TITLE
Only change the default logger level if default_logger_level is set

### DIFF
--- a/rcl/src/rcl/logging.c
+++ b/rcl/src/rcl/logging.c
@@ -74,8 +74,10 @@ rcl_logging_configure_with_output_handler(
   g_rcl_logging_num_out_handlers = 0;
 
   if (log_levels) {
-    default_level = (int)log_levels->default_logger_level;
-    rcutils_logging_set_default_logger_level(default_level);
+    if (log_levels->default_logger_level != RCUTILS_LOG_SEVERITY_UNSET) {
+      default_level = (int)log_levels->default_logger_level;
+      rcutils_logging_set_default_logger_level(default_level);
+    }
 
     for (size_t i = 0; i < log_levels->num_logger_settings; ++i) {
       rcutils_ret_t rcutils_status = rcutils_logging_set_logger_level(


### PR DESCRIPTION
Required for https://github.com/ros2/rcutils/pull/347 to set the default logger value from the config file, otherwise, https://github.com/ros2/rcutils/blob/master/src/logging.c#L378 will set the default logger value back to RCUTILS_DEFAULT_LOGGER_DEFAULT_LEVEL after changing it in the linked PR