### PR TITLE
Make rcl_difference_times args const

### DIFF
--- a/rcl/include/rcl/time.h
+++ b/rcl/include/rcl/time.h
@@ -473,7 +473,7 @@ RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
 rcl_difference_times(
-  rcl_time_point_t * start, rcl_time_point_t * finish, rcl_duration_t * delta);
+  const rcl_time_point_t * start, const rcl_time_point_t * finish, rcl_duration_t * delta);
 
 /// Fill the time point value with the current value of the associated clock.
 /**

--- a/rcl/src/rcl/time.c
+++ b/rcl/src/rcl/time.c
@@ -231,7 +231,7 @@ rcl_system_clock_fini(
 
 rcl_ret_t
 rcl_difference_times(
-  rcl_time_point_t * start, rcl_time_point_t * finish, rcl_duration_t * delta)
+  const rcl_time_point_t * start, const rcl_time_point_t * finish, rcl_duration_t * delta)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(start, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(finish, RCL_RET_INVALID_ARGUMENT);


### PR DESCRIPTION
This allows passing `const rcl_time_point_t *` variables into this function.