### PR TITLE
rcl_send_response returns RCL_RET_TIMEOUT.

### DIFF
--- a/rcl/src/rcl/service.c
+++ b/rcl/src/rcl/service.c
@@ -373,10 +373,12 @@ rcl_send_response(
   const rcl_service_options_t * options = rcl_service_get_options(service);
   RCL_CHECK_FOR_NULL_WITH_MSG(options, "Failed to get service options", return RCL_RET_ERROR);
 
-  if (rmw_send_response(
-      service->impl->rmw_handle, request_header, ros_response) != RMW_RET_OK)
-  {
+  rmw_ret_t ret = rmw_send_response(service->impl->rmw_handle, request_header, ros_response);
+  if (ret != RMW_RET_OK) {
     RCL_SET_ERROR_MSG(rmw_get_error_string().str);
+    if (ret == RMW_RET_TIMEOUT) {
+      return RCL_RET_TIMEOUT;
+    }
     return RCL_RET_ERROR;
   }
 


### PR DESCRIPTION
part of ros2/ros2#1253

We hit this problem where a broken client crashes the service executor. With this change we can fix it in rclcpp.

Note: this is same as https://github.com/ros2/rcl/pull/1048 which is not taken attention for a while.