### PR TITLE
publish for rosout topic multiple times to avoid flaky test

### DIFF
--- a/rcl/test/rcl/test_logging_rosout.cpp
+++ b/rcl/test/rcl/test_logging_rosout.cpp
@@ -193,8 +193,8 @@ check_if_rosout_subscription_gets_a_message(
   });
   size_t iteration = 0;
   const char * message = "SOMETHING";
-  RCUTILS_LOG_INFO_NAMED(logger_name, message);
   do {
+    RCUTILS_LOG_INFO_NAMED(logger_name, message);
     ++iteration;
     ret = rcl_wait_set_clear(&wait_set);
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;


### PR DESCRIPTION
to fix https://github.com/ros2/rcl/issues/1050

Sorry, I updated the publish times to once in https://github.com/ros2/rcl/pull/921 as I thought the publisher using qos(https://github.com/ros2/rcl/blob/d15594effa63065a19a9f69960ea80f5ac5be8bd/rcl/include/rcl/logging_rosout.h#L41-L42) can make the subscribe using qos(https://github.com/ros2/rmw/blob/ac633c09056fb8525c072513c4a2665e7c13a530/rmw/include/rmw/qos_profiles.h#L55-L56) receive the message.