### PR TITLE
improve error msg of `rcl_expand_topic_name`

### DIFF
--- a/rcl/src/rcl/expand_topic_name.c
+++ b/rcl/src/rcl/expand_topic_name.c
@@ -70,7 +70,7 @@ rcl_expand_topic_name(
     return ret;
   }
   if (validation_result != RCL_TOPIC_NAME_VALID) {
-    RCL_SET_ERROR_MSG("topic name is invalid");
+    RCL_SET_ERROR_MSG(rcl_topic_name_validation_result_string(validation_result));
     return RCL_RET_TOPIC_NAME_INVALID;
   }
   // validate the node name


### PR DESCRIPTION
If `RCL_RET_TOPIC_NAME_INVALID` is returned the error msg is obtained by calling `rcl_topic_name_validation_result_string` to ease debugging invalid topics.

I think this change would be useful because currently I have to debug erratically failing subscription initialisations at work and having a more specific error message would help a lot in understanding what went wrong in the future.