### PR TITLE
Add functions to get a compatible QoS profiles

### DIFF
--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -55,6 +55,7 @@ set(${PROJECT_NAME}_sources
   src/rcl/publisher.c
   src/rcl/remap.c
   src/rcl/node_resolve_name.c
+  src/rcl/qos_compatibility.c
   src/rcl/rmw_implementation_identifier_check.c
   src/rcl/security.c
   src/rcl/service.c

--- a/rcl/include/rcl/qos_compatibility.h
+++ b/rcl/include/rcl/qos_compatibility.h
@@ -36,10 +36,11 @@ extern "C"
  * <hr>
  * Attribute          | Adherence
  * ------------------ | -------------
- * Allocates Memory   | No
+ * Allocates Memory   | Yes
  * Thread-Safe        | No
  * Uses Atomics       | No
- * Lock-Free          | Yes
+ * Lock-Free          | Maybe [1]
+ * <i>[1] implementation may need to protect the data structure with a lock</i>
  *
  * \param[in] node The node to use to query the graph.
  * \param[in] topic_name Name of the topic to query for endpoints.

--- a/rcl/include/rcl/qos_compatibility.h
+++ b/rcl/include/rcl/qos_compatibility.h
@@ -1,0 +1,64 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// @file
+
+#ifndef RCL__QOS_COMPATIBILITY_H_
+#define RCL__QOS_COMPATIBILITY_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include "rcl/graph.h"
+#include "rcl/types.h"
+#include "rcl/visibility_control.h"
+
+/// Get a subscription QoS profile that is compatible with discovered endpoints.
+/**
+ * Adapts the given QoS profile to be compatible with the majority of publishers on a given topic,
+ * while maintaining the highest level of service possible.
+ *
+ * See also \ref rmw_qos_profile_get_most_compatible_for_subscription().
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] node The node to use to query the graph.
+ * \param[in] topic_name Name of the topic to query for endpoints.
+ * \param[out] subscription_qos_profile This QoS profile is modified such that is is compatible
+ *   with the majority of publishers on the given topic.
+ * \return #RCL_RET_OK if there were no errors, or
+ * \return #RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or
+ * \return #RCL_RET_ERROR an unexpected error occurred.
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_get_compatible_qos_for_topic_subscription(
+  const rcl_node_t * node,
+  const char * topic_name,
+  rmw_qos_profile_t * subscription_qos_profile);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // RCL__QOS_COMPATIBILITY_H_

--- a/rcl/src/rcl/qos_compatibility.c
+++ b/rcl/src/rcl/qos_compatibility.c
@@ -1,0 +1,78 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rcl/qos_compatibility.h"
+
+#include "rcl/error_handling.h"
+#include "rcl/graph.h"
+#include "rcl/types.h"
+
+#include "rmw/qos_profiles.h"
+
+rcl_ret_t
+rcl_get_compatible_qos_for_topic_subscription(
+  const rcl_node_t * node,
+  const char * topic_name,
+  rmw_qos_profile_t * subscription_qos_profile)
+{
+  if (!rcl_node_is_valid(node)) {
+    return RCL_RET_INVALID_ARGUMENT;
+  }
+  RCL_CHECK_ARGUMENT_FOR_NULL(topic_name, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(subscription_qos_profile, RCL_RET_INVALID_ARGUMENT);
+
+  const rcl_node_options_t * node_options = rcl_node_get_options(node);
+  const rcl_allocator_t * allocator = &node_options->allocator;
+
+  rcl_topic_endpoint_info_array_t publishers_info =
+    rcl_get_zero_initialized_topic_endpoint_info_array();
+  rcl_ret_t ret = rcl_get_publishers_info_by_topic(
+    node,
+    // TODO(jacobperron): Update rcl_get_publishers_info_by_topic API to take an rcl_allocator_t 
+    (rcutils_allocator_t *)allocator,
+    topic_name,
+    false,
+    &publishers_info);
+  if (RCL_RET_OK != ret) {
+    return ret;
+  }
+
+  const size_t number_of_publishers = publishers_info.size;
+  if (0u == number_of_publishers) {
+    return RCL_RET_OK;
+  }
+
+  // Copy QoS profiles to array
+  rmw_qos_profile_t * publisher_qos_profiles = (rmw_qos_profile_t *)allocator->allocate(
+    number_of_publishers * sizeof(rmw_qos_profile_t),
+    allocator->state);
+  for (size_t i = 0u; i < number_of_publishers; ++i) {
+    publisher_qos_profiles[i] = publishers_info.info_array[i].qos_profile;
+  }
+
+  rmw_ret_t rmw_ret = rmw_qos_profile_get_most_compatible_for_subscription(
+    publisher_qos_profiles,
+    number_of_publishers,
+    subscription_qos_profile,
+    NULL);
+
+  allocator->deallocate(publisher_qos_profiles, allocator->state);
+
+  if (RMW_RET_OK != rmw_ret) {
+    RCL_SET_ERROR_MSG("unexpected error getting compatible QoS profile for subscription");
+    return RCL_RET_ERROR;
+  }
+
+  return RCL_RET_OK;
+}


### PR DESCRIPTION
Connects to https://github.com/ros2/rmw/issues/304

Given a node and a topic name, query QoS profiles of publishers on the topic and
provide a QoS profile that is compatible with the majority of publishers.
All while keeping the highest level of service possible.

---

In draft, since I still need to add the equivalent function for publishers. Waiting to get some feedback on the API first though.