### PR TITLE
localhost_only prevails auto discovery options if enabled.

### DIFF
--- a/rcl/src/rcl/init.c
+++ b/rcl/src/rcl/init.c
@@ -188,16 +188,16 @@ rcl_init(
   if (*localhost_only == RMW_LOCALHOST_ONLY_ENABLED) {
     RCUTILS_LOG_WARN_NAMED(
       ROS_PACKAGE_NAME,
-      "'localhost_only' is enabled, that prevails over "
-      "'automatic_discovery_range' and ignore 'static_peers'.");
+      "'localhost_only' is enabled, "
+      "'automatic_discovery_range' and 'static_peers' will be ignored.");
     discovery_options->automatic_discovery_range = RMW_AUTOMATIC_DISCOVERY_RANGE_LOCALHOST;
     discovery_options->static_peers_count = 0;
   } else {
     if (*localhost_only == RMW_LOCALHOST_ONLY_DISABLED) {
       RCUTILS_LOG_WARN_NAMED(
         ROS_PACKAGE_NAME,
-        "'localhost_only' is disable, that falls down to use "
-        "'automatic_discovery_range' and 'static_peers'.");
+        "'localhost_only' is disabled, "
+        "'automatic_discovery_range' and 'static_peers' will be used.");
     }
 
     // Get actual discovery range option based on environment variable, if not given

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -402,6 +402,7 @@ rcl_add_custom_gtest(test_discovery_options
   SRCS rcl/test_discovery_options.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
   LIBRARIES ${PROJECT_NAME}
+  AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
 )
 
 rcl_add_custom_gtest(test_domain_id


### PR DESCRIPTION
follow up of https://github.com/ros2/ros2/issues/1359.

during deprecation period for `locaohost_only` option for Iron, `locaohost_only` prevails over discovery option which has been added with https://github.com/ros2/ros2/issues/1359 as new feature.

see https://github.com/ros2/ros2_documentation/pull/3519#discussion_r1185468875 for more details and discussion.