### PR TITLE
add error msg in rcl_timer_get_time_until_next_call

### DIFF
--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -316,6 +316,7 @@ rcl_timer_get_time_until_next_call(const rcl_timer_t * timer, int64_t * time_unt
   RCL_CHECK_ARGUMENT_FOR_NULL(timer->impl, RCL_RET_TIMER_INVALID);
   RCL_CHECK_ARGUMENT_FOR_NULL(time_until_next_call, RCL_RET_INVALID_ARGUMENT);
   if (rcutils_atomic_load_bool(&timer->impl->canceled)) {
+    RCL_SET_ERROR_MSG("failed load atomic bool");
     return RCL_RET_TIMER_CANCELED;
   }
   rcl_time_point_value_t now;

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -316,7 +316,7 @@ rcl_timer_get_time_until_next_call(const rcl_timer_t * timer, int64_t * time_unt
   RCL_CHECK_ARGUMENT_FOR_NULL(timer->impl, RCL_RET_TIMER_INVALID);
   RCL_CHECK_ARGUMENT_FOR_NULL(time_until_next_call, RCL_RET_INVALID_ARGUMENT);
   if (rcutils_atomic_load_bool(&timer->impl->canceled)) {
-    RCL_SET_ERROR_MSG("failed load atomic bool");
+    RCL_SET_ERROR_MSG("failed load timer is canceled");
     return RCL_RET_TIMER_CANCELED;
   }
   rcl_time_point_value_t now;

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -316,7 +316,7 @@ rcl_timer_get_time_until_next_call(const rcl_timer_t * timer, int64_t * time_unt
   RCL_CHECK_ARGUMENT_FOR_NULL(timer->impl, RCL_RET_TIMER_INVALID);
   RCL_CHECK_ARGUMENT_FOR_NULL(time_until_next_call, RCL_RET_INVALID_ARGUMENT);
   if (rcutils_atomic_load_bool(&timer->impl->canceled)) {
-    RCL_SET_ERROR_MSG("failed load timer is canceled");
+    RCL_SET_ERROR_MSG("timer is canceled");
     return RCL_RET_TIMER_CANCELED;
   }
   rcl_time_point_value_t now;

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -667,6 +667,7 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
   }
 
   if (RMW_RET_TIMEOUT == ret && !is_timer_timeout) {
+    RCL_SET_ERROR_MSG("rmw time out");
     return RCL_RET_TIMEOUT;
   }
   return RCL_RET_OK;

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -667,7 +667,6 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
   }
 
   if (RMW_RET_TIMEOUT == ret && !is_timer_timeout) {
-    RCL_SET_ERROR_MSG("rmw time out");
     return RCL_RET_TIMEOUT;
   }
   return RCL_RET_OK;


### PR DESCRIPTION
I got an error message like this,
```bash
[planner_server-3] terminate called after throwing an instance of 'rclcpp::exceptions::RCLError'
[planner_server-3]   what():  rcl_wait() failed: error not set
```

https://github.com/ros2/rcl/blob/rolling/rcl/src/rcl/timer.c#L318-L320

if rcutils_atomic_load_bool(&timer->impl->canceled) failed, error msg not set.
so, I added error msg at rcl_timer_get_time_until_next_call()

