### PR TITLE
Install includes to include/${PROJECT_NAME}

### DIFF
--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -69,7 +69,7 @@ set(${PROJECT_NAME}_sources
 add_library(${PROJECT_NAME} ${${PROJECT_NAME}_sources})
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 # specific order: dependents before dependencies
 ament_target_dependencies(${PROJECT_NAME}
   "rcl_interfaces"
@@ -104,11 +104,13 @@ install(
 # This is overwritten each loop, but which one it points to doesn't really matter.
 set(rcl_lib_dir "$<TARGET_FILE_DIR:${PROJECT_NAME}>")
 
-# specific order: dependents before dependencies
-ament_export_include_directories(include)
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
+# Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
 
+# specific order: dependents before dependencies
 ament_export_dependencies(ament_cmake)
 ament_export_dependencies(rcl_interfaces)
 ament_export_dependencies(rcl_logging_interface)
@@ -135,5 +137,5 @@ install(
 )
 install(
   DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )

--- a/rcl_action/CMakeLists.txt
+++ b/rcl_action/CMakeLists.txt
@@ -45,7 +45,7 @@ add_library(${PROJECT_NAME}
 
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
 ament_target_dependencies(${PROJECT_NAME}
   "action_msgs"
@@ -62,7 +62,7 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE "RCL_ACTION_BUILDING_DLL")
 
 install(
   DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
 
 install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
@@ -85,7 +85,6 @@ if(BUILD_TESTING)
   )
   if(TARGET test_action_client)
     target_include_directories(test_action_client PUBLIC
-      include
       src
     )
     target_link_libraries(test_action_client
@@ -119,9 +118,6 @@ if(BUILD_TESTING)
         PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")
         target_compile_definitions(${target}${target_suffix}
           PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
-      target_include_directories(${target}${target_suffix} PUBLIC
-        include
-      )
       target_link_libraries(${target}${target_suffix}
         ${PROJECT_NAME}
       )
@@ -151,7 +147,6 @@ if(BUILD_TESTING)
   )
   if(TARGET test_action_server)
     target_include_directories(test_action_server PUBLIC
-      include
       src
     )
     target_link_libraries(test_action_server
@@ -168,9 +163,6 @@ if(BUILD_TESTING)
     test/rcl_action/test_goal_handle.cpp
   )
   if(TARGET test_goal_handle)
-    target_include_directories(test_goal_handle PUBLIC
-      include
-    )
     target_link_libraries(test_goal_handle
       ${PROJECT_NAME}
     )
@@ -189,9 +181,6 @@ if(BUILD_TESTING)
     test/rcl_action/test_types.cpp
   )
   if(TARGET test_types)
-    target_include_directories(test_types PUBLIC
-      include
-    )
     target_link_libraries(test_types
       ${PROJECT_NAME}
     )
@@ -224,10 +213,14 @@ if(BUILD_TESTING)
   endif()
 endif()
 
-# specific order: dependents before dependencies
-ament_export_include_directories(include)
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
+
+# Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
+
+# specific order: dependents before dependencies
 ament_export_dependencies(action_msgs)
 ament_export_dependencies(ament_cmake)
 ament_export_dependencies(rcl)

--- a/rcl_lifecycle/CMakeLists.txt
+++ b/rcl_lifecycle/CMakeLists.txt
@@ -45,7 +45,7 @@ add_library(
 
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
 # specific order: dependents before dependencies
 ament_target_dependencies(rcl_lifecycle
@@ -125,10 +125,14 @@ if(BUILD_TESTING)
   endif()
 endif()
 
-# specific order: dependents before dependencies
-ament_export_include_directories(include)
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
 ament_export_libraries(${PROJECT_NAME})
+
+# Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
+
+# specific order: dependents before dependencies
 ament_export_dependencies(ament_cmake)
 ament_export_dependencies(lifecycle_msgs)
 ament_export_dependencies(rcl)
@@ -139,4 +143,4 @@ ament_package()
 
 install(
   DIRECTORY include/
-  DESTINATION include)
+  DESTINATION include/${PROJECT_NAME})

--- a/rcl_yaml_param_parser/CMakeLists.txt
+++ b/rcl_yaml_param_parser/CMakeLists.txt
@@ -33,7 +33,7 @@ add_library(
   ${rcl_yaml_parser_sources})
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
-  "$<INSTALL_INTERFACE:include>")
+  "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 ament_target_dependencies(${PROJECT_NAME} "libyaml_vendor" "rcutils" "rmw")
 
 # Set the visibility to hidden by default if possible
@@ -185,13 +185,17 @@ if(BUILD_TESTING)
   endif()
 endif()
 
+# Export old-style CMake variables
+ament_export_include_directories("include/${PROJECT_NAME}")
+ament_export_libraries(${PROJECT_NAME})
+
+# Export modern CMake targets
+ament_export_targets(${PROJECT_NAME})
+
 ament_export_dependencies(ament_cmake libyaml_vendor)
 ament_export_dependencies(rmw)
-ament_export_include_directories(include)
 install(
   DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
-ament_export_libraries(${PROJECT_NAME})
-ament_export_targets(${PROJECT_NAME})
 ament_package()


### PR DESCRIPTION
Part of ros2/ros2#1150 - This eliminates issues with the include directory search order when overriding these packages by installing their includes to `include/${PROJECT_NAME}`