### PR TITLE
Cleanup the dependencies in rcl_yaml_param_parser.

### DIFF
--- a/rcl_yaml_param_parser/CMakeLists.txt
+++ b/rcl_yaml_param_parser/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rmw REQUIRED)
 find_package(libyaml_vendor REQUIRED)
+find_package(yaml REQUIRED)
 
 # Default to C++17
 if(NOT CMAKE_CXX_STANDARD)
@@ -20,7 +21,8 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "Clang")
   )
 endif()
 
-set(rcl_yaml_parser_sources
+add_library(
+  ${PROJECT_NAME}
   src/add_to_arrays.c
   src/namespace.c
   src/node_params.c
@@ -28,14 +30,16 @@ set(rcl_yaml_parser_sources
   src/parser.c
   src/yaml_variant.c
 )
-
-add_library(
-  ${PROJECT_NAME}
-  ${rcl_yaml_parser_sources})
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
-ament_target_dependencies(${PROJECT_NAME} "libyaml_vendor" "rcutils" "rmw")
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  rcutils::rcutils
+)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  rmw::rmw
+  yaml
+)
 
 # Set the visibility to hidden by default if possible
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
@@ -73,12 +77,12 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
   )
   if(TARGET test_namespace)
-    ament_target_dependencies(test_namespace
-      "rcutils"
-      "osrf_testing_tools_cpp"
+    target_link_libraries(test_namespace
+      ${PROJECT_NAME}
+      osrf_testing_tools_cpp::memory_tools
+      rcutils::rcutils
     )
     target_compile_definitions(test_namespace PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
-    target_link_libraries(test_namespace ${PROJECT_NAME})
   endif()
 
   ament_add_gtest(test_node_params
@@ -86,11 +90,10 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
   )
   if(TARGET test_node_params)
-    ament_target_dependencies(test_node_params
-      "rcutils"
-      "osrf_testing_tools_cpp"
+    target_link_libraries(test_node_params
+      ${PROJECT_NAME}
+      rcutils::rcutils
     )
-    target_link_libraries(test_node_params ${PROJECT_NAME})
   endif()
 
   ament_add_gtest(test_parse_yaml
@@ -98,7 +101,11 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
   )
   if(TARGET test_parse_yaml)
-    target_link_libraries(test_parse_yaml ${PROJECT_NAME})
+    target_link_libraries(test_parse_yaml
+      ${PROJECT_NAME}
+      osrf_testing_tools_cpp::memory_tools
+      rcutils::rcutils
+    )
     target_include_directories(test_parse_yaml
       PRIVATE ${osrf_testing_tools_cpp_INCLUDE_DIRS})
   endif()
@@ -108,11 +115,13 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
   )
   if(TARGET test_parse)
-    ament_target_dependencies(test_parse
-      "rcutils"
-      "osrf_testing_tools_cpp"
+    target_link_libraries(test_parse
+      ${PROJECT_NAME}
+      mimick
+      osrf_testing_tools_cpp::memory_tools
+      rcutils::rcutils
+      yaml
     )
-    target_link_libraries(test_parse ${PROJECT_NAME} mimick)
   endif()
 
   ament_add_gtest(test_parser
@@ -120,11 +129,13 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
   )
   if(TARGET test_parser)
-    ament_target_dependencies(test_parser
-      "rcutils"
-      "osrf_testing_tools_cpp"
+    target_link_libraries(test_parser
+      ${PROJECT_NAME}
+      mimick
+      osrf_testing_tools_cpp::memory_tools
+      rcutils::rcutils
+      yaml
     )
-    target_link_libraries(test_parser ${PROJECT_NAME} mimick)
     target_compile_definitions(test_parser PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
   endif()
 
@@ -134,11 +145,12 @@ if(BUILD_TESTING)
     TIMEOUT 240  # Large timeout to wait for fault injection tests
   )
   if(TARGET test_parser_multiple_nodes)
-    ament_target_dependencies(test_parser_multiple_nodes
-      "rcutils"
-      "osrf_testing_tools_cpp"
+    target_link_libraries(test_parser_multiple_nodes
+      ${PROJECT_NAME}
+      mimick
+      osrf_testing_tools_cpp::memory_tools
+      rcutils::rcutils
     )
-    target_link_libraries(test_parser_multiple_nodes ${PROJECT_NAME} mimick)
     target_compile_definitions(test_parser_multiple_nodes PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
   endif()
 
@@ -147,11 +159,12 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
   )
   if(TARGET test_parser_multiple_params)
-    ament_target_dependencies(test_parser_multiple_params
-      "rcutils"
-      "osrf_testing_tools_cpp"
+    target_link_libraries(test_parser_multiple_params
+      ${PROJECT_NAME}
+      mimick
+      osrf_testing_tools_cpp::memory_tools
+      rcutils::rcutils
     )
-    target_link_libraries(test_parser_multiple_params ${PROJECT_NAME} mimick)
     target_compile_definitions(test_parser_multiple_params PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
   endif()
 
@@ -160,28 +173,31 @@ if(BUILD_TESTING)
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
   )
   if(TARGET test_yaml_variant)
-    ament_target_dependencies(test_yaml_variant
-      "rcutils"
-      "osrf_testing_tools_cpp"
+    target_link_libraries(test_yaml_variant
+      ${PROJECT_NAME}
+      osrf_testing_tools_cpp::memory_tools
+      rcutils::rcutils
     )
-    target_link_libraries(test_yaml_variant ${PROJECT_NAME})
   endif()
 
   add_performance_test(benchmark_parse_yaml test/benchmark/benchmark_parse_yaml.cpp
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
   if(TARGET benchmark_parse_yaml)
-    target_link_libraries(benchmark_parse_yaml ${PROJECT_NAME})
-    ament_target_dependencies(benchmark_parse_yaml
-      "rcpputils"
-      "rcutils"
+    target_link_libraries(benchmark_parse_yaml
+      ${PROJECT_NAME}
+      performance_test_fixture::performance_test_fixture
+      rcpputils::rcpputils
+      rcutils::rcutils
     )
   endif()
 
   add_performance_test(benchmark_variant test/benchmark/benchmark_variant.cpp)
   if(TARGET benchmark_variant)
-    target_link_libraries(benchmark_variant ${PROJECT_NAME})
-    ament_target_dependencies(benchmark_variant
-      "rcutils"
+    target_link_libraries(benchmark_variant
+      ${PROJECT_NAME}
+      osrf_testing_tools_cpp::memory_tools
+      performance_test_fixture::performance_test_fixture
+      rcutils::rcutils
     )
   endif()
 endif()
@@ -193,8 +209,8 @@ ament_export_libraries(${PROJECT_NAME})
 # Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
 
-ament_export_dependencies(ament_cmake libyaml_vendor)
-ament_export_dependencies(rmw)
+ament_export_dependencies(ament_cmake rcutils)
+
 install(
   DIRECTORY include/
   DESTINATION include/${PROJECT_NAME}

--- a/rcl_yaml_param_parser/include/rcl_yaml_param_parser/parser.h
+++ b/rcl_yaml_param_parser/include/rcl_yaml_param_parser/parser.h
@@ -32,6 +32,9 @@
 #include "rcl_yaml_param_parser/types.h"
 #include "rcl_yaml_param_parser/visibility_control.h"
 
+#include "rcutils/allocator.h"
+#include "rcutils/types/rcutils_ret.h"
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/rcl_yaml_param_parser/package.xml
+++ b/rcl_yaml_param_parser/package.xml
@@ -17,9 +17,9 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>libyaml_vendor</depend>
-  <depend>yaml</depend>
+  <depend>rcutils</depend>
   <depend>rmw</depend>
-  <build_depend>rcutils</build_depend>
+  <depend>yaml</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/rcl_yaml_param_parser/src/add_to_arrays.c
+++ b/rcl_yaml_param_parser/src/add_to_arrays.c
@@ -12,6 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "rcutils/allocator.h"
+#include "rcutils/error_handling.h"
+#include "rcutils/types/rcutils_ret.h"
+#include "rcutils/types/string_array.h"
+
 #include "./impl/add_to_arrays.h"
 
 #define ADD_VALUE_TO_SIMPLE_ARRAY(val_array, value, value_type, allocator) \

--- a/rcl_yaml_param_parser/src/impl/add_to_arrays.h
+++ b/rcl_yaml_param_parser/src/impl/add_to_arrays.h
@@ -15,9 +15,10 @@
 #ifndef IMPL__ADD_TO_ARRAYS_H_
 #define IMPL__ADD_TO_ARRAYS_H_
 
-#include <yaml.h>
-
-#include "rcutils/types.h"
+#include "rcutils/allocator.h"
+#include "rcutils/macros.h"
+#include "rcutils/types/rcutils_ret.h"
+#include "rcutils/types/string_array.h"
 
 #include "./types.h"
 #include "rcl_yaml_param_parser/types.h"

--- a/rcl_yaml_param_parser/src/impl/namespace.h
+++ b/rcl_yaml_param_parser/src/impl/namespace.h
@@ -15,12 +15,11 @@
 #ifndef IMPL__NAMESPACE_H_
 #define IMPL__NAMESPACE_H_
 
-#include <yaml.h>
-
-#include "rcutils/types.h"
+#include "rcutils/allocator.h"
+#include "rcutils/macros.h"
+#include "rcutils/types/rcutils_ret.h"
 
 #include "./types.h"
-#include "rcl_yaml_param_parser/types.h"
 #include "rcl_yaml_param_parser/visibility_control.h"
 
 #ifdef __cplusplus

--- a/rcl_yaml_param_parser/src/impl/node_params.h
+++ b/rcl_yaml_param_parser/src/impl/node_params.h
@@ -15,6 +15,10 @@
 #ifndef IMPL__NODE_PARAMS_H_
 #define IMPL__NODE_PARAMS_H_
 
+#include "rcutils/allocator.h"
+#include "rcutils/macros.h"
+#include "rcutils/types/rcutils_ret.h"
+
 #include "rcl_yaml_param_parser/types.h"
 #include "rcl_yaml_param_parser/visibility_control.h"
 

--- a/rcl_yaml_param_parser/src/impl/parse.h
+++ b/rcl_yaml_param_parser/src/impl/parse.h
@@ -17,7 +17,9 @@
 
 #include <yaml.h>
 
-#include "rcutils/types.h"
+#include "rcutils/allocator.h"
+#include "rcutils/macros.h"
+#include "rcutils/types/rcutils_ret.h"
 
 #include "./types.h"
 #include "rcl_yaml_param_parser/types.h"

--- a/rcl_yaml_param_parser/src/impl/yaml_variant.h
+++ b/rcl_yaml_param_parser/src/impl/yaml_variant.h
@@ -16,6 +16,7 @@
 #define IMPL__YAML_VARIANT_H_
 
 #include "rcutils/allocator.h"
+#include "rcutils/macros.h"
 
 #include "./types.h"
 #include "rcl_yaml_param_parser/types.h"

--- a/rcl_yaml_param_parser/src/namespace.c
+++ b/rcl_yaml_param_parser/src/namespace.c
@@ -12,9 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "./impl/namespace.h"
+#include <string.h>
 
+#include "./impl/namespace.h"
+#include "./impl/types.h"
+
+#include "rcutils/allocator.h"
+#include "rcutils/error_handling.h"
 #include "rcutils/strdup.h"
+#include "rcutils/types/rcutils_ret.h"
 
 rcutils_ret_t add_name_to_ns(
   namespace_tracker_t * ns_tracker,

--- a/rcl_yaml_param_parser/src/node_params.c
+++ b/rcl_yaml_param_parser/src/node_params.c
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string.h>
+
+#include "rcutils/allocator.h"
+#include "rcutils/error_handling.h"
+#include "rcutils/types/rcutils_ret.h"
+
 #include "./impl/node_params.h"
 #include "./impl/types.h"
 #include "./impl/yaml_variant.h"

--- a/rcl_yaml_param_parser/src/parse.c
+++ b/rcl_yaml_param_parser/src/parse.c
@@ -17,9 +17,14 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <yaml.h>
+
 #include "rcutils/allocator.h"
+#include "rcutils/error_handling.h"
 #include "rcutils/format_string.h"
 #include "rcutils/strdup.h"
+#include "rcutils/types/rcutils_ret.h"
+#include "rcutils/types/string_array.h"
 
 #include "rmw/error_handling.h"
 #include "rmw/validate_namespace.h"

--- a/rcl_yaml_param_parser/src/parser.c
+++ b/rcl_yaml_param_parser/src/parser.c
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
 #include <yaml.h>
 
 #include "rcl_yaml_param_parser/parser.h"
@@ -28,7 +29,7 @@
 #include "rcutils/allocator.h"
 #include "rcutils/error_handling.h"
 #include "rcutils/strdup.h"
-#include "rcutils/types.h"
+#include "rcutils/types/rcutils_ret.h"
 
 #include "./impl/types.h"
 #include "./impl/parse.h"

--- a/rcl_yaml_param_parser/src/yaml_variant.c
+++ b/rcl_yaml_param_parser/src/yaml_variant.c
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 #include "rcutils/allocator.h"
+#include "rcutils/error_handling.h"
 #include "rcutils/strdup.h"
-#include "rcutils/types.h"
+#include "rcutils/types/string_array.h"
 
 #include "./impl/types.h"
 #include "./impl/yaml_variant.h"

--- a/rcl_yaml_param_parser/test/benchmark/benchmark_parse_yaml.cpp
+++ b/rcl_yaml_param_parser/test/benchmark/benchmark_parse_yaml.cpp
@@ -22,7 +22,6 @@
 
 #include "rcutils/allocator.h"
 #include "rcutils/error_handling.h"
-#include "rcutils/filesystem.h"
 
 using performance_test_fixture::PerformanceTest;
 

--- a/rcl_yaml_param_parser/test/benchmark/benchmark_variant.cpp
+++ b/rcl_yaml_param_parser/test/benchmark/benchmark_variant.cpp
@@ -23,8 +23,8 @@
 
 #include "rcutils/allocator.h"
 #include "rcutils/error_handling.h"
-#include "rcutils/filesystem.h"
 #include "rcutils/strdup.h"
+#include "rcutils/types/string_array.h"
 
 #include "../src/impl/yaml_variant.h"
 

--- a/rcl_yaml_param_parser/test/test_namespace.cpp
+++ b/rcl_yaml_param_parser/test/test_namespace.cpp
@@ -14,16 +14,14 @@
 
 #include <gtest/gtest.h>
 
-#include <yaml.h>
-
-#include <string>
-#include <vector>
-
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcl_yaml_param_parser/parser.h"
 #include "../src/impl/namespace.h"
+
 #include "rcutils/allocator.h"
+#include "rcutils/error_handling.h"
 #include "rcutils/strdup.h"
+#include "rcutils/types/rcutils_ret.h"
 
 TEST(TestNamespace, add_name_to_ns) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();

--- a/rcl_yaml_param_parser/test/test_node_params.cpp
+++ b/rcl_yaml_param_parser/test/test_node_params.cpp
@@ -14,15 +14,11 @@
 
 #include <gtest/gtest.h>
 
-#include <yaml.h>
-
-#include <string>
-#include <vector>
-
-#include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcl_yaml_param_parser/parser.h"
 #include "../src/impl/node_params.h"
+
 #include "rcutils/allocator.h"
+#include "rcutils/types/rcutils_ret.h"
 
 TEST(TestNodeParams, init_fini) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();

--- a/rcl_yaml_param_parser/test/test_parse.cpp
+++ b/rcl_yaml_param_parser/test/test_parse.cpp
@@ -16,14 +16,16 @@
 
 #include <yaml.h>
 
-#include <string>
-#include <vector>
-
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcl_yaml_param_parser/parser.h"
 #include "../src/impl/parse.h"
 #include "../src/impl/node_params.h"
+
+#include "rcutils/allocator.h"
+#include "rcutils/error_handling.h"
 #include "rcutils/filesystem.h"
+#include "rcutils/types/rcutils_ret.h"
+#include "rcutils/types/string_array.h"
 
 #include "./mocking_utils/patch.hpp"
 

--- a/rcl_yaml_param_parser/test/test_parser.cpp
+++ b/rcl_yaml_param_parser/test/test_parser.cpp
@@ -20,10 +20,16 @@
 #include "gtest/gtest.h"
 
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
+
 #include "rcl_yaml_param_parser/parser.h"
+
+#include "rcutils/allocator.h"
 #include "rcutils/error_handling.h"
 #include "rcutils/filesystem.h"
 #include "rcutils/testing/fault_injection.h"
+#include "rcutils/types/rcutils_ret.h"
+#include "rcutils/types/string_array.h"
+
 #include "./mocking_utils/patch.hpp"
 #include "./time_bomb_allocator_testing_utils.h"
 

--- a/rcl_yaml_param_parser/test/test_parser_multiple_nodes.cpp
+++ b/rcl_yaml_param_parser/test/test_parser_multiple_nodes.cpp
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <yaml.h>
-
 #include <string>
-#include <vector>
 
 #include "gtest/gtest.h"
 
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
+
 #include "rcl_yaml_param_parser/parser.h"
+
+#include "rcutils/allocator.h"
 #include "rcutils/error_handling.h"
 #include "rcutils/filesystem.h"
 #include "rcutils/testing/fault_injection.h"
+
 #include "./mocking_utils/patch.hpp"
 
 static char cur_dir[1024];

--- a/rcl_yaml_param_parser/test/test_parser_multiple_params.cpp
+++ b/rcl_yaml_param_parser/test/test_parser_multiple_params.cpp
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <yaml.h>
-
 #include <string>
-#include <vector>
 
 #include "gtest/gtest.h"
 
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
+
 #include "rcl_yaml_param_parser/parser.h"
+
+#include "rcutils/allocator.h"
 #include "rcutils/error_handling.h"
 #include "rcutils/filesystem.h"
 #include "rcutils/testing/fault_injection.h"
+
 #include "./mocking_utils/patch.hpp"
 
 static char cur_dir[1024];

--- a/rcl_yaml_param_parser/test/test_yaml_variant.cpp
+++ b/rcl_yaml_param_parser/test/test_yaml_variant.cpp
@@ -14,17 +14,19 @@
 
 #include <gtest/gtest.h>
 
-#include <yaml.h>
-
-#include <string>
-#include <vector>
+#include <type_traits>
 
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
+
 #include "rcl_yaml_param_parser/parser.h"
+
 #include "../src/impl/yaml_variant.h"
+
 #include "rcutils/allocator.h"
 #include "rcutils/strdup.h"
 #include "rcutils/testing/fault_injection.h"
+#include "rcutils/types/rcutils_ret.h"
+#include "rcutils/types/string_array.h"
 
 #define TEST_VARIANT_COPY(field, tmp_var) \
   do { \


### PR DESCRIPTION
The main goal of this commit is to make sure that the dependencies listed in the package.xml and the CMakeLists.txt are correct. To get there, we first go through all of the files in this package and make sure that the includes are correct.  With that done, it is a simple matter of seeing what is needed and not in the depends and the tests.

While we are in here, we also switch from ament_target_dependencies to target_link_libraries wherever possible.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>