### PR TITLE
Use TRACETOOLS_ prefix for tracepoint-related macros

### DIFF
--- a/rcl/src/rcl/client.c
+++ b/rcl/src/rcl/client.c
@@ -176,7 +176,7 @@ rcl_client_init(
   client->impl->options = *options;
   atomic_init(&client->impl->sequence_number, 0);
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Client initialized");
-  TRACEPOINT(
+  TRACETOOLS_TRACEPOINT(
     rcl_client_init,
     (const void *)client,
     (const void *)node,

--- a/rcl/src/rcl/init.c
+++ b/rcl/src/rcl/init.c
@@ -312,7 +312,7 @@ rcl_init(
     goto fail;
   }
 
-  TRACEPOINT(rcl_init, (const void *)context);
+  TRACETOOLS_TRACEPOINT(rcl_init, (const void *)context);
 
   return RCL_RET_OK;
 fail:

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -301,7 +301,7 @@ rcl_node_init(
   }
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Node initialized");
   ret = RCL_RET_OK;
-  TRACEPOINT(
+  TRACETOOLS_TRACEPOINT(
     rcl_node_init,
     (const void *)node,
     (const void *)rcl_node_get_rmw_handle(node),

--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -130,7 +130,7 @@ rcl_publisher_init(
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Publisher initialized");
   // context
   publisher->impl->context = node->context;
-  TRACEPOINT(
+  TRACETOOLS_TRACEPOINT(
     rcl_publisher_init,
     (const void *)publisher,
     (const void *)node,
@@ -258,7 +258,7 @@ rcl_publish(
     return RCL_RET_PUBLISHER_INVALID;  // error already set
   }
   RCL_CHECK_ARGUMENT_FOR_NULL(ros_message, RCL_RET_INVALID_ARGUMENT);
-  TRACEPOINT(rcl_publish, (const void *)publisher, (const void *)ros_message);
+  TRACETOOLS_TRACEPOINT(rcl_publish, (const void *)publisher, (const void *)ros_message);
   if (rmw_publish(publisher->impl->rmw_handle, ros_message, allocation) != RMW_RET_OK) {
     RCL_SET_ERROR_MSG(rmw_get_error_string().str);
     return RCL_RET_ERROR;

--- a/rcl/src/rcl/service.c
+++ b/rcl/src/rcl/service.c
@@ -187,7 +187,7 @@ rcl_service_init(
   // options
   service->impl->options = *options;
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Service initialized");
-  TRACEPOINT(
+  TRACETOOLS_TRACEPOINT(
     rcl_service_init,
     (const void *)service,
     (const void *)node,

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -124,7 +124,7 @@ rcl_subscription_init(
   subscription->impl->options = *options;
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Subscription initialized");
   ret = RCL_RET_OK;
-  TRACEPOINT(
+  TRACETOOLS_TRACEPOINT(
     rcl_subscription_init,
     (const void *)subscription,
     (const void *)node,
@@ -536,7 +536,7 @@ rcl_take(
   }
   RCUTILS_LOG_DEBUG_NAMED(
     ROS_PACKAGE_NAME, "Subscription take succeeded: %s", taken ? "true" : "false");
-  TRACEPOINT(rcl_take, (const void *)ros_message);
+  TRACETOOLS_TRACEPOINT(rcl_take, (const void *)ros_message);
   if (!taken) {
     return RCL_RET_SUBSCRIPTION_TAKE_FAILED;
   }

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -205,7 +205,7 @@ rcl_timer_init(
     return RCL_RET_BAD_ALLOC;
   }
   *timer->impl = impl;
-  TRACEPOINT(rcl_timer_init, (const void *)timer, period);
+  TRACETOOLS_TRACEPOINT(rcl_timer_init, (const void *)timer, period);
   return RCL_RET_OK;
 }
 

--- a/rcl_lifecycle/src/rcl_lifecycle.c
+++ b/rcl_lifecycle/src/rcl_lifecycle.c
@@ -247,7 +247,7 @@ rcl_lifecycle_state_machine_init(
     }
   }
 
-  TRACEPOINT(
+  TRACETOOLS_TRACEPOINT(
     rcl_lifecycle_state_machine_init,
     (const void *)node_handle,
     (const void *)state_machine);
@@ -370,7 +370,7 @@ _trigger_transition(
     }
   }
 
-  TRACEPOINT(
+  TRACETOOLS_TRACEPOINT(
     rcl_lifecycle_transition,
     (const void *)state_machine,
     transition->start->label,


### PR DESCRIPTION
Part of https://github.com/ros2/ros2_tracing/issues/18

Requires https://github.com/ros2/ros2_tracing/pull/56

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>