### PR TITLE
Add rcl guard condition on_trigger_callback

### DIFF
--- a/rcl/include/rcl/guard_condition.h
+++ b/rcl/include/rcl/guard_condition.h
@@ -24,6 +24,7 @@ extern "C"
 
 #include "rcl/allocator.h"
 #include "rcl/context.h"
+#include "rcl/event_callback.h"
 #include "rcl/macros.h"
 #include "rcl/types.h"
 #include "rcl/visibility_control.h"
@@ -47,6 +48,14 @@ typedef struct rcl_guard_condition_options_s
   /// Custom allocator for the guard condition, used for internal allocations.
   rcl_allocator_t allocator;
 } rcl_guard_condition_options_t;
+
+/// On trigger callback data
+typedef struct rcl_guard_condition_callback_data_s
+{
+  rcl_event_callback_t on_trigger_callback;
+  const void * user_data;
+  size_t trigger_count;
+} rcl_guard_condition_callback_data_t;
 
 /// Return a rcl_guard_condition_t struct with members set to `NULL`.
 RCL_PUBLIC
@@ -261,6 +270,34 @@ RCL_PUBLIC
 RCL_WARN_UNUSED
 rmw_guard_condition_t *
 rcl_guard_condition_get_rmw_handle(const rcl_guard_condition_t * guard_condition);
+
+/// Set the on trigger callback function for the guard_condition.
+/**
+ * This API sets the callback function to be called whenever the
+ * guard_condition is triggered.
+ *
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | No
+ *
+ * \param[in] guard_condition The guard_condition on which to set the callback
+ * \param[in] on_trigger_callback The callback to be called when guard condition is triggered
+ * \param[in] user_data Given to the callback when called later, may be NULL
+ * \return `RCL_RET_OK` if successful, or
+ * \return `RCL_RET_INVALID_ARGUMENT` if `guard_condition` is NULL
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_guard_condition_set_on_trigger_callback(
+  const rcl_guard_condition_t * guard_condition,
+  rcl_event_callback_t on_trigger_callback,
+  const void * user_data);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This PR adds the `on_trigger_callback` callback to rcl guard conditions.

If the `on_trigger_callback` is set to a guard condition, it will be called every time the guard condition is triggered. 
If not, a counter will count the times the guard condiiton was triggered, and if eventually a callback is set it will use the counter as argument.

This PR is aligned to the recently added listener callbacks to the RMW entities ([subscriptions](https://github.com/ros2/rcl/blob/master/rcl/src/rcl/subscription.c#L449), [clients](rcl_client_set_on_new_response_callback), [services](https://github.com/ros2/rcl/blob/master/rcl/src/rcl/service.c#L350)).

The motivation behind this PR, be able to wake up events driven executors (not relying on a wait set) when guard conditions are triggered. For example, a timer is reset after being cancelled, so it's inner guard condition is triggered and we can take actions to update the next trigger time for the timer.

Signed-off-by: Mauro Passerino <mpasserino@irobot.com>