### PR TITLE
Reduce result_timeout to 10 seconds.

### DIFF
--- a/rcl_action/include/rcl_action/action_server.h
+++ b/rcl_action/include/rcl_action/action_server.h
@@ -225,7 +225,7 @@ rcl_action_server_fini(rcl_action_server_t * action_server, rcl_node_t * node);
  * - feedback_topic_qos = rmw_qos_profile_default;
  * - status_topic_qos = rcl_action_qos_profile_status_default;
  * - allocator = rcl_get_default_allocator();
- * - result_timeout = RCUTILS_S_TO_NS(15 * 60);  // 15 minutes
+ * - result_timeout = RCUTILS_S_TO_NS(10);  // 10 seconds
  */
 RCL_ACTION_PUBLIC
 RCL_WARN_UNUSED

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -173,7 +173,7 @@ rcl_action_server_init(
   // Store reference to clock
   action_server->impl->clock = clock;
 
-// Initialize Timer
+  // Initialize Timer
   ret = rcl_timer_init(
     &action_server->impl->expire_timer, action_server->impl->clock, node->context,
     options->result_timeout.nanoseconds, NULL, allocator);
@@ -267,7 +267,7 @@ rcl_action_server_get_default_options(void)
   default_options.feedback_topic_qos = rmw_qos_profile_default;
   default_options.status_topic_qos = rcl_action_qos_profile_status_default;
   default_options.allocator = rcl_get_default_allocator();
-  default_options.result_timeout.nanoseconds = RCUTILS_S_TO_NS(15 * 60);  // 15 minutes
+  default_options.result_timeout.nanoseconds = RCUTILS_S_TO_NS(10);  // 10 seconds
   return default_options;
 }
 


### PR DESCRIPTION
Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

I spent a bit of time investigating https://github.com/ros2/ros2/issues/1074 .  One problem I found is that if an action client calls an action server repeatedly, the time it takes to complete that action gets slower and slower, eventually ending up taking a good portion of a second.

After doing some debugging, I found out that at least part of the problem is that the number of goal handles (as stored by the rcl_action_server_t structure) continually goes up.  Since rclcpp_action goes and copies all of the goal handles during [publish_status](https://github.com/ros2/rclcpp/blob/b9b1468d15c7ddc697c079e6934d54f183294280/rclcpp_action/src/server.cpp#L597-L626), this causes the amount of time necessary to call publish_status to go up and up.

But looking at it further, it seems like the main problem is that goal_handles are never being cleared out when they are done being used.  Instead, it looks like they are meant to "expire", but this only happens by default every 15 minutes.  Quite a lot of goal handles can be accumulated in that time.

This PR is a not-serious attempt to remedy this by reducing the default expiration time to 10 seconds.  With this in place, things still end up going slower for 10 seconds when first starting up, but then the expiration logic kicks in and keeps the number of goal handles to a reasonable number.  I don't really intend this to go in as-is, but I would like to have a discussion about whether we should remove goals automatically once `goal_handle->succeed` is called, whether `publish_status` should really publish status on *all* goals, and whether we should reduce the default time expiration period for action goal handles.