### PR TITLE
Make loaned messages const on the subscription side

### DIFF
--- a/rcl/include/rcl/subscription.h
+++ b/rcl/include/rcl/subscription.h
@@ -630,7 +630,7 @@ RCL_WARN_UNUSED
 rcl_ret_t
 rcl_take_loaned_message(
   const rcl_subscription_t * subscription,
-  void ** loaned_message,
+  const void ** loaned_message,
   rmw_message_info_t * message_info,
   rmw_subscription_allocation_t * allocation);
 
@@ -662,7 +662,7 @@ RCL_WARN_UNUSED
 rcl_ret_t
 rcl_return_loaned_message_from_subscription(
   const rcl_subscription_t * subscription,
-  void * loaned_message);
+  const void * loaned_message);
 
 /// Get the topic name for the subscription.
 /**

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -610,7 +610,7 @@ rcl_take_serialized_message(
 rcl_ret_t
 rcl_take_loaned_message(
   const rcl_subscription_t * subscription,
-  void ** loaned_message,
+  const void ** loaned_message,
   rmw_message_info_t * message_info,
   rmw_subscription_allocation_t * allocation)
 {
@@ -646,7 +646,7 @@ rcl_take_loaned_message(
 rcl_ret_t
 rcl_return_loaned_message_from_subscription(
   const rcl_subscription_t * subscription,
-  void * loaned_message)
+  const void * loaned_message)
 {
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Subscription releasing loaned message");
   if (!rcl_subscription_is_valid(subscription)) {

--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -703,9 +703,9 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_subscription
         });
     }
 
-    test_msgs__msg__Strings * msg_loaned = nullptr;
+    const test_msgs__msg__Strings * msg_loaned = nullptr;
     ret = rcl_take_loaned_message(
-      &subscription, reinterpret_cast<void **>(&msg_loaned), nullptr, nullptr);
+      &subscription, reinterpret_cast<const void **>(&msg_loaned), nullptr, nullptr);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     EXPECT_EQ(
       std::string(test_string),
@@ -764,8 +764,9 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_bad_take_loa
     &subscription_options);
   ASSERT_EQ(RMW_RET_OK, ret) << rcl_get_error_string().str;
 
-  test_msgs__msg__Strings * loaned_message = nullptr;
-  void ** type_erased_loaned_message_pointer = reinterpret_cast<void **>(&loaned_message);
+  const test_msgs__msg__Strings * loaned_message = nullptr;
+  const void ** type_erased_loaned_message_pointer =
+    reinterpret_cast<const void **>(&loaned_message);
   rmw_message_info_t * message_info = nullptr;  // is a valid argument
   rmw_subscription_allocation_t * allocation = nullptr;  // is a valid argument
   EXPECT_EQ(


### PR DESCRIPTION
It seems to me that it is an error for the receiver of a loaned message to modify it – other subscriptions could be reading the same message at the same time. Therefore, this PR makes the API stricter by handing out only const pointers.

I have also made corresponding changes in rclcpp, which I'll open a PR for as well and link here.