### PR TITLE
suppress false positive from clang-tidy

### DIFF
--- a/rcl/include/rcl/logging_rosout.h
+++ b/rcl/include/rcl/logging_rosout.h
@@ -158,7 +158,10 @@ rcl_logging_rosout_fini_publisher_for_node(
  * message out via that publisher. If there is no publisher directly correlated
  * with the logger then nothing will be done.
  *
- * This function is meant to be registered with the logging functions for rcutils
+ * This function is meant to be registered with the logging functions for
+ * rcutils, and shouldn't be used outside of that context.
+ * Additionally, arguments like args should be non-null and properly initialized
+ * otherwise it is undefined behavior.
  *
  * <hr>
  * Attribute          | Adherence
@@ -176,7 +179,8 @@ rcl_logging_rosout_fini_publisher_for_node(
  * \param[in] args argument for the string format
  */
 RCL_PUBLIC
-void rcl_logging_rosout_output_handler(
+void
+rcl_logging_rosout_output_handler(
   const rcutils_log_location_t * location,
   int severity,
   const char * name,

--- a/rcl/src/rcl/logging.c
+++ b/rcl/src/rcl/logging.c
@@ -165,8 +165,11 @@ static
 void
 rcl_logging_ext_lib_output_handler(
   const rcutils_log_location_t * location,
-  int severity, const char * name, rcutils_time_point_value_t timestamp,
-  const char * format, va_list * args)
+  int severity,
+  const char * name,
+  rcutils_time_point_value_t timestamp,
+  const char * format,
+  va_list * args)
 {
   rcl_ret_t status;
   char msg_buf[1024] = "";
@@ -188,7 +191,9 @@ rcl_logging_ext_lib_output_handler(
   };
 
   va_list args_clone;
-  va_copy(args_clone, *args);
+  // The args are initialized, but clang-tidy cannot tell.
+  // It may be related to this bug: https://bugs.llvm.org/show_bug.cgi?id=41311
+  va_copy(args_clone, *args);  // NOLINT(clang-analyzer-valist.Uninitialized)
   status = rcutils_char_array_vsprintf(&msg_array, format, args_clone);
   va_end(args_clone);
 

--- a/rcl/src/rcl/logging_rosout.c
+++ b/rcl/src/rcl/logging_rosout.c
@@ -231,8 +231,11 @@ rcl_ret_t rcl_logging_rosout_fini_publisher_for_node(
 
 void rcl_logging_rosout_output_handler(
   const rcutils_log_location_t * location,
-  int severity, const char * name, rcutils_time_point_value_t timestamp,
-  const char * format, va_list * args)
+  int severity,
+  const char * name,
+  rcutils_time_point_value_t timestamp,
+  const char * format,
+  va_list * args)
 {
   rosout_map_entry_t entry;
   rcl_ret_t status = RCL_RET_OK;
@@ -251,7 +254,9 @@ void rcl_logging_rosout_output_handler(
     };
 
     va_list args_clone;
-    va_copy(args_clone, *args);
+    // The args are initialized, but clang-tidy cannot tell.
+    // It may be related to this bug: https://bugs.llvm.org/show_bug.cgi?id=41311
+    va_copy(args_clone, *args);  // NOLINT(clang-analyzer-valist.Uninitialized)
     RCL_RET_FROM_RCUTIL_RET(status, rcutils_char_array_vsprintf(&msg_array, format, args_clone));
     va_end(args_clone);
     if (RCL_RET_OK != status) {


### PR DESCRIPTION
I believe this issue identified from clang-tidy is a false positive, but we should have more eyes on it.

It's similar to, but perhaps not the same, issue as in this clang-tidy bug: https://bugs.llvm.org/show_bug.cgi?id=41311

Either way, looking at the code I believe it to be safe, and clang-tidy simply cannot tell that the args are always initialized elsewhere. Again, more eyes would be good here.

This pull request suppresses these warnings with this in mind.

closes https://github.com/space-ros/space-ros/issues/4