### PR TITLE
Fix jump callbacks being called when zero time jump thresholds used

### DIFF
--- a/rcl/src/rcl/time.c
+++ b/rcl/src/rcl/time.c
@@ -275,9 +275,9 @@ rcl_clock_call_callbacks(
     rcl_jump_callback_info_t * info = &(clock->jump_callbacks[cb_idx]);
     if (
       (is_clock_change && info->threshold.on_clock_change) ||
-      (time_jump->delta.nanoseconds < 0 &&
+      (info->threshold.min_backward.nanoseconds < 0 &&
       time_jump->delta.nanoseconds <= info->threshold.min_backward.nanoseconds) ||
-      (time_jump->delta.nanoseconds > 0 &&
+      (info->threshold.min_forward.nanoseconds > 0 &&
       time_jump->delta.nanoseconds >= info->threshold.min_forward.nanoseconds))
     {
       info->callback(time_jump, before_jump, info->user_data);

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -549,6 +549,12 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_forward_jump_callbacks) {
   EXPECT_FALSE(pre_callback_called);
   EXPECT_FALSE(post_callback_called);
 
+  // Jump backwards, no jump callbacks
+  ret = rcl_set_ros_time_override(&ros_clock, set_point1);
+  EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+  EXPECT_FALSE(pre_callback_called);
+  EXPECT_FALSE(post_callback_called);
+
   // disable no callbacks
   ret = rcl_disable_ros_time_override(&ros_clock);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
@@ -602,6 +608,12 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_backward_jump_callbacks) 
 
   // Setting same value as previous time, not a jump
   ret = rcl_set_ros_time_override(&ros_clock, set_point1);
+  EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+  EXPECT_FALSE(pre_callback_called);
+  EXPECT_FALSE(post_callback_called);
+
+  // Jump forwards, no jump callbacks
+  ret = rcl_set_ros_time_override(&ros_clock, set_point2);
   EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
   EXPECT_FALSE(pre_callback_called);
   EXPECT_FALSE(post_callback_called);


### PR DESCRIPTION
Fixes #947 
Related to ros2/rclcpp#1814
requries https://github.com/ros2/rclcpp/pull/1815

Zero callback thresholds are intended to disable the callbacks, but they were still being called.

https://github.com/ros2/rcl/blob/d8817fdd24c33b5e02786663f804a6240746c751/rcl/include/rcl/time.h#L113-L123

This PR adds expectations to existing tests for this case in the first commit, and fixes the bug in the second.