### PR TITLE
Adding duplicate node information

### DIFF
--- a/rcl/src/rcl/logging_rosout.c
+++ b/rcl/src/rcl/logging_rosout.c
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "rcl/logging_rosout.h"
+
 #include "rcl/allocator.h"
 #include "rcl/error_handling.h"
-#include "rcl/logging_rosout.h"
 #include "rcl/node.h"
 #include "rcl/publisher.h"
 #include "rcl/time.h"
@@ -250,13 +251,20 @@ rcl_ret_t rcl_logging_rosout_init_publisher_for_node(rcl_node_t * node)
   if (rcutils_hash_map_key_exists(&__logger_map, &logger_name)) {
     // @TODO(nburek) Update behavior to either enforce unique names or work with non-unique
     // names based on the outcome here: https://github.com/ros2/design/issues/187
+    const char * node_name = rcl_node_get_name(node);
+    if (NULL == node_name) {
+      node_name = "unknown node";
+    }
+
     RCUTILS_LOG_WARN_NAMED(
       "rcl.logging_rosout",
-      "Publisher already registered for provided node name. If this is due to multiple nodes "
-      "with the same name then all logs for that logger name will go out over the existing "
-      "publisher. As soon as any node with that name is destructed it will unregister the "
-      "publisher, preventing any further logs for that name from being published on the rosout "
-      "topic.");
+      "Publisher already registered for node name: '%s'. If this is due to multiple nodes "
+      "with the same name then all logs for the logger named '%s' will go out over "
+      "the existing publisher. As soon as any node with that name is destructed "
+      "it will unregister the publisher, preventing any further logs for that name from "
+      "being published on the rosout topic.",
+      node_name,
+      logger_name);
     return RCL_RET_OK;
   }
 


### PR DESCRIPTION
This resolves issue #984 just bringing more information to an error message when there are multiple nodes that are being published. Originally the issue wanted to just add the `logger name` to make it easier to read, but I also got the `node name` because I figured to user should want to know both, making an easier to resolve the duplicate node.

That should solve the issue, but there is still a TODO, that's been there since [2019](https://github.com/ros2/rcl/commit/af49d6b3bf13925ac61f3c950391cc63e15211e8), which talks about the design docs and the instability of duplicate nodes. Do we want to add anything now, like mentioned in [the doc](https://github.com/ros2/design/issues/187):
> For a default (non-production) behavior I think having the newer node raise an exception makes sense

Or is it better to leave it be?