### PR TITLE
If timer canceled, rcl_timer_get_time_until_next_call returns TIMER_CANCELED

### DIFF
--- a/rcl/include/rcl/timer.h
+++ b/rcl/include/rcl/timer.h
@@ -318,6 +318,7 @@ rcl_timer_is_ready(const rcl_timer_t * timer, bool * is_ready);
  * \return #RCL_RET_OK if the timer until next call was successfully calculated, or
  * \return #RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or
  * \return #RCL_RET_TIMER_INVALID if the timer is invalid, or
+ * \return #RCL_RET_TIMER_CANCELED if the timer is canceled, or
  * \return #RCL_RET_ERROR an unspecified error occur.
  */
 RCL_PUBLIC

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -297,10 +297,13 @@ rcl_timer_is_ready(const rcl_timer_t * timer, bool * is_ready)
   RCL_CHECK_ARGUMENT_FOR_NULL(is_ready, RCL_RET_INVALID_ARGUMENT);
   int64_t time_until_next_call;
   rcl_ret_t ret = rcl_timer_get_time_until_next_call(timer, &time_until_next_call);
-  if (ret != RCL_RET_OK) {
+  if (ret == RCL_RET_TIMER_CANCELED) {
+    *is_ready = false;
+    return RCL_RET_OK;
+  } else if (ret != RCL_RET_OK) {
     return ret;  // rcl error state should already be set.
   }
-  *is_ready = (time_until_next_call <= 0) && !rcutils_atomic_load_bool(&timer->impl->canceled);
+  *is_ready = (time_until_next_call <= 0);
   return RCL_RET_OK;
 }
 

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -309,6 +309,9 @@ rcl_timer_get_time_until_next_call(const rcl_timer_t * timer, int64_t * time_unt
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(timer, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(time_until_next_call, RCL_RET_INVALID_ARGUMENT);
+  if (rcutils_atomic_load_bool(&timer->impl->canceled)) {
+    return RCL_RET_TIMER_CANCELED;
+  }
   rcl_time_point_value_t now;
   rcl_ret_t ret = rcl_clock_get_now(timer->impl->clock, &now);
   if (ret != RCL_RET_OK) {

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -499,7 +499,7 @@ TEST_F(TestTimerFixture, test_canceled_timer) {
 
   int64_t time_until_next_call = 0;
   ret = rcl_timer_get_time_until_next_call(&timer, &time_until_next_call);
-  EXPECT_EQ(RCL_RET_TIMER_CANCELED, ret);
+  EXPECT_EQ(RCL_RET_TIMER_CANCELED, ret) << rcl_get_error_string().str;
 
   rcl_wait_set_t wait_set = rcl_get_zero_initialized_wait_set();
   ret = rcl_wait_set_init(&wait_set, 0, 0, 1, 0, 0, 0, context_ptr, rcl_get_default_allocator());

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -497,6 +497,10 @@ TEST_F(TestTimerFixture, test_canceled_timer) {
   ret = rcl_timer_cancel(&timer);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
+  int64_t time_until_next_call = 0;
+  ret = rcl_timer_get_time_until_next_call(&timer, &time_until_next_call);
+  EXPECT_EQ(RCL_RET_TIMER_CANCELED, ret);
+
   rcl_wait_set_t wait_set = rcl_get_zero_initialized_wait_set();
   ret = rcl_wait_set_init(&wait_set, 0, 0, 1, 0, 0, 0, context_ptr, rcl_get_default_allocator());
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;


### PR DESCRIPTION
Return TIMER_CANCELED rcl_timer_get_time_until_next_call

Signed-off-by: Mauro Passerino <mpasserino@irobot.com>