### PR TITLE
Cleanup network flow endpoints test.

### DIFF
--- a/rcl/src/rcl/network_flow_endpoints.c
+++ b/rcl/src/rcl/network_flow_endpoints.c
@@ -12,11 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-
 #include "rcl/error_handling.h"
 #include "rcl/graph.h"
 #include "rcl/network_flow_endpoints.h"
@@ -115,7 +110,3 @@ rcl_subscription_get_network_flow_endpoints(
   }
   return rcl_convert_rmw_ret_to_rcl_ret(rmw_ret);
 }
-
-#ifdef __cplusplus
-}
-#endif

--- a/rcl/test/rcl/test_network_flow_endpoints.cpp
+++ b/rcl/test/rcl/test_network_flow_endpoints.cpp
@@ -408,9 +408,11 @@ TEST_F(
           strcmp_ret);
       }
     }
-  }
 
-  // Release resources
-  rcl_network_flow_endpoint_array_fini(&network_flow_endpoint_array_1);
-  rcl_network_flow_endpoint_array_fini(&network_flow_endpoint_array_2);
+    // Release resources
+    rcl_network_flow_endpoint_array_fini(&network_flow_endpoint_array_1);
+    rcl_network_flow_endpoint_array_fini(&network_flow_endpoint_array_2);
+  } else {
+    rcl_reset_error();
+  }
 }


### PR DESCRIPTION
So that we don't get warnings on unsupported RMW implementations.