### PR TITLE
Fix some warnings from clang.

### DIFF
--- a/rcl/test/rcl/test_init.cpp
+++ b/rcl/test/rcl/test_init.cpp
@@ -510,8 +510,10 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_init_options_acce
   // nullptr copy cases
   EXPECT_EQ(
     RCL_RET_INVALID_ARGUMENT, rcl_init_options_copy(nullptr, &init_options_dst));
+  rcl_reset_error();
   EXPECT_EQ(
     RCL_RET_INVALID_ARGUMENT, rcl_init_options_copy(&init_options, nullptr));
+  rcl_reset_error();
 
   // Expected usage copy
   ASSERT_EQ(RCL_RET_OK, rcl_init_options_copy(&init_options, &init_options_dst));

--- a/rcl/test/rcl/test_logging_rosout.cpp
+++ b/rcl/test/rcl/test_logging_rosout.cpp
@@ -414,7 +414,7 @@ TEST_F(
     logger_name + std::string(RCUTILS_LOGGING_SEPARATOR_STRING) + sublogger_name;
 
   // not to get the message before adding the sublogger
-  bool expected;
+  bool expected = false;
   check_if_rosout_subscription_gets_a_message(
     full_sublogger_name.c_str(), this->subscription_ptr,
     this->context_ptr, 30, 100, expected);
@@ -447,7 +447,7 @@ TEST_F(
   const char * sublogger_name = "child";
   std::string full_sublogger_name =
     logger_name + std::string(RCUTILS_LOGGING_SEPARATOR_STRING) + sublogger_name;
-  bool expected;
+  bool expected = false;
 
   EXPECT_EQ(RCL_RET_OK, rcl_logging_rosout_add_sublogger(logger_name, sublogger_name));
 

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -878,6 +878,7 @@ TEST_F(TestPreInitTimer, test_on_reset_timer_callback) {
   EXPECT_EQ(
     RCL_RET_INVALID_ARGUMENT,
     rcl_timer_set_on_reset_callback(nullptr, nullptr, nullptr));
+  rcl_reset_error();
 
   // Set a null on reset callback to a valid timer
   ASSERT_EQ(
@@ -903,6 +904,7 @@ TEST_F(TestPreInitTimer, test_on_reset_timer_callback) {
 
 TEST_F(TestPreInitTimer, test_invalid_get_guard) {
   ASSERT_EQ(NULL, rcl_timer_get_guard_condition(nullptr));
+  rcl_reset_error();
 }
 
 TEST_F(TestPreInitTimer, test_invalid_init_fini) {

--- a/rcl_yaml_param_parser/test/benchmark/benchmark_parse_yaml.cpp
+++ b/rcl_yaml_param_parser/test/benchmark/benchmark_parse_yaml.cpp
@@ -31,6 +31,7 @@ BENCHMARK_F(PerformanceTest, parser_yaml_param)(benchmark::State & st)
     (rcpputils::fs::current_path() / "test" / "benchmark" / "benchmark_params.yaml").string();
   reset_heap_counters();
   for (auto _ : st) {
+    RCUTILS_UNUSED(_);
     rcl_params_t * params_hdl = rcl_yaml_node_struct_init(rcutils_get_default_allocator());
     if (NULL == params_hdl) {
       st.SkipWithError(rcutils_get_error_string().str);

--- a/rcl_yaml_param_parser/test/benchmark/benchmark_variant.cpp
+++ b/rcl_yaml_param_parser/test/benchmark/benchmark_variant.cpp
@@ -46,6 +46,7 @@ BENCHMARK_F(PerformanceTest, bool_copy_variant)(benchmark::State & st)
   reset_heap_counters();
 
   for (auto _ : st) {
+    RCUTILS_UNUSED(_);
     if (!rcl_yaml_variant_copy(&dest_variant, &src_variant, allocator)) {
       st.SkipWithError(rcutils_get_error_string().str);
     }
@@ -65,6 +66,7 @@ BENCHMARK_F(PerformanceTest, int_copy_variant)(benchmark::State & st)
   reset_heap_counters();
 
   for (auto _ : st) {
+    RCUTILS_UNUSED(_);
     if (!rcl_yaml_variant_copy(&dest_variant, &src_variant, allocator)) {
       st.SkipWithError(rcutils_get_error_string().str);
     }
@@ -84,6 +86,7 @@ BENCHMARK_F(PerformanceTest, double_copy_variant)(benchmark::State & st)
   reset_heap_counters();
 
   for (auto _ : st) {
+    RCUTILS_UNUSED(_);
     if (!rcl_yaml_variant_copy(&dest_variant, &src_variant, allocator)) {
       st.SkipWithError(rcutils_get_error_string().str);
     }
@@ -110,6 +113,7 @@ BENCHMARK_F(PerformanceTest, string_copy_variant)(benchmark::State & st)
   reset_heap_counters();
 
   for (auto _ : st) {
+    RCUTILS_UNUSED(_);
     if (!rcl_yaml_variant_copy(&dest_variant, &src_variant, allocator)) {
       st.SkipWithError(rcutils_get_error_string().str);
     }
@@ -139,6 +143,7 @@ BENCHMARK_F(PerformanceTest, array_bool_copy_variant)(benchmark::State & st)
   reset_heap_counters();
 
   for (auto _ : st) {
+    RCUTILS_UNUSED(_);
     if (!rcl_yaml_variant_copy(&dest_variant, &src_variant, allocator)) {
       st.SkipWithError(rcutils_get_error_string().str);
     }
@@ -168,6 +173,7 @@ BENCHMARK_F(PerformanceTest, array_int_copy_variant)(benchmark::State & st)
   reset_heap_counters();
 
   for (auto _ : st) {
+    RCUTILS_UNUSED(_);
     if (!rcl_yaml_variant_copy(&dest_variant, &src_variant, allocator)) {
       st.SkipWithError(rcutils_get_error_string().str);
     }
@@ -197,6 +203,7 @@ BENCHMARK_F(PerformanceTest, array_double_copy_variant)(benchmark::State & st)
   reset_heap_counters();
 
   for (auto _ : st) {
+    RCUTILS_UNUSED(_);
     if (!rcl_yaml_variant_copy(&dest_variant, &src_variant, allocator)) {
       st.SkipWithError(rcutils_get_error_string().str);
     }
@@ -235,6 +242,7 @@ BENCHMARK_F(PerformanceTest, array_string_copy_variant)(benchmark::State & st)
   reset_heap_counters();
 
   for (auto _ : st) {
+    RCUTILS_UNUSED(_);
     if (!rcl_yaml_variant_copy(&dest_variant, &src_variant, allocator)) {
       st.SkipWithError(rcutils_get_error_string().str);
     }


### PR DESCRIPTION
1. The "expected" variable should be default initialized, otherwise it might have a garbage value when being checked.
2. Mark some variables in tests as unused.
3. Call rcl_reset_error in a few more places.