### PR TITLE
Switch to target_link_libraries in rcl.

### DIFF
--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -78,20 +78,24 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
-# specific order: dependents before dependencies
-ament_target_dependencies(${PROJECT_NAME}
-  "libyaml_vendor"
-  "rcl_interfaces"
-  "rcl_logging_interface"
-  "rcl_yaml_param_parser"
-  "rcutils"
-  "rmw"
-  "rmw_implementation"
-  ${RCL_LOGGING_IMPL}
-  "rosidl_runtime_c"
-  "service_msgs"
-  "tracetools"
-  "type_description_interfaces"
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  # TODO(clalancette): rcl_interfaces should be PRIVATE, but downstream depends on it for now
+  ${rcl_interfaces_TARGETS}
+  # TODO(clalancette): rcl_logging_interface should be PRIVATE, but downstream depends on it for now
+  rcl_logging_interface::rcl_logging_interface
+  rcl_yaml_param_parser::rcl_yaml_param_parser
+  rcutils::rcutils
+  rmw::rmw
+  # TODO(clalancette): rmw_implementation should be PRIVATE, but downstream depends on it for now
+  rmw_implementation::rmw_implementation
+  rosidl_runtime_c::rosidl_runtime_c
+  ${type_description_interfaces_TARGETS}
+)
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  ${RCL_LOGGING_IMPL}::${RCL_LOGGING_IMPL}
+  ${service_msgs_TARGETS}
+  tracetools::tracetools
+  yaml
 )
 
 # Causes the visibility macros to use dllexport rather than dllimport,
@@ -121,20 +125,18 @@ ament_export_libraries(${PROJECT_NAME})
 # Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
 
-# specific order: dependents before dependencies
 ament_export_dependencies(ament_cmake)
+# TODO(clalancette): rcl_interfaces shouldn't be exported, but downstream depends on it for now
 ament_export_dependencies(rcl_interfaces)
+# TODO(clalancette): rcl_logging_interface shouldn't be exported, but downstream depends on it for now
 ament_export_dependencies(rcl_logging_interface)
 ament_export_dependencies(rcl_yaml_param_parser)
-ament_export_dependencies(rmw_implementation)
-ament_export_dependencies(rmw)
 ament_export_dependencies(rcutils)
-ament_export_dependencies(${RCL_LOGGING_IMPL})
+ament_export_dependencies(rmw)
+# TODO(clalancette): rmw_implementation shouldn't be exported, but downstream depends on it for now
+ament_export_dependencies(rmw_implementation)
 ament_export_dependencies(rosidl_runtime_c)
-ament_export_dependencies(service_msgs)
-ament_export_dependencies(tracetools)
 ament_export_dependencies(type_description_interfaces)
-ament_export_dependencies(libyaml_vendor)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -413,7 +413,8 @@ rcl_add_custom_gtest(test_localhost
 rcl_add_custom_gtest(test_logging
   SRCS rcl/test_logging.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME} mimick
+  LIBRARIES ${PROJECT_NAME} mimick ${rcl_interfaces_TARGETS}
+    rcl_logging_interface::rcl_logging_interface ${RCL_LOGGING_IMPL}::${RCL_LOGGING_IMPL}
   AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
 )
 


### PR DESCRIPTION
This makes it possible to hide some of our libraries, which is much nicer for downstream projects.  It also means we can export fewer dependencies.

@emersonknapp FYI, this is the followup to #1027 