### PR TITLE
fix flaky test

### DIFF
--- a/rcl/test/rcl/test_graph.cpp
+++ b/rcl/test/rcl/test_graph.cpp
@@ -881,11 +881,9 @@ void expect_topics_types(
   ret = func(node, topic_name, &nat);
   // Ignore the `RCL_RET_NODE_NAME_NON_EXISTENT` result since the discovery may be asynchronous
   // that the node information is not updated immediately into the graph cache.
-  if (ret == RCL_RET_NODE_NAME_NON_EXISTENT) {
-    rcl_reset_error();
-    return;
+  if (ret != RCL_RET_NODE_NAME_NON_EXISTENT) {
+    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   }
-  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   rcl_reset_error();
   is_success &= num_topics == nat.names.size;
   if (expect) {

--- a/rcl/test/rcl/test_graph.cpp
+++ b/rcl/test/rcl/test_graph.cpp
@@ -879,6 +879,11 @@ void expect_topics_types(
   rcl_names_and_types_t nat{};
   nat = rcl_get_zero_initialized_names_and_types();
   ret = func(node, topic_name, &nat);
+  // Ignore the `RCL_RET_NODE_NAME_NON_EXISTENT` result since the discovery may be asynchronous
+  // that the node information is not updated immediately into the graph cache.
+  if (ret != RCL_RET_NODE_NAME_NON_EXISTENT) {
+    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  }
   rcl_reset_error();
   is_success &= num_topics == nat.names.size;
   if (expect) {

--- a/rcl/test/rcl/test_graph.cpp
+++ b/rcl/test/rcl/test_graph.cpp
@@ -879,7 +879,6 @@ void expect_topics_types(
   rcl_names_and_types_t nat{};
   nat = rcl_get_zero_initialized_names_and_types();
   ret = func(node, topic_name, &nat);
-  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   rcl_reset_error();
   is_success &= num_topics == nat.names.size;
   if (expect) {

--- a/rcl/test/rcl/test_graph.cpp
+++ b/rcl/test/rcl/test_graph.cpp
@@ -881,9 +881,11 @@ void expect_topics_types(
   ret = func(node, topic_name, &nat);
   // Ignore the `RCL_RET_NODE_NAME_NON_EXISTENT` result since the discovery may be asynchronous
   // that the node information is not updated immediately into the graph cache.
-  if (ret != RCL_RET_NODE_NAME_NON_EXISTENT) {
-    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  if (ret == RCL_RET_NODE_NAME_NON_EXISTENT) {
+    rcl_reset_error();
+    return;
   }
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   rcl_reset_error();
   is_success &= num_topics == nat.names.size;
   if (expect) {

--- a/rcl/test/rcl/test_graph.cpp
+++ b/rcl/test/rcl/test_graph.cpp
@@ -882,6 +882,7 @@ void expect_topics_types(
   // Ignore the `RCL_RET_NODE_NAME_NON_EXISTENT` result since the discovery may be asynchronous
   // that the node information is not updated immediately into the graph cache.
   if (ret == RCL_RET_NODE_NAME_NON_EXISTENT) {
+    is_success &= false;
     rcl_reset_error();
     return;
   }

--- a/rcl/test/rcl/test_graph.cpp
+++ b/rcl/test/rcl/test_graph.cpp
@@ -882,7 +882,6 @@ void expect_topics_types(
   // Ignore the `RCL_RET_NODE_NAME_NON_EXISTENT` result since the discovery may be asynchronous
   // that the node information is not updated immediately into the graph cache.
   if (ret == RCL_RET_NODE_NAME_NON_EXISTENT) {
-    is_success &= false;
     rcl_reset_error();
     return;
   }


### PR DESCRIPTION
to fix https://github.com/ros2/rcl/issues/1062

https://github.com/ros2/rcl/blob/959ef2836e8cb88bcc1805752ad857127684ac4d/rcl/test/rcl/test_graph.cpp#L870
is only called in [VerifySubsystemCount](https://github.com/ros2/rcl/blob/959ef2836e8cb88bcc1805752ad857127684ac4d/rcl/test/rcl/test_graph.cpp#L1025), which expect to cost (20*400ms) if failure happened in the test, 
but we can find `[  FAILED  ] NodeGraphMultiNodeFixture.test_node_info_publishers (3909 ms)` just consume 4s running the test.

I think this [ASSERT](https://github.com/ros2/rcl/blob/959ef2836e8cb88bcc1805752ad857127684ac4d/rcl/test/rcl/test_graph.cpp#L882) can be removed as the discovery in operations ([1](https://github.com/ros2/rcl/blob/959ef2836e8cb88bcc1805752ad857127684ac4d/rcl/test/rcl/test_graph.cpp#L949), [2](https://github.com/ros2/rcl/blob/959ef2836e8cb88bcc1805752ad857127684ac4d/rcl/test/rcl/test_graph.cpp#L957), [3](https://github.com/ros2/rcl/blob/959ef2836e8cb88bcc1805752ad857127684ac4d/rcl/test/rcl/test_graph.cpp#L965), [4](https://github.com/ros2/rcl/blob/959ef2836e8cb88bcc1805752ad857127684ac4d/rcl/test/rcl/test_graph.cpp#L972)) might be asynchronous(doc needs to be updated) which is similar to [rmw_get_publishers_info_by_topic](https://github.com/ros2/rmw/blob/bb044d59df89fac9fed8706aa58a8d7092fa31a2/rmw/include/rmw/get_topic_endpoint_info.h#L34).

`rcl_get_publisher_names_and_types_by_node` -> `rmw_get_publisher_names_and_types_by_node` -> `rmw_api_connextdds_get_publisher_names_and_types_by_node` -> ... -> `get_writer_names_and_types_by_node` -> `GraphCache::get_writer_names_and_types_by_node` ->
	https://github.com/ros2/rmw_dds_common/blob/0dc8af3cc1c471c60a96e896ab66633d486feb50/rmw_dds_common/src/graph_cache.cpp#L891-L898
