### PR TITLE
Add enable_type_description_service node option - API only (rep2011)

### DIFF
--- a/rcl/include/rcl/node_options.h
+++ b/rcl/include/rcl/node_options.h
@@ -54,6 +54,9 @@ typedef struct rcl_node_options_s
 
   /// Middleware quality of service settings for /rosout.
   rmw_qos_profile_t rosout_qos;
+
+  /// Register the ~/get_type_description service. Defaults to false.
+  bool enable_type_description_service;
 } rcl_node_options_t;
 
 /// Return the default node options in a rcl_node_options_t.

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -293,6 +293,12 @@ rcl_node_init(
       goto fail;
     }
   }
+  if (node->impl->options.enable_type_description_service) {
+    RCUTILS_LOG_WARN_NAMED(
+      ROS_PACKAGE_NAME,
+      "Requested ~/get_type_description service enabled, but feature is not yet implemented. "
+      "Service is not created.");
+  }
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Node initialized");
   ret = RCL_RET_OK;
   TRACEPOINT(

--- a/rcl/src/rcl/node_options.c
+++ b/rcl/src/rcl/node_options.c
@@ -36,6 +36,7 @@ rcl_node_get_default_options()
     .arguments = rcl_get_zero_initialized_arguments(),
     .enable_rosout = true,
     .rosout_qos = rcl_qos_profile_rosout_default,
+    .enable_type_description_service = false,
   };
   return default_options;
 }
@@ -61,6 +62,7 @@ rcl_node_options_copy(
   options_out->use_global_arguments = options->use_global_arguments;
   options_out->enable_rosout = options->enable_rosout;
   options_out->rosout_qos = options->rosout_qos;
+  options_out->enable_type_description_service = options->enable_type_description_service;
   if (NULL != options->arguments.impl) {
     return rcl_arguments_copy(&(options->arguments), &(options_out->arguments));
   }


### PR DESCRIPTION
Part of ros2/ros2#1159

Stabilizes `rcl` API/ABI to enable #1052 as a backport into Iron after initial release.