### PR TITLE
Micro-optimizations in rcl

### DIFF
--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -217,7 +217,7 @@ rcl_wait_set_get_allocator(const rcl_wait_set_t * wait_set, rcl_allocator_t * al
 
 #define SET_ADD(Type) \
   RCL_CHECK_ARGUMENT_FOR_NULL(wait_set, RCL_RET_INVALID_ARGUMENT); \
-  if (!rcl_wait_set_is_valid(wait_set)) { \
+  if (!wait_set->impl) { \
     RCL_SET_ERROR_MSG("wait set is invalid"); \
     return RCL_RET_WAIT_SET_INVALID; \
   } \

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -586,6 +586,10 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
     temporary_timeout_storage.sec = 0;
     temporary_timeout_storage.nsec = 0;
     timeout_argument = &temporary_timeout_storage;
+    RCUTILS_LOG_DEBUG_NAMED(
+      ROS_PACKAGE_NAME,
+      "Waiting with timeout: %" PRIu64 "s + %" PRIu64 "ns, based on next scheduled timer: %d",
+      temporary_timeout_storage.sec, temporary_timeout_storage.nsec, is_timer_timeout);
   } else if (timeout > 0 || is_timer_timeout) {
     // If min_timeout was negative, we need to wake up immediately.
     if (min_timeout < 0) {
@@ -594,16 +598,16 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
     temporary_timeout_storage.sec = RCL_NS_TO_S(min_timeout);
     temporary_timeout_storage.nsec = min_timeout % 1000000000;
     timeout_argument = &temporary_timeout_storage;
+    RCUTILS_LOG_DEBUG_NAMED(
+      ROS_PACKAGE_NAME,
+      "Waiting with timeout: %" PRIu64 "s + %" PRIu64 "ns, based on next scheduled timer: %d",
+      temporary_timeout_storage.sec, temporary_timeout_storage.nsec, is_timer_timeout);
+  } else {
+    RCUTILS_LOG_DEBUG_NAMED(
+      ROS_PACKAGE_NAME,
+      "Waiting without timeout, based on next scheduled timer: %d",
+      is_timer_timeout);
   }
-  RCUTILS_LOG_DEBUG_EXPRESSION_NAMED(
-    !timeout_argument, ROS_PACKAGE_NAME, "Waiting without timeout");
-  RCUTILS_LOG_DEBUG_EXPRESSION_NAMED(
-    timeout_argument, ROS_PACKAGE_NAME,
-    "Waiting with timeout: %" PRIu64 "s + %" PRIu64 "ns",
-    temporary_timeout_storage.sec, temporary_timeout_storage.nsec);
-  RCUTILS_LOG_DEBUG_NAMED(
-    ROS_PACKAGE_NAME, "Timeout calculated based on next scheduled timer: %s",
-    is_timer_timeout ? "true" : "false");
 
   // Wait.
   rmw_ret_t ret = rmw_wait(

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -586,10 +586,6 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
     temporary_timeout_storage.sec = 0;
     temporary_timeout_storage.nsec = 0;
     timeout_argument = &temporary_timeout_storage;
-    RCUTILS_LOG_DEBUG_NAMED(
-      ROS_PACKAGE_NAME,
-      "Waiting with timeout: %" PRIu64 "s + %" PRIu64 "ns, based on next scheduled timer: %d",
-      temporary_timeout_storage.sec, temporary_timeout_storage.nsec, is_timer_timeout);
   } else if (timeout > 0 || is_timer_timeout) {
     // If min_timeout was negative, we need to wake up immediately.
     if (min_timeout < 0) {
@@ -598,15 +594,6 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
     temporary_timeout_storage.sec = RCL_NS_TO_S(min_timeout);
     temporary_timeout_storage.nsec = min_timeout % 1000000000;
     timeout_argument = &temporary_timeout_storage;
-    RCUTILS_LOG_DEBUG_NAMED(
-      ROS_PACKAGE_NAME,
-      "Waiting with timeout: %" PRIu64 "s + %" PRIu64 "ns, based on next scheduled timer: %d",
-      temporary_timeout_storage.sec, temporary_timeout_storage.nsec, is_timer_timeout);
-  } else {
-    RCUTILS_LOG_DEBUG_NAMED(
-      ROS_PACKAGE_NAME,
-      "Waiting without timeout, based on next scheduled timer: %d",
-      is_timer_timeout);
   }
 
   // Wait.
@@ -634,7 +621,6 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
     if (ret != RCL_RET_OK) {
       return ret;  // The rcl error state should already be set.
     }
-    RCUTILS_LOG_DEBUG_EXPRESSION_NAMED(is_ready, ROS_PACKAGE_NAME, "Timer in wait set is ready");
     if (!is_ready) {
       wait_set->timers[i] = NULL;
     }
@@ -647,8 +633,6 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
   // Set corresponding rcl subscription handles NULL.
   for (i = 0; i < wait_set->size_of_subscriptions; ++i) {
     bool is_ready = wait_set->impl->rmw_subscriptions.subscribers[i] != NULL;
-    RCUTILS_LOG_DEBUG_EXPRESSION_NAMED(
-      is_ready, ROS_PACKAGE_NAME, "Subscription in wait set is ready");
     if (!is_ready) {
       wait_set->subscriptions[i] = NULL;
     }
@@ -656,8 +640,6 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
   // Set corresponding rcl guard_condition handles NULL.
   for (i = 0; i < wait_set->size_of_guard_conditions; ++i) {
     bool is_ready = wait_set->impl->rmw_guard_conditions.guard_conditions[i] != NULL;
-    RCUTILS_LOG_DEBUG_EXPRESSION_NAMED(
-      is_ready, ROS_PACKAGE_NAME, "Guard condition in wait set is ready");
     if (!is_ready) {
       wait_set->guard_conditions[i] = NULL;
     }
@@ -665,7 +647,6 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
   // Set corresponding rcl client handles NULL.
   for (i = 0; i < wait_set->size_of_clients; ++i) {
     bool is_ready = wait_set->impl->rmw_clients.clients[i] != NULL;
-    RCUTILS_LOG_DEBUG_EXPRESSION_NAMED(is_ready, ROS_PACKAGE_NAME, "Client in wait set is ready");
     if (!is_ready) {
       wait_set->clients[i] = NULL;
     }
@@ -673,7 +654,6 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
   // Set corresponding rcl service handles NULL.
   for (i = 0; i < wait_set->size_of_services; ++i) {
     bool is_ready = wait_set->impl->rmw_services.services[i] != NULL;
-    RCUTILS_LOG_DEBUG_EXPRESSION_NAMED(is_ready, ROS_PACKAGE_NAME, "Service in wait set is ready");
     if (!is_ready) {
       wait_set->services[i] = NULL;
     }
@@ -681,7 +661,6 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
   // Set corresponding rcl event handles NULL.
   for (i = 0; i < wait_set->size_of_events; ++i) {
     bool is_ready = wait_set->impl->rmw_events.events[i] != NULL;
-    RCUTILS_LOG_DEBUG_EXPRESSION_NAMED(is_ready, ROS_PACKAGE_NAME, "Event in wait set is ready");
     if (!is_ready) {
       wait_set->events[i] = NULL;
     }


### PR DESCRIPTION
While doing some profiling of the rcl code, I noticed a few different places where we were unnecessarily doing work. This PR has three commits:

1. The first commit gets rid of duplicate checking of whether `wait_set` is NULL, since we just did that in the previous line.  Here I've chosen to remove the duplication by not calling `rcl_wait_set_is_valid` and just checking the `impl` pointer directly.  Another way to fix this is to remove the `RCL_CHECK_ARGUMENT_FOR_NULL` call on the previous line, and rely on `rcl_wait_set_is_valid` for validating both pointers.  I don't have a strong opinion about which way to go.
2. The second commit refactors a couple of the `RCUTILS_DEBUG` statements to try to reduce their overhead on the hot path.
3. The third commit somewhat controversially removes the `RCUTILS_DEBUG` statements from within `rcl_wait` completely.  Since this is a hot-path, the overhead of continually checking whether a debug statement should be output or not actually shows up in profiles.  Also, my feeling is that in general, these debug statements are not useful; if you are actually debugging something here, you need to use something more targeted.

With these statements removed, and in combination with https://github.com/ros2/rclcpp/pull/1896 , I saw about a 20% reduction in overhead in the application I was benchmarking.