### PR TITLE
fixed rcl_wait return error when timer cancelled

### DIFF
--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -316,6 +316,7 @@ rcl_timer_get_time_until_next_call(const rcl_timer_t * timer, int64_t * time_unt
   RCL_CHECK_ARGUMENT_FOR_NULL(timer->impl, RCL_RET_TIMER_INVALID);
   RCL_CHECK_ARGUMENT_FOR_NULL(time_until_next_call, RCL_RET_INVALID_ARGUMENT);
   if (rcutils_atomic_load_bool(&timer->impl->canceled)) {
+    RCL_SET_ERROR_MSG("failed load atomic bool");
     return RCL_RET_TIMER_CANCELED;
   }
   rcl_time_point_value_t now;

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -316,7 +316,7 @@ rcl_timer_get_time_until_next_call(const rcl_timer_t * timer, int64_t * time_unt
   RCL_CHECK_ARGUMENT_FOR_NULL(timer->impl, RCL_RET_TIMER_INVALID);
   RCL_CHECK_ARGUMENT_FOR_NULL(time_until_next_call, RCL_RET_INVALID_ARGUMENT);
   if (rcutils_atomic_load_bool(&timer->impl->canceled)) {
-    RCL_SET_ERROR_MSG("failed load atomic bool");
+    RCL_SET_ERROR_MSG("failed load timer is canceled");
     return RCL_RET_TIMER_CANCELED;
   }
   rcl_time_point_value_t now;

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -316,7 +316,7 @@ rcl_timer_get_time_until_next_call(const rcl_timer_t * timer, int64_t * time_unt
   RCL_CHECK_ARGUMENT_FOR_NULL(timer->impl, RCL_RET_TIMER_INVALID);
   RCL_CHECK_ARGUMENT_FOR_NULL(time_until_next_call, RCL_RET_INVALID_ARGUMENT);
   if (rcutils_atomic_load_bool(&timer->impl->canceled)) {
-    RCL_SET_ERROR_MSG("failed load timer is canceled");
+    RCL_SET_ERROR_MSG("timer is canceled");
     return RCL_RET_TIMER_CANCELED;
   }
   rcl_time_point_value_t now;

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -316,7 +316,6 @@ rcl_timer_get_time_until_next_call(const rcl_timer_t * timer, int64_t * time_unt
   RCL_CHECK_ARGUMENT_FOR_NULL(timer->impl, RCL_RET_TIMER_INVALID);
   RCL_CHECK_ARGUMENT_FOR_NULL(time_until_next_call, RCL_RET_INVALID_ARGUMENT);
   if (rcutils_atomic_load_bool(&timer->impl->canceled)) {
-    RCL_SET_ERROR_MSG("timer is canceled");
     return RCL_RET_TIMER_CANCELED;
   }
   rcl_time_point_value_t now;

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -562,7 +562,7 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
       // TODO(sloretz) fix spurious wake-ups on ROS_TIME timers with ROS_TIME enabled
       int64_t timer_timeout = INT64_MAX;
 
-      ret = rcl_timer_get_time_until_next_call(wait_set->timers[i], &timer_timeout);
+      rcl_ret_t ret = rcl_timer_get_time_until_next_call(wait_set->timers[i], &timer_timeout);
       if (ret == RCL_RET_TIMER_CANCELED) {
         wait_set->timers[i] = NULL;
         continue;

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -667,6 +667,7 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
   }
 
   if (RMW_RET_TIMEOUT == ret && !is_timer_timeout) {
+    RCL_SET_ERROR_MSG("rmw time out");
     return RCL_RET_TIMEOUT;
   }
   return RCL_RET_OK;

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -561,7 +561,6 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
       // use timer time to to set the rmw_wait timeout
       // TODO(sloretz) fix spurious wake-ups on ROS_TIME timers with ROS_TIME enabled
       int64_t timer_timeout = INT64_MAX;
-
       rcl_ret_t ret = rcl_timer_get_time_until_next_call(wait_set->timers[i], &timer_timeout);
       if (ret == RCL_RET_TIMER_CANCELED) {
         wait_set->timers[i] = NULL;

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -558,26 +558,15 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
           rmw_gcs->guard_conditions[gc_idx];
         ++(rmw_gcs->guard_condition_count);
       }
-      bool is_canceled = false;
-      rcl_ret_t ret = rcl_timer_is_canceled(wait_set->timers[i], &is_canceled);
-      if (ret != RCL_RET_OK) {
-        return ret;  // The rcl error state should already be set.
-      }
-      if (is_canceled) {
-        wait_set->timers[i] = NULL;
-        continue;
-      }
       // use timer time to to set the rmw_wait timeout
       // TODO(sloretz) fix spurious wake-ups on ROS_TIME timers with ROS_TIME enabled
       int64_t timer_timeout = INT64_MAX;
 
-      // reset timer (prevent timer cancelled)
-      ret = rcl_timer_reset(wait_set->timers[i]);
-      if (ret != RCL_RET_OK) {
-        return ret;  // The rcl error state should already be set.
-      }
-
       ret = rcl_timer_get_time_until_next_call(wait_set->timers[i], &timer_timeout);
+      if (ret == RCL_RET_TIMER_CANCELED) {
+        wait_set->timers[i] = NULL;
+        continue;
+      }
       if (ret != RCL_RET_OK) {
         return ret;  // The rcl error state should already be set.
       }

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -667,7 +667,6 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
   }
 
   if (RMW_RET_TIMEOUT == ret && !is_timer_timeout) {
-    RCL_SET_ERROR_MSG("rmw time out");
     return RCL_RET_TIMEOUT;
   }
   return RCL_RET_OK;

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -570,6 +570,13 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
       // use timer time to to set the rmw_wait timeout
       // TODO(sloretz) fix spurious wake-ups on ROS_TIME timers with ROS_TIME enabled
       int64_t timer_timeout = INT64_MAX;
+
+      // reset timer (prevent timer cancelled)
+      ret = rcl_timer_reset(wait_set->timers[i]);
+      if (ret != RCL_RET_OK) {
+        return ret;  // The rcl error state should already be set.
+      }
+
       ret = rcl_timer_get_time_until_next_call(wait_set->timers[i], &timer_timeout);
       if (ret != RCL_RET_OK) {
         return ret;  // The rcl error state should already be set.


### PR DESCRIPTION
when timer canclled, `rcl_timer_get_time_until_next_call` return `RCL_RET_TIMER_CANCELED`
rcl_wait return with "error not set" like below ( we checked `rcl_timer_is_canceled` but timer is atomic, we can miss this)

```bash
[planner_server-3] terminate called after throwing an instance of 'rclcpp::exceptions::RCLError'
[planner_server-3]   what():  rcl_wait() failed: error not set
```
so, I changed check timer canceled by `rcl_timer_get_time_until_next_call`'s return value.

Would these solutions be appropriate?