### PR TITLE
Reset errors in tests to reduce warnings

### DIFF
--- a/rcl/test/rcl/test_discovery_options.cpp
+++ b/rcl/test/rcl/test_discovery_options.cpp
@@ -209,12 +209,15 @@ TEST(TestDiscoveryInfo, test_bad_argument) {
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
 
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_get_automatic_discovery_range(nullptr));
+  rcl_reset_error();
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_get_discovery_static_peers(nullptr, &allocator));
+  rcl_reset_error();
 
   rmw_discovery_options_t discovery_options_var = rmw_get_zero_initialized_discovery_options();
   EXPECT_EQ(
     RCL_RET_INVALID_ARGUMENT,
     rcl_get_discovery_static_peers(&discovery_options_var, nullptr));
+  rcl_reset_error();
   EXPECT_EQ(RCL_RET_OK, rmw_discovery_options_fini(&discovery_options_var));
 }
 

--- a/rcl/test/rcl/test_init.cpp
+++ b/rcl/test/rcl/test_init.cpp
@@ -469,12 +469,16 @@ TEST_F(CLASSNAME(TestRCLFixture, RMW_IMPLEMENTATION), test_rcl_init_options_acce
   EXPECT_EQ(0u, options->instance_id);
   EXPECT_EQ(nullptr, options->impl);
   EXPECT_EQ(NULL, rcl_init_options_get_rmw_init_options(nullptr));
+  rcl_reset_error();
   EXPECT_EQ(NULL, rcl_init_options_get_rmw_init_options(&not_ini_init_options));
+  rcl_reset_error();
 
   const rcl_allocator_t * options_allocator = rcl_init_options_get_allocator(&init_options);
   EXPECT_TRUE(rcutils_allocator_is_valid(options_allocator));
   EXPECT_EQ(NULL, rcl_init_options_get_allocator(nullptr));
+  rcl_reset_error();
   EXPECT_EQ(NULL, rcl_init_options_get_allocator(&not_ini_init_options));
+  rcl_reset_error();
 
   size_t domain_id;
   ret = rcl_init_options_get_domain_id(NULL, &domain_id);

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -523,6 +523,7 @@ TEST_F(TestTimerFixture, test_timer_init_state) {
     &timer, &clock, this->context_ptr, RCL_S_TO_NS(1), nullptr, rcl_get_default_allocator(),
     true);
   ASSERT_EQ(RCL_RET_ALREADY_INIT, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
 
   timer = rcl_get_zero_initialized_timer();
 

--- a/rcl/test/rcl/test_type_description_conversions.cpp
+++ b/rcl/test/rcl/test_type_description_conversions.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include "rcl/error_handling.h"
 #include "rcl/type_description_conversions.h"
 #include "rosidl_runtime_c/message_type_support_struct.h"
 #include "rosidl_runtime_c/type_description/type_description__functions.h"
@@ -45,7 +46,9 @@ TEST(TestTypeDescriptionConversions, type_description_conversion_round_trip) {
 
 TEST(TestTypeDescriptionConversions, type_description_invalid_input) {
   EXPECT_TRUE(NULL == rcl_convert_type_description_runtime_to_msg(NULL));
+  rcl_reset_error();
   EXPECT_TRUE(NULL == rcl_convert_type_description_msg_to_runtime(NULL));
+  rcl_reset_error();
 }
 
 TEST(TestTypeDescriptionConversions, type_source_sequence_conversion_round_trip) {
@@ -101,7 +104,9 @@ TEST(TestTypeDescriptionConversions, actually_empty_sources_ok) {
 
 TEST(TestTypeDescriptionConversions, type_source_sequence_invalid_input) {
   EXPECT_TRUE(NULL == rcl_convert_type_source_sequence_msg_to_runtime(NULL));
+  rcl_reset_error();
   EXPECT_TRUE(NULL == rcl_convert_type_source_sequence_runtime_to_msg(NULL));
+  rcl_reset_error();
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
When we have a test that fails, we always want to do an `rcl_reset_error` after it to reset the internal error that is set.  That prepares it for the next test.  We were missing this in a few places in our tests, so add them as needed.