### PR TITLE
Make sure to reset errors more places in the tests.

### DIFF
--- a/rcl/test/rcl/test_client.cpp
+++ b/rcl/test/rcl/test_client.cpp
@@ -250,10 +250,13 @@ TEST_F(TestClientFixture, test_client_bad_arguments) {
     RCL_RET_SERVICE_NAME_INVALID, rcl_client_init(
       &client, this->node_ptr, ts,
       "invalid name", &default_client_options)) << rcl_get_error_string().str;
+  rcl_reset_error();
 
   EXPECT_EQ(RCL_RET_NODE_INVALID, rcl_client_fini(&client, nullptr));
+  rcl_reset_error();
   rcl_node_t not_valid_node = rcl_get_zero_initialized_node();
   EXPECT_EQ(RCL_RET_NODE_INVALID, rcl_client_fini(&client, &not_valid_node));
+  rcl_reset_error();
 
   rmw_service_info_t header;
   int64_t sequence_number = 24;
@@ -268,39 +271,55 @@ TEST_F(TestClientFixture, test_client_bad_arguments) {
   });
 
   EXPECT_EQ(nullptr, rcl_client_get_rmw_handle(nullptr));
+  rcl_reset_error();
   EXPECT_EQ(nullptr, rcl_client_get_service_name(nullptr));
+  rcl_reset_error();
   EXPECT_EQ(nullptr, rcl_client_get_service_name(nullptr));
+  rcl_reset_error();
   EXPECT_EQ(nullptr, rcl_client_get_options(nullptr));
   EXPECT_EQ(
     RCL_RET_CLIENT_INVALID, rcl_take_response_with_info(
       nullptr, &header, &client_response)) << rcl_get_error_string().str;
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_CLIENT_INVALID, rcl_take_response(
       nullptr, &(header.request_id), &client_response)) << rcl_get_error_string().str;
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_CLIENT_INVALID, rcl_send_request(
       nullptr, &client_request, &sequence_number)) << rcl_get_error_string().str;
+  rcl_reset_error();
   EXPECT_EQ(24, sequence_number);
   EXPECT_EQ(nullptr, rcl_client_request_publisher_get_actual_qos(nullptr));
+  rcl_reset_error();
   EXPECT_EQ(nullptr, rcl_client_response_subscription_get_actual_qos(nullptr));
+  rcl_reset_error();
 
   // Not init client
   EXPECT_EQ(nullptr, rcl_client_get_rmw_handle(&client));
+  rcl_reset_error();
   EXPECT_EQ(nullptr, rcl_client_get_service_name(&client));
+  rcl_reset_error();
   EXPECT_EQ(nullptr, rcl_client_get_service_name(&client));
+  rcl_reset_error();
   EXPECT_EQ(nullptr, rcl_client_get_options(&client));
   EXPECT_EQ(
     RCL_RET_CLIENT_INVALID, rcl_take_response_with_info(
       &client, &header, &client_response)) << rcl_get_error_string().str;
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_CLIENT_INVALID, rcl_take_response(
       &client, &(header.request_id), &client_response)) << rcl_get_error_string().str;
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_CLIENT_INVALID, rcl_send_request(
       &client, &client_request, &sequence_number)) << rcl_get_error_string().str;
+  rcl_reset_error();
   EXPECT_EQ(24, sequence_number);
   EXPECT_EQ(nullptr, rcl_client_request_publisher_get_actual_qos(&client));
+  rcl_reset_error();
   EXPECT_EQ(nullptr, rcl_client_response_subscription_get_actual_qos(&client));
+  rcl_reset_error();
 }
 
 TEST_F(TestClientFixture, test_client_init_fini_maybe_fail)

--- a/rcl/test/rcl/test_domain_id.cpp
+++ b/rcl/test/rcl/test_domain_id.cpp
@@ -51,6 +51,7 @@ TEST(TestGetDomainId, test_nominal) {
   EXPECT_EQ(RCL_DEFAULT_DOMAIN_ID, domain_id);
 
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_get_default_domain_id(nullptr));
+  rcl_reset_error();
 }
 
 TEST(TestGetDomainId, test_mock_get_default_domain_id) {

--- a/rcl/test/rcl/test_events.cpp
+++ b/rcl/test/rcl/test_events.cpp
@@ -686,6 +686,7 @@ TEST_F(TestEventFixture, test_bad_event_ini)
     &publisher,
     unknown_pub_type);
   EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT);
+  rcl_reset_error();
 
   subscription_event = rcl_get_zero_initialized_event();
   ret = rcl_subscription_event_init(
@@ -693,6 +694,7 @@ TEST_F(TestEventFixture, test_bad_event_ini)
     &subscription,
     unknown_sub_type);
   EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT);
+  rcl_reset_error();
 
   tear_down_publisher_subscriber();
 }
@@ -744,12 +746,16 @@ TEST_F(TestEventFixture, test_event_is_invalid) {
   // nullptr
   rmw_offered_deadline_missed_status_t deadline_status;
   EXPECT_EQ(RCL_RET_EVENT_INVALID, rcl_take_event(NULL, &deadline_status));
+  rcl_reset_error();
   EXPECT_EQ(NULL, rcl_event_get_rmw_handle(NULL));
+  rcl_reset_error();
 
   // Zero Init, invalid
   rcl_event_t publisher_event_test = rcl_get_zero_initialized_event();
   EXPECT_EQ(RCL_RET_EVENT_INVALID, rcl_take_event(&publisher_event_test, &deadline_status));
+  rcl_reset_error();
   EXPECT_EQ(NULL, rcl_event_get_rmw_handle(&publisher_event_test));
+  rcl_reset_error();
 }
 
 /*

--- a/rcl/test/rcl/test_info_by_topic.cpp
+++ b/rcl/test/rcl/test_info_by_topic.cpp
@@ -141,6 +141,7 @@ TEST_F(
     nullptr, &allocator, this->topic_name, false,
     &this->topic_endpoint_info_array);
   EXPECT_EQ(RCL_RET_NODE_INVALID, ret);
+  rcl_reset_error();
 }
 
 /*
@@ -156,6 +157,7 @@ TEST_F(
     nullptr, &allocator, this->topic_name, false,
     &this->topic_endpoint_info_array);
   EXPECT_EQ(RCL_RET_NODE_INVALID, ret);
+  rcl_reset_error();
 }
 
 /*
@@ -172,6 +174,7 @@ TEST_F(
     &this->old_node, &allocator, this->topic_name, false,
     &this->topic_endpoint_info_array);
   EXPECT_EQ(RCL_RET_NODE_INVALID, ret);
+  rcl_reset_error();
 }
 
 /*
@@ -188,6 +191,7 @@ TEST_F(
     &this->old_node, &allocator, this->topic_name, false,
     &this->topic_endpoint_info_array);
   EXPECT_EQ(RCL_RET_NODE_INVALID, ret);
+  rcl_reset_error();
 }
 
 /*
@@ -202,6 +206,7 @@ TEST_F(
     &this->node, nullptr, this->topic_name, false,
     &this->topic_endpoint_info_array);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
+  rcl_reset_error();
 }
 
 /*
@@ -216,6 +221,7 @@ TEST_F(
     &this->node, nullptr, this->topic_name, false,
     &this->topic_endpoint_info_array);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
+  rcl_reset_error();
 }
 
 /*
@@ -230,6 +236,7 @@ TEST_F(
   const auto ret = rcl_get_publishers_info_by_topic(
     &this->node, &allocator, nullptr, false, &this->topic_endpoint_info_array);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
+  rcl_reset_error();
 }
 
 /*
@@ -244,6 +251,7 @@ TEST_F(
   const auto ret = rcl_get_subscriptions_info_by_topic(
     &this->node, &allocator, nullptr, false, &this->topic_endpoint_info_array);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
+  rcl_reset_error();
 }
 
 /*
@@ -258,6 +266,7 @@ TEST_F(
   const auto ret = rcl_get_publishers_info_by_topic(
     &this->node, &allocator, this->topic_name, false, nullptr);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
+  rcl_reset_error();
 }
 
 /*
@@ -272,6 +281,7 @@ TEST_F(
   const auto ret = rcl_get_subscriptions_info_by_topic(
     &this->node, &allocator, this->topic_name, false, nullptr);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
+  rcl_reset_error();
 }
 
 /*
@@ -294,6 +304,7 @@ TEST_F(
     &this->node, &allocator, this->topic_name, false,
     &this->topic_endpoint_info_array);
   EXPECT_EQ(RCL_RET_ERROR, ret);
+  rcl_reset_error();
 }
 
 /*
@@ -316,6 +327,7 @@ TEST_F(
     &this->node, &allocator, this->topic_name, false,
     &this->topic_endpoint_info_array);
   EXPECT_EQ(RCL_RET_ERROR, ret);
+  rcl_reset_error();
 }
 
 TEST_F(

--- a/rcl/test/rcl/test_log_level.cpp
+++ b/rcl/test/rcl/test_log_level.cpp
@@ -237,6 +237,7 @@ TEST(TestLogLevel, log_level_init_fini) {
   EXPECT_EQ(
     RCL_RET_INVALID_ARGUMENT,
     rcl_log_levels_init(nullptr, &allocator, capacity_count));
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_INVALID_ARGUMENT,
     rcl_log_levels_init(&log_levels, nullptr, capacity_count));
@@ -252,8 +253,10 @@ TEST(TestLogLevel, log_level_init_fini) {
   rcl_log_levels_t empty_log_levels = rcl_get_zero_initialized_log_levels();
   EXPECT_EQ(
     RCL_RET_BAD_ALLOC, rcl_log_levels_init(&empty_log_levels, &bad_allocator, capacity_count));
+  rcl_reset_error();
 
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_log_levels_fini(nullptr));
+  rcl_reset_error();
 }
 
 TEST(TestLogLevel, logger_log_level_copy) {
@@ -290,7 +293,9 @@ TEST(TestLogLevel, logger_log_level_copy) {
   // Bad usage
   rcl_log_levels_t empty_log_levels = rcl_get_zero_initialized_log_levels();
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_log_levels_copy(nullptr, &empty_log_levels));
+  rcl_reset_error();
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_log_levels_copy(&log_levels, nullptr));
+  rcl_reset_error();
   // Already copied
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_log_levels_copy(&log_levels, &copied_log_levels));
   EXPECT_TRUE(rcl_error_is_set());
@@ -330,15 +335,18 @@ TEST(TestLogLevel, test_add_logger_setting) {
   EXPECT_EQ(
     RCL_RET_INVALID_ARGUMENT,
     rcl_log_levels_add_logger_setting(nullptr, "rcl", RCUTILS_LOG_SEVERITY_DEBUG));
+  rcl_reset_error();
 
   rcl_log_levels_t not_ini_log_levels = rcl_get_zero_initialized_log_levels();
   EXPECT_EQ(
     RCL_RET_INVALID_ARGUMENT,
     rcl_log_levels_add_logger_setting(&not_ini_log_levels, "rcl", RCUTILS_LOG_SEVERITY_DEBUG));
+  rcl_reset_error();
 
   EXPECT_EQ(
     RCL_RET_INVALID_ARGUMENT,
     rcl_log_levels_add_logger_setting(&log_levels, nullptr, RCUTILS_LOG_SEVERITY_DEBUG));
+  rcl_reset_error();
 
   rcl_allocator_t saved_allocator = log_levels.allocator;
   log_levels.allocator = {NULL, NULL, NULL, NULL, NULL};

--- a/rcl/test/rcl/test_network_flow_endpoints.cpp
+++ b/rcl/test/rcl/test_network_flow_endpoints.cpp
@@ -266,7 +266,9 @@ TEST_F(
   // Get network flow endpoints of publisher with unique network flow endpoints
   rcl_network_flow_endpoint_array_t network_flow_endpoint_array_2 =
     rcl_get_zero_initialized_network_flow_endpoint_array();
-  if (rcl_publisher_is_valid(&this->publisher_2)) {
+  bool pub_2_is_valid = rcl_publisher_is_valid(&this->publisher_2);
+  rcl_reset_error();
+  if (pub_2_is_valid) {
     rcl_network_flow_endpoint_array_t network_flow_endpoint_array_2 =
       rcl_get_zero_initialized_network_flow_endpoint_array();
     ret_2 = rcl_publisher_get_network_flow_endpoints(
@@ -305,7 +307,9 @@ TEST_F(
 
   // Release resources
   rcl_network_flow_endpoint_array_fini(&network_flow_endpoint_array_1);
+  rcl_reset_error();
   rcl_network_flow_endpoint_array_fini(&network_flow_endpoint_array_2);
+  rcl_reset_error();
 }
 
 TEST_F(

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -544,6 +544,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_init_with_i
       ASSERT_TRUE(rcl_node_is_valid(&node));
       EXPECT_EQ(RCL_RET_OK, rcl_node_fini(&node)) << rcl_get_error_string().str;
     } else {
+      rcl_reset_error();
       ASSERT_FALSE(rcl_node_is_valid(&node));
       rcl_reset_error();
     }
@@ -869,8 +870,11 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_options) {
   EXPECT_TRUE(rcutils_allocator_is_valid(&(default_options.allocator)));
 
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_node_options_copy(nullptr, &default_options));
+  rcl_reset_error();
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_node_options_copy(&default_options, nullptr));
+  rcl_reset_error();
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_node_options_copy(&default_options, &default_options));
+  rcl_reset_error();
 
   const char * argv[] = {
     "process_name", "--ros-args", "/foo/bar:=", "-r", "bar:=/fiz/buz", "}bar:=fiz", "--", "arg"};
@@ -893,6 +897,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_options) {
     rcl_arguments_get_count_unparsed_ros(&(not_ini_options.arguments)));
 
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_node_options_fini(nullptr));
+  rcl_reset_error();
   EXPECT_EQ(RCL_RET_OK, rcl_node_options_fini(&default_options));
   EXPECT_EQ(RCL_RET_OK, rcl_node_options_fini(&not_ini_options));
 }
@@ -909,6 +914,7 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_options_fai
 
   rcl_node_options_t default_options = rcl_node_get_default_options();
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_node_options_copy(&default_options, &prev_ini_options));
+  rcl_reset_error();
 
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&prev_ini_options.arguments));
 }
@@ -923,9 +929,11 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_resolve_nam
   EXPECT_EQ(
     RCL_RET_INVALID_ARGUMENT,
     rcl_node_resolve_name(NULL, "my_topic", default_allocator, false, false, &final_name));
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_ERROR,
     rcl_node_resolve_name(&node, "my_topic", default_allocator, false, false, &final_name));
+  rcl_reset_error();
 
   // Initialize rcl with rcl_init().
   rcl_init_options_t init_options = rcl_get_zero_initialized_init_options();
@@ -968,9 +976,11 @@ TEST_F(CLASSNAME(TestNodeFixture, RMW_IMPLEMENTATION), test_rcl_node_resolve_nam
   EXPECT_EQ(
     RCL_RET_INVALID_ARGUMENT,
     rcl_node_resolve_name(&node, NULL, default_allocator, false, false, &final_name));
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_INVALID_ARGUMENT,
     rcl_node_resolve_name(&node, "my_topic", default_allocator, false, false, NULL));
+  rcl_reset_error();
 
   // Some valid options, test_remap and test_expand_topic_name already have good coverage
   EXPECT_EQ(

--- a/rcl/test/rcl/test_publisher.cpp
+++ b/rcl/test/rcl/test_publisher.cpp
@@ -457,7 +457,6 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_invalid_publish
   EXPECT_NE(nullptr, rcl_publisher_get_rmw_handle(&publisher));
   EXPECT_NE(nullptr, rcl_publisher_get_actual_qos(&publisher));
   EXPECT_NE(nullptr, rcl_publisher_get_options(&publisher));
-  rcl_reset_error();
   EXPECT_FALSE(rcl_publisher_is_valid(&publisher));
   rcl_reset_error();
   EXPECT_EQ(nullptr, rcl_publisher_get_context(&publisher));
@@ -816,18 +815,22 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_mock_loaned_fun
     EXPECT_EQ(
       RCL_RET_PUBLISHER_INVALID,
       rcl_publish_loaned_message(nullptr, &msg, null_allocation_is_valid_arg));
+    rcl_reset_error();
     EXPECT_EQ(
       RCL_RET_PUBLISHER_INVALID,
       rcl_publish_loaned_message(&not_init_publisher, &msg, null_allocation_is_valid_arg));
+    rcl_reset_error();
     EXPECT_EQ(
       RCL_RET_INVALID_ARGUMENT,
       rcl_publish_loaned_message(&publisher, nullptr, null_allocation_is_valid_arg));
+    rcl_reset_error();
   }
   {
     // mocked, failure publish
     auto mock = mocking_utils::patch_and_return(
       "lib:rcl", rmw_publish_loaned_message, RMW_RET_ERROR);
     EXPECT_EQ(RCL_RET_ERROR, rcl_publish_loaned_message(&publisher, &msg, nullptr));
+    rcl_reset_error();
   }
   {
     // mocked, borrow loaned nominal usage
@@ -837,8 +840,10 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_mock_loaned_fun
   {
     // bad params borrow loaned
     EXPECT_EQ(RCL_RET_PUBLISHER_INVALID, rcl_borrow_loaned_message(nullptr, ts, &msg_pointer));
+    rcl_reset_error();
     EXPECT_EQ(
       RCL_RET_PUBLISHER_INVALID, rcl_borrow_loaned_message(&not_init_publisher, ts, &msg_pointer));
+    rcl_reset_error();
   }
   {
     // mocked, nominal return loaned message
@@ -851,12 +856,15 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_mock_loaned_fun
     EXPECT_EQ(
       RCL_RET_PUBLISHER_INVALID,
       rcl_return_loaned_message_from_publisher(nullptr, &msg));
+    rcl_reset_error();
     EXPECT_EQ(
       RCL_RET_PUBLISHER_INVALID,
       rcl_return_loaned_message_from_publisher(&not_init_publisher, &msg));
+    rcl_reset_error();
     EXPECT_EQ(
       RCL_RET_INVALID_ARGUMENT,
       rcl_return_loaned_message_from_publisher(&publisher, nullptr));
+    rcl_reset_error();
   }
 
   test_msgs__msg__BasicTypes__fini(&msg);
@@ -931,4 +939,5 @@ TEST_F(CLASSNAME(TestPublisherFixture, RMW_IMPLEMENTATION), test_mock_publisher_
   auto mock = mocking_utils::patch_and_return("lib:rcl", rmw_destroy_publisher, RMW_RET_ERROR);
   ret = rcl_publisher_fini(&publisher, this->node_ptr);
   EXPECT_EQ(RCL_RET_ERROR, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
 }

--- a/rcl/test/rcl/test_remap.cpp
+++ b/rcl/test/rcl/test_remap.cpp
@@ -183,6 +183,7 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), topic_and_service_name_n
       NULL, &global_arguments, NULL, "NodeName", "/", rcl_get_default_allocator(), &output);
     EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
     ASSERT_EQ(NULL, output);
+    rcl_reset_error();
   }
   {
     char * output = NULL;
@@ -190,6 +191,7 @@ TEST_F(CLASSNAME(TestRemapFixture, RMW_IMPLEMENTATION), topic_and_service_name_n
       NULL, &global_arguments, NULL, "NodeName", "/", rcl_get_default_allocator(), &output);
     EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
     EXPECT_EQ(NULL, output);
+    rcl_reset_error();
   }
 }
 

--- a/rcl/test/rcl/test_service.cpp
+++ b/rcl/test/rcl/test_service.cpp
@@ -92,6 +92,7 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_service_nominal) 
 
   ret = rcl_service_init(&service, this->node_ptr, ts, topic, &service_options);
   EXPECT_EQ(RCL_RET_ALREADY_INIT, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
 
   const rmw_qos_profile_t * request_subscription_qos =
     rcl_service_request_subscription_get_actual_qos(&service);
@@ -124,7 +125,6 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_service_nominal) 
   ret = rcl_service_init(&service, this->node_ptr, ts, topic, &service_options);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   EXPECT_TRUE(rcl_service_is_valid(&service));
-  rcl_reset_error();
 
   // Check that the service name matches what we assigned.
   EXPECT_EQ(strcmp(rcl_service_get_service_name(&service), expected_topic), 0);
@@ -252,7 +252,6 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_service_without_i
   ret = rcl_service_init(&service, this->node_ptr, ts, topic, &service_options);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   EXPECT_TRUE(rcl_service_is_valid(&service));
-  rcl_reset_error();
 
   // Check that the service name matches what we assigned.
   EXPECT_STREQ(rcl_service_get_service_name(&service), expected_topic);
@@ -354,33 +353,43 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_bad_arguments) {
   EXPECT_EQ(
     RCL_RET_NODE_INVALID, rcl_service_init(
       &service, nullptr, ts, topic, &service_options)) << rcl_get_error_string().str;
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_NODE_INVALID, rcl_service_init(
       &service, &invalid_node, ts, topic, &service_options)) << rcl_get_error_string().str;
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_INVALID_ARGUMENT, rcl_service_init(
       nullptr, this->node_ptr, ts, topic, &service_options)) << rcl_get_error_string().str;
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_INVALID_ARGUMENT, rcl_service_init(
       &service, this->node_ptr, nullptr, topic, &service_options)) << rcl_get_error_string().str;
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_INVALID_ARGUMENT, rcl_service_init(
       &service, this->node_ptr, ts, nullptr, &service_options)) << rcl_get_error_string().str;
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_INVALID_ARGUMENT, rcl_service_init(
       &service, this->node_ptr, ts, topic, nullptr)) << rcl_get_error_string().str;
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_INVALID_ARGUMENT, rcl_service_init(
       &service, this->node_ptr, ts, topic,
       &service_options_bad_alloc)) << rcl_get_error_string().str;
+  rcl_reset_error();
 
   EXPECT_EQ(
     RCL_RET_NODE_INVALID, rcl_service_fini(&service, nullptr)) << rcl_get_error_string().str;
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_NODE_INVALID, rcl_service_fini(&service, &invalid_node)) << rcl_get_error_string().str;
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_SERVICE_INVALID, rcl_service_fini(
       nullptr, this->node_ptr)) << rcl_get_error_string().str;
+  rcl_reset_error();
 
   test_msgs__srv__BasicTypes_Request service_request;
   test_msgs__srv__BasicTypes_Response service_response;
@@ -394,35 +403,52 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_bad_arguments) {
   });
 
   EXPECT_EQ(nullptr, rcl_service_get_service_name(nullptr));
+  rcl_reset_error();
   EXPECT_EQ(nullptr, rcl_service_get_options(nullptr));
+  rcl_reset_error();
   EXPECT_EQ(nullptr, rcl_service_get_rmw_handle(nullptr));
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_SERVICE_INVALID, rcl_take_request_with_info(nullptr, &header, &service_request));
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_SERVICE_INVALID, rcl_send_response(nullptr, &header.request_id, &service_response));
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_SERVICE_INVALID, rcl_take_request(nullptr, &(header.request_id), &service_request));
+  rcl_reset_error();
   EXPECT_EQ(nullptr, rcl_service_request_subscription_get_actual_qos(nullptr));
+  rcl_reset_error();
   EXPECT_EQ(nullptr, rcl_service_response_publisher_get_actual_qos(nullptr));
+  rcl_reset_error();
 
   EXPECT_EQ(nullptr, rcl_service_get_service_name(&service));
+  rcl_reset_error();
   EXPECT_EQ(nullptr, rcl_service_get_options(&service));
+  rcl_reset_error();
   EXPECT_EQ(nullptr, rcl_service_get_rmw_handle(&service));
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_SERVICE_INVALID, rcl_take_request_with_info(&service, &header, &service_request));
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_SERVICE_INVALID, rcl_send_response(&service, &(header.request_id), &service_response));
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_SERVICE_INVALID, rcl_take_request(&service, &(header.request_id), &service_request));
+  rcl_reset_error();
 
   service_options_bad_alloc.allocator = get_failing_allocator();
   EXPECT_EQ(
     RCL_RET_BAD_ALLOC, rcl_service_init(
       &service, this->node_ptr, ts,
       topic, &service_options_bad_alloc)) << rcl_get_error_string().str;
+  rcl_reset_error();
 
   EXPECT_EQ(nullptr, rcl_service_request_subscription_get_actual_qos(&service));
+  rcl_reset_error();
   EXPECT_EQ(nullptr, rcl_service_response_publisher_get_actual_qos(&service));
+  rcl_reset_error();
 }
 
 /* Name failed tests
@@ -633,12 +659,15 @@ TEST_F(CLASSNAME(TestServiceFixture, RMW_IMPLEMENTATION), test_fail_send_respons
 
   ret = rcl_send_response(nullptr, &header.request_id, &service_response);
   EXPECT_EQ(RCL_RET_SERVICE_INVALID, ret);
+  rcl_reset_error();
 
   ret = rcl_send_response(&service, nullptr, &service_response);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
+  rcl_reset_error();
 
   ret = rcl_send_response(&service, &header.request_id, nullptr);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
+  rcl_reset_error();
 
   {
     auto mock = mocking_utils::patch_and_return(

--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -460,6 +460,8 @@ TEST_F(
 
     ASSERT_EQ(0u, messages.size);
     ASSERT_EQ(0u, message_infos.size);
+
+    rcl_reset_error();
   }
 
   {
@@ -1004,6 +1006,7 @@ TEST_F(
       std::this_thread::sleep_for(std::chrono::seconds(10));
     } else {
       ASSERT_EQ(RCL_RET_UNSUPPORTED, ret);
+      rcl_reset_error();
     }
 
     EXPECT_EQ(
@@ -1094,6 +1097,7 @@ TEST_F(
       );
     } else {
       ASSERT_EQ(RCL_RET_UNSUPPORTED, ret);
+      rcl_reset_error();
     }
   }
 
@@ -1120,6 +1124,7 @@ TEST_F(
       ASSERT_FALSE(rcl_subscription_is_cft_enabled(&subscription));
     } else {
       ASSERT_EQ(RCL_RET_UNSUPPORTED, ret);
+      rcl_reset_error();
     }
 
     EXPECT_EQ(
@@ -1195,6 +1200,7 @@ TEST_F(
     ret = rcl_subscription_get_content_filter(
       &subscription, &content_filter_options);
     ASSERT_NE(RCL_RET_OK, ret);
+    rcl_reset_error();
   }
 
   ASSERT_TRUE(wait_for_established_subscription(&publisher, 10, 1000));
@@ -1247,6 +1253,7 @@ TEST_F(
       &subscription, &options);
     if (!is_cft_support) {
       ASSERT_EQ(RCL_RET_UNSUPPORTED, ret);
+      rcl_reset_error();
     } else {
       ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
       // waiting to allow for filter propagation
@@ -1333,10 +1340,11 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_get_options)
   ASSERT_EQ(subscription_options.qos.durability, get_sub_options->qos.durability);
 
   ASSERT_EQ(NULL, rcl_subscription_get_options(nullptr));
+  rcl_reset_error();
 }
 
 /* bad take()
-*/
+ */
 TEST_F(CLASSNAME(TestSubscriptionFixtureInit, RMW_IMPLEMENTATION), test_subscription_bad_take) {
   test_msgs__msg__BasicTypes msg;
   rmw_message_info_t message_info = rmw_get_zero_initialized_message_info();
@@ -1375,7 +1383,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixtureInit, RMW_IMPLEMENTATION), test_subscrip
 }
 
 /* bad take_serialized
-*/
+ */
 TEST_F(
   CLASSNAME(TestSubscriptionFixtureInit, RMW_IMPLEMENTATION),
   test_subscription_bad_take_serialized) {
@@ -1696,6 +1704,7 @@ TEST_F(CLASSNAME(TestSubscriptionFixture, RMW_IMPLEMENTATION), test_init_fini_ma
       if (RCL_RET_OK != ret) {
         // If fault injection caused fini to fail, we should try it again.
         EXPECT_EQ(RCL_RET_OK, rcl_subscription_fini(&subscription, this->node_ptr));
+        rcl_reset_error();
       }
     } else {
       EXPECT_TRUE(rcl_error_is_set());

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -842,6 +842,7 @@ TEST_F(TestPreInitTimer, test_timer_reset) {
 
   ASSERT_EQ(RCL_RET_OK, rcl_timer_cancel(&timer)) << rcl_get_error_string().str;
   EXPECT_EQ(RCL_RET_TIMER_CANCELED, rcl_timer_call(&timer));
+  rcl_reset_error();
   EXPECT_EQ(times_called, 2);
   ASSERT_EQ(RCL_RET_OK, rcl_timer_reset(&timer));
   EXPECT_EQ(RCL_RET_OK, rcl_timer_call(&timer)) << rcl_get_error_string().str;

--- a/rcl/test/rcl/test_validate_enclave_name.cpp
+++ b/rcl/test/rcl/test_validate_enclave_name.cpp
@@ -35,14 +35,17 @@ TEST(TestValidateEnclaveName, test_validate) {
   EXPECT_EQ(
     RMW_RET_INVALID_ARGUMENT,
     rcl_validate_enclave_name(nullptr, &validation_result, &invalid_index));
+  rcl_reset_error();
 
   EXPECT_EQ(
     RMW_RET_INVALID_ARGUMENT,
     rcl_validate_enclave_name_with_size(nullptr, 20, &validation_result, &invalid_index));
+  rcl_reset_error();
 
   EXPECT_EQ(
     RMW_RET_INVALID_ARGUMENT,
     rcl_validate_enclave_name_with_size("/foo", 20, nullptr, &invalid_index));
+  rcl_reset_error();
 
   EXPECT_EQ(
     RCL_RET_OK,


### PR DESCRIPTION
This makes it so we don't get as many warnings when the tests are running.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Note that this does *not* get rid of all warnings; there are quite a few still remaining, and those mostly involve actual bugs in our error handling.  Nevertheless, I think this is worthwhile to get in for our sanity, and to make those other bugs more visible.