### PR TITLE
Change next_call_time computation of rcl_timer to always result in a future timestamp

### DIFF
--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -294,7 +294,7 @@ rcl_timer_call(rcl_timer_t * timer)
   // between the timer being ready and the callback being triggered
   next_call_time += period;
   // in case the timer has missed at least once cycle
-  if (next_call_time < now) {
+  if (next_call_time <= now) {
     if (0 == period) {
       // a timer with a period of zero is considered always ready
       next_call_time = now;
@@ -302,7 +302,7 @@ rcl_timer_call(rcl_timer_t * timer)
       // move the next call time forward by as many periods as necessary
       int64_t now_ahead = now - next_call_time;
       // rounding up without overflow
-      int64_t periods_ahead = 1 + (now_ahead - 1) / period;
+      int64_t periods_ahead = 1 + now_ahead / period;
       next_call_time += periods_ahead * period;
     }
   }


### PR DESCRIPTION
In the current implementation `next_call_time` can be equal to `now` after the timer has been called. This can lead to consecutive callback calls with the same timestamp when using sim time.

With this change `next_call_time` will always be greater than `now` after the timer has been called.