### PR TITLE
test_publisher_wait_all_ack depends on rcpputils

### DIFF
--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -223,7 +223,12 @@ function(test_target_function)
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
     LIBRARIES ${PROJECT_NAME} mimick wait_for_entity_helpers
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs" "rcpputils"
+    AMENT_DEPENDENCIES ${rmw_implementation}
+      "osrf_testing_tools_cpp"
+      "rcpputils"
+      "rcutils"
+      "rosidl_runtime_c"
+      "test_msgs"
   )
 
   rcl_add_custom_gtest(test_service${target_suffix}

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -223,7 +223,7 @@ function(test_target_function)
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
     LIBRARIES ${PROJECT_NAME} mimick wait_for_entity_helpers
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
+    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs" "rcpputils"
   )
 
   rcl_add_custom_gtest(test_service${target_suffix}


### PR DESCRIPTION
This adds a missing dependency of `test_publisher_wait_all_ack` on `rcpputils`.

https://github.com/ros2/rcl/blob/7ca950b78cf0661f305e54b047f767f6dbf536fa/rcl/test/rcl/test_publisher_wait_all_ack.cpp#L24