### PR TITLE
Reduce the number of tests we run

### DIFF
--- a/rcl/src/rcl/arguments.c
+++ b/rcl/src/rcl/arguments.c
@@ -32,13 +32,6 @@
 #include "rcutils/logging.h"
 #include "rcutils/logging_macros.h"
 #include "rcutils/strdup.h"
-#include "rmw/validate_namespace.h"
-#include "rmw/validate_node_name.h"
-
-#ifdef __cplusplus
-extern "C"
-{
-#endif
 
 /// Parse an argument that may or may not be a remap rule.
 /**
@@ -2071,9 +2064,5 @@ _rcl_allocate_initialized_arguments_impl(rcl_arguments_t * args, rcl_allocator_t
 
   return RCL_RET_OK;
 }
-
-#ifdef __cplusplus
-}
-#endif
 
 /// \endcond  // Internal Doxygen documentation

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -86,14 +86,6 @@ function(test_target_function)
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp"
   )
 
-  rcl_add_custom_gtest(test_lexer_lookahead${target_suffix}
-    SRCS rcl/test_lexer_lookahead.cpp
-    ENV ${rmw_implementation_env_var}
-    APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME}
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp"
-  )
-
   rcl_add_custom_gtest(test_graph${target_suffix}
     SRCS rcl/test_graph.cpp
     ENV ${rmw_implementation_env_var}
@@ -416,6 +408,13 @@ rcl_add_custom_gtest(test_lexer
   SRCS rcl/test_lexer.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
   LIBRARIES ${PROJECT_NAME}
+)
+
+rcl_add_custom_gtest(test_lexer_lookahead
+  SRCS rcl/test_lexer_lookahead.cpp
+  APPEND_LIBRARY_DIRS ${extra_lib_dirs}
+  LIBRARIES ${PROJECT_NAME}
+  AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
 )
 
 rcl_add_custom_gtest(test_validate_enclave_name

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -86,14 +86,6 @@ function(test_target_function)
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp"
   )
 
-  rcl_add_custom_gtest(test_lexer${target_suffix}
-    SRCS rcl/test_lexer.cpp
-    ENV ${rmw_implementation_env_var}
-    APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME}
-    AMENT_DEPENDENCIES ${rmw_implementation}
-  )
-
   rcl_add_custom_gtest(test_lexer_lookahead${target_suffix}
     SRCS rcl/test_lexer_lookahead.cpp
     ENV ${rmw_implementation_env_var}
@@ -418,6 +410,12 @@ rcl_add_custom_gtest(test_time
   ENV ${memory_tools_ld_preload_env_var}
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
   LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
+)
+
+rcl_add_custom_gtest(test_lexer
+  SRCS rcl/test_lexer.cpp
+  APPEND_LIBRARY_DIRS ${extra_lib_dirs}
+  LIBRARIES ${PROJECT_NAME}
 )
 
 rcl_add_custom_gtest(test_validate_enclave_name

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -170,15 +170,6 @@ function(test_target_function)
     TIMEOUT 240  # Large timeout to wait for fault injection tests
   )
 
-  rcl_add_custom_gtest(test_arguments${target_suffix}
-    SRCS rcl/test_arguments.cpp
-    ENV ${rmw_implementation_env_var}
-    APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
-    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
-    AMENT_DEPENDENCIES "osrf_testing_tools_cpp" "rcpputils"
-  )
-
   rcl_add_custom_gtest(test_remap${target_suffix}
     SRCS rcl/test_remap.cpp
     ENV ${rmw_implementation_env_var}
@@ -421,6 +412,14 @@ target_link_libraries(wait_for_entity_helpers PRIVATE
   rcutils::rcutils)
 
 call_for_each_rmw_implementation(test_target)
+
+rcl_add_custom_gtest(test_arguments
+  SRCS rcl/test_arguments.cpp
+  APPEND_LIBRARY_DIRS ${extra_lib_dirs}
+  INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
+  LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
+  AMENT_DEPENDENCIES "osrf_testing_tools_cpp" "rcpputils"
+)
 
 rcl_add_custom_gtest(test_validate_enclave_name
   SRCS rcl/test_validate_enclave_name.cpp

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -62,14 +62,6 @@ function(test_target_function)
     AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
   )
 
-  rcl_add_custom_gtest(test_time${target_suffix}
-    SRCS rcl/test_time.cpp
-    ENV ${rmw_implementation_env_var} ${memory_tools_ld_preload_env_var}
-    APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
-    AMENT_DEPENDENCIES ${rmw_implementation}
-  )
-
   rcl_add_custom_gtest(test_timer${target_suffix}
     SRCS rcl/test_timer.cpp
     ENV ${rmw_implementation_env_var}
@@ -419,6 +411,13 @@ rcl_add_custom_gtest(test_arguments
   INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
   LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
   AMENT_DEPENDENCIES "osrf_testing_tools_cpp" "rcpputils"
+)
+
+rcl_add_custom_gtest(test_time
+  SRCS rcl/test_time.cpp
+  ENV ${memory_tools_ld_preload_env_var}
+  APPEND_LIBRARY_DIRS ${extra_lib_dirs}
+  LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
 )
 
 rcl_add_custom_gtest(test_validate_enclave_name

--- a/rcl/test/rcl/test_arguments.cpp
+++ b/rcl/test/rcl/test_arguments.cpp
@@ -31,14 +31,7 @@
 #include "./allocator_testing_utils.h"
 #include "./arguments_impl.h"
 
-#ifdef RMW_IMPLEMENTATION
-# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
-# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
-#else
-# define CLASSNAME(NAME, SUFFIX) NAME
-#endif
-
-class CLASSNAME (TestArgumentsFixture, RMW_IMPLEMENTATION) : public ::testing::Test
+class TestArgumentsFixture : public ::testing::Test
 {
 public:
   void SetUp()
@@ -50,6 +43,7 @@ public:
   {
   }
 
+protected:
   rcpputils::fs::path test_path{TEST_RESOURCES_DIRECTORY};
 };
 
@@ -128,7 +122,7 @@ are_known_ros_args(std::vector<const char *> argv)
   return is_valid;
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), check_known_vs_unknown_args) {
+TEST_F(TestArgumentsFixture, check_known_vs_unknown_args) {
   EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "__node:=node_name"}));
   EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "old_name:__node:=node_name"}));
   EXPECT_TRUE(are_known_ros_args({"--ros-args", "-r", "old_name:__node:=nodename123"}));
@@ -219,7 +213,7 @@ are_valid_ros_args(std::vector<const char *> argv)
   return true;
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), check_valid_vs_invalid_args) {
+TEST_F(TestArgumentsFixture, check_valid_vs_invalid_args) {
   const std::string parameters_filepath = (test_path / "test_parameters.1.yaml").string();
   EXPECT_TRUE(
     are_valid_ros_args(
@@ -291,7 +285,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), check_valid_vs_inval
   EXPECT_FALSE(are_valid_ros_args({"--ros-args", "--log-level", "foo"}));
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_no_args) {
+TEST_F(TestArgumentsFixture, test_no_args) {
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
   rcl_ret_t ret = rcl_parse_arguments(0, NULL, rcl_get_default_allocator(), &parsed_args);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
@@ -300,7 +294,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_no_args) {
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_null_args) {
+TEST_F(TestArgumentsFixture, test_null_args) {
   const int argc = 1;
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
   rcl_ret_t ret = rcl_parse_arguments(argc, NULL, rcl_get_default_allocator(), &parsed_args);
@@ -308,7 +302,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_null_args) {
   rcl_reset_error();
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_negative_args) {
+TEST_F(TestArgumentsFixture, test_negative_args) {
   const int argc = -1;
   const char * const argv[] = {"process_name"};
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
@@ -317,7 +311,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_negative_args) 
   rcl_reset_error();
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_alloc_parse_args) {
+TEST_F(TestArgumentsFixture, test_bad_alloc_parse_args) {
   const char * const argv[] = {"process_name"};
   const int argc = sizeof(argv) / sizeof(const char *);
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
@@ -327,7 +321,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_alloc_parse
   rcl_reset_error();
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_alloc_unparse_args) {
+TEST_F(TestArgumentsFixture, test_bad_alloc_unparse_args) {
   const char * const argv[] = {
     "process_name", "--ros-args", "/foo/bar:=", "-r", "bar:=/fiz/buz", "}bar:=fiz", "--", "arg"};
   const int argc = sizeof(argv) / sizeof(const char *);
@@ -355,7 +349,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_alloc_unpar
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_empty_unparsed) {
+TEST_F(TestArgumentsFixture, test_empty_unparsed) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_arguments_t empty_parsed_args = rcl_get_zero_initialized_arguments();
   int * actual_unparsed = NULL;
@@ -372,7 +366,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_empty_unparsed)
   rcl_reset_error();
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_params_get_counts) {
+TEST_F(TestArgumentsFixture, test_bad_params_get_counts) {
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
   EXPECT_EQ(-1, rcl_arguments_get_count_unparsed(nullptr));
   rcl_reset_error();
@@ -388,7 +382,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_params_get_
   rcl_reset_error();
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_null_args_output) {
+TEST_F(TestArgumentsFixture, test_null_args_output) {
   const char * const argv[] = {"process_name"};
   const int argc = sizeof(argv) / sizeof(const char *);
   rcl_ret_t ret = rcl_parse_arguments(argc, argv, rcl_get_default_allocator(), NULL);
@@ -396,7 +390,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_null_args_outpu
   rcl_reset_error();
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_no_ros_args) {
+TEST_F(TestArgumentsFixture, test_no_ros_args) {
   const char * const argv[] = {"process_name"};
   const int argc = sizeof(argv) / sizeof(const char *);
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
@@ -407,7 +401,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_no_ros_args) {
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_zero_ros_args) {
+TEST_F(TestArgumentsFixture, test_zero_ros_args) {
   const char * const argv[] = {"process_name", "--ros-args"};
   const int argc = sizeof(argv) / sizeof(const char *);
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
@@ -418,7 +412,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_zero_ros_args) 
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_zero_ros_args_w_trailing_dashes) {
+TEST_F(TestArgumentsFixture, test_zero_ros_args_w_trailing_dashes) {
   const char * const argv[] = {"process_name", "--ros-args", "--"};
   const int argc = sizeof(argv) / sizeof(const char *);
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
@@ -429,7 +423,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_zero_ros_args_w
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_remap) {
+TEST_F(TestArgumentsFixture, test_remap) {
   const char * const argv[] = {
     "process_name", "--ros-args", "-r", "/foo/bar:=/fiz/buz", "--remap", "foo:=/baz"
   };
@@ -443,7 +437,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_remap) {
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_one_remap_two_ros_args) {
+TEST_F(TestArgumentsFixture, test_one_remap_two_ros_args) {
   const char * const argv[] =
   {"process_name", "--ros-args", "--ros-args", "-r", "/foo/bar:=/fiz/buz"};
   const int argc = sizeof(argv) / sizeof(const char *);
@@ -456,7 +450,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_one_remap_two_r
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_one_remap_w_trailing_dashes) {
+TEST_F(TestArgumentsFixture, test_one_remap_w_trailing_dashes) {
   const char * const argv[] = {"process_name", "--ros-args", "-r", "/foo/bar:=/fiz/buz", "--"};
   const int argc = sizeof(argv) / sizeof(const char *);
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
@@ -468,7 +462,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_one_remap_w_tra
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_one_remap_w_two_trailing_dashes) {
+TEST_F(TestArgumentsFixture, test_one_remap_w_two_trailing_dashes) {
   const char * const argv[] =
   {"process_name", "--ros-args", "-r", "/foo/bar:=/fiz/buz", "--", "--"};
   const int argc = sizeof(argv) / sizeof(const char *);
@@ -481,7 +475,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_one_remap_w_two
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_mix_valid_invalid_rules) {
+TEST_F(TestArgumentsFixture, test_mix_valid_invalid_rules) {
   const char * const argv[] = {
     "process_name", "--ros-args", "/foo/bar:=", "-r", "bar:=/fiz/buz", "}bar:=fiz", "--", "arg"
   };
@@ -495,7 +489,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_mix_valid_inval
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_copy) {
+TEST_F(TestArgumentsFixture, test_copy) {
   const char * const argv[] = {
     "process_name", "--ros-args", "/foo/bar:=", "-r", "bar:=/fiz/buz", "-r", "__ns:=/foo", "--",
     "arg"
@@ -525,7 +519,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_copy) {
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&copied_args));
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_copy_bad_alloc) {
+TEST_F(TestArgumentsFixture, test_copy_bad_alloc) {
   const char * const argv[] = {"process_name", "--ros-args", "/foo/bar:="};
   const int argc = sizeof(argv) / sizeof(const char *);
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
@@ -546,7 +540,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_copy_bad_alloc)
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args)) << rcl_get_error_string().str;
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_copy_no_ros_args) {
+TEST_F(TestArgumentsFixture, test_copy_no_ros_args) {
   const char * const argv[] = {"process_name", "--ros-args", "--", "arg", "--ros-args"};
   const int argc = sizeof(argv) / sizeof(const char *);
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
@@ -581,7 +575,7 @@ __return_null_on_zero_allocate(size_t size, void * state)
   return malloc(size);
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_copy_no_args) {
+TEST_F(TestArgumentsFixture, test_copy_no_args) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   allocator.allocate = __return_null_on_zero_allocate;
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
@@ -600,7 +594,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_copy_no_args) {
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&copied_args));
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_two_namespace) {
+TEST_F(TestArgumentsFixture, test_two_namespace) {
   const char * const argv[] = {
     "process_name", "--ros-args", "-r", "__ns:=/foo/bar", "-r", "__ns:=/fiz/buz"
   };
@@ -614,7 +608,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_two_namespace) 
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&parsed_args));
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_uninitialized_parsed_args) {
+TEST_F(TestArgumentsFixture, test_uninitialized_parsed_args) {
   const char * const argv[] = {"process_name"};
   const int argc = sizeof(argv) / sizeof(const char *);
   rcl_arguments_t parsed_args;
@@ -626,7 +620,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_uninitialized_p
   rcl_reset_error();
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_double_parse) {
+TEST_F(TestArgumentsFixture, test_double_parse) {
   const char * const argv[] = {
     "process_name", "--ros-args", "-r", "__ns:=/foo/bar", "-r", "__ns:=/fiz/buz"
   };
@@ -645,19 +639,19 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_double_parse) {
   rcl_reset_error();
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_fini_null) {
+TEST_F(TestArgumentsFixture, test_fini_null) {
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_arguments_fini(NULL));
   rcl_reset_error();
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_fini_impl_null) {
+TEST_F(TestArgumentsFixture, test_fini_impl_null) {
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
   parsed_args.impl = NULL;
   EXPECT_EQ(RCL_RET_ERROR, rcl_arguments_fini(&parsed_args));
   rcl_reset_error();
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_fini_twice) {
+TEST_F(TestArgumentsFixture, test_fini_twice) {
   const char * const argv[] = {"process_name"};
   const int argc = sizeof(argv) / sizeof(const char *);
   rcl_arguments_t parsed_args = rcl_get_zero_initialized_arguments();
@@ -667,7 +661,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_fini_twice) {
   rcl_reset_error();
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_remove_ros_args) {
+TEST_F(TestArgumentsFixture, test_bad_remove_ros_args) {
   const char * const argv[] = {"process_name"};
   const int argc = sizeof(argv) / sizeof(const char *);
 
@@ -746,7 +740,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_remove_ros_
   EXPECT_EQ(0, nonros_argc);
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_alloc_remove_ros_args) {
+TEST_F(TestArgumentsFixture, test_bad_alloc_remove_ros_args) {
   const char * const argv[] = {
     "process_name", "-d", "--ros-args", "-r", "__ns:=/foo/bar", "-r", "__ns:=/fiz/buz", "--",
     "--foo=bar", "--baz", "--ros-args", "--ros-args", "-p", "bar:=baz", "--", "--", "arg",
@@ -775,7 +769,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_alloc_remov
   EXPECT_EQ(RCL_RET_BAD_ALLOC, ret);
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_remove_ros_args) {
+TEST_F(TestArgumentsFixture, test_remove_ros_args) {
   const char * const argv[] = {
     "process_name", "-d", "--ros-args", "-r", "__ns:=/foo/bar", "-r", "__ns:=/fiz/buz", "--",
     "--foo=bar", "--baz", "--ros-args", "--ros-args", "-p", "bar:=baz", "--", "--", "arg",
@@ -815,7 +809,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_remove_ros_args
   EXPECT_STREQ(nonros_argv[5], "arg");
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_remove_ros_args_if_ros_only) {
+TEST_F(TestArgumentsFixture, test_remove_ros_args_if_ros_only) {
   const char * const argv[] = {"--ros-args", "--disable-rosout-logs"};
   const int argc = sizeof(argv) / sizeof(const char *);
 
@@ -849,7 +843,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_remove_ros_args
 }
 
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_remove_ros_args_if_no_args) {
+TEST_F(TestArgumentsFixture, test_remove_ros_args_if_no_args) {
   const char ** argv = NULL;
   const int argc = 0;
 
@@ -882,7 +876,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_remove_ros_args
   EXPECT_TRUE(NULL == nonros_argv);
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_zero) {
+TEST_F(TestArgumentsFixture, test_param_argument_zero) {
   const char * const argv[] =
   {"process_name", "--ros-args", "-r", "__ns:=/namespace", "random:=arg"};
   const int argc = sizeof(argv) / sizeof(const char *);
@@ -901,7 +895,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_
   EXPECT_EQ(0, parameter_filecount);
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_single) {
+TEST_F(TestArgumentsFixture, test_param_argument_single) {
   const std::string parameters_filepath = (test_path / "test_parameters.1.yaml").string();
   const char * const argv[] = {
     "process_name", "--ros-args", "-r", "__ns:=/namespace", "random:=arg",
@@ -963,7 +957,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_
   EXPECT_EQ(1, *(param_value->integer_value));
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_multiple) {
+TEST_F(TestArgumentsFixture, test_param_argument_multiple) {
   const std::string parameters_filepath1 = (test_path / "test_parameters.1.yaml").string();
   const std::string parameters_filepath2 = (test_path / "test_parameters.2.yaml").string();
   const char * const argv[] = {
@@ -1034,7 +1028,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_argument_
   EXPECT_FALSE(bool_value);
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_arguments_copy) {
+TEST_F(TestArgumentsFixture, test_param_arguments_copy) {
   const std::string parameters_filepath1 = (test_path / "test_parameters.1.yaml").string();
   const std::string parameters_filepath2 = (test_path / "test_parameters.2.yaml").string();
   const char * const argv[] = {
@@ -1064,7 +1058,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_arguments
   EXPECT_EQ(RCL_RET_OK, rcl_arguments_fini(&copied_args));
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_no_param_overrides) {
+TEST_F(TestArgumentsFixture, test_no_param_overrides) {
   const char * const argv[] = {"process_name"};
   const int argc = sizeof(argv) / sizeof(const char *);
 
@@ -1104,7 +1098,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_no_param_overri
   EXPECT_TRUE(NULL == params);
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_overrides) {
+TEST_F(TestArgumentsFixture, test_param_overrides) {
   const std::string parameters_filepath = (test_path / "test_parameters.1.yaml").string();
   const char * const argv[] = {
     "process_name", "--ros-args",
@@ -1157,7 +1151,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_param_overrides
   EXPECT_STREQ("foo", param_value->string_value);
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_alloc_get_param_files) {
+TEST_F(TestArgumentsFixture, test_bad_alloc_get_param_files) {
   const std::string parameters_filepath1 = (test_path / "test_parameters.1.yaml").string();
   const std::string parameters_filepath2 = (test_path / "test_parameters.2.yaml").string();
   const char * const argv[] = {
@@ -1193,7 +1187,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_bad_alloc_get_p
   EXPECT_EQ(RCL_RET_BAD_ALLOC, ret) << rcl_get_error_string().str;
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_null_get_param_files) {
+TEST_F(TestArgumentsFixture, test_null_get_param_files) {
   const std::string parameters_filepath1 = (test_path / "test_parameters.1.yaml").string();
   const char * const argv[] = {
     "process_name", "--ros-args", "--params-file", parameters_filepath1.c_str()
@@ -1227,7 +1221,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_null_get_param_
   rcl_reset_error();
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_parse_with_internal_errors) {
+TEST_F(TestArgumentsFixture, test_parse_with_internal_errors) {
   const std::string parameters_filepath1 =
     (test_path / "test_parameters.1.yaml").string();
   const std::string parameters_filepath2 =
@@ -1272,7 +1266,7 @@ TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_parse_with_inte
   });
 }
 
-TEST_F(CLASSNAME(TestArgumentsFixture, RMW_IMPLEMENTATION), test_copy_with_internal_errors) {
+TEST_F(TestArgumentsFixture, test_copy_with_internal_errors) {
   const std::string parameters_filepath1 =
     (test_path / "test_parameters.1.yaml").string();
   const std::string parameters_filepath2 =

--- a/rcl/test/rcl/test_lexer.cpp
+++ b/rcl/test/rcl/test_lexer.cpp
@@ -18,25 +18,6 @@
 
 #include "rcl/lexer.h"
 
-#ifdef RMW_IMPLEMENTATION
-# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
-# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
-#else
-# define CLASSNAME(NAME, SUFFIX) NAME
-#endif
-
-class CLASSNAME (TestLexerFixture, RMW_IMPLEMENTATION) : public ::testing::Test
-{
-public:
-  void SetUp()
-  {
-  }
-
-  void TearDown()
-  {
-  }
-};
-
 // Not using a function so gtest failure output shows the line number where the macro is used
 #define EXPECT_LEX(expected_lexeme, expected_text, text) \
   do { \
@@ -50,7 +31,7 @@ public:
     EXPECT_STREQ(expected_text, actual_text.c_str()); \
   } while (false)
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_different_endings)
+TEST(TestLexer, test_token_different_endings)
 {
   // Things get recognized as tokens whether input ends or non token characters come after them
   EXPECT_LEX(RCL_LEXEME_TOKEN, "foo", "foo");
@@ -59,7 +40,7 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_different_end
   EXPECT_LEX(RCL_LEXEME_TOKEN, "foo_", "foo_:");
 }
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_start_char)
+TEST(TestLexer, test_token_start_char)
 {
   // Check full range for starting character
   EXPECT_LEX(RCL_LEXEME_TOKEN, "a", "a");
@@ -117,7 +98,7 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_start_char)
   EXPECT_LEX(RCL_LEXEME_TOKEN, "_", "_");
 }
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_adjacent_ascii)
+TEST(TestLexer, test_token_adjacent_ascii)
 {
   // Check banned characters adjacent to allowed ones in ASCII
   EXPECT_LEX(RCL_LEXEME_NONE, "@", "@");
@@ -126,7 +107,7 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_adjacent_asci
   EXPECT_LEX(RCL_LEXEME_NONE, "{", "{");
 }
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_cannot_start_with_digits)
+TEST(TestLexer, test_token_cannot_start_with_digits)
 {
   // Tokens cannot start with digits
   EXPECT_LEX(RCL_LEXEME_NONE, "0", "0");
@@ -141,7 +122,7 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_cannot_start_
   EXPECT_LEX(RCL_LEXEME_NONE, "9", "9");
 }
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_underscores)
+TEST(TestLexer, test_token_underscores)
 {
   // Tokens may contain underscores
   EXPECT_LEX(RCL_LEXEME_TOKEN, "_abcd", "_abcd");
@@ -157,7 +138,7 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_underscores)
   EXPECT_LEX(RCL_LEXEME_NONE, "__A", "__A");
 }
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_contain_digits)
+TEST(TestLexer, test_token_contain_digits)
 {
   // Tokens may contain digits
   EXPECT_LEX(RCL_LEXEME_TOKEN, "_0_", "_0_");
@@ -182,7 +163,7 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_contain_digit
   EXPECT_LEX(RCL_LEXEME_TOKEN, "a9a", "a9a");
 }
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_end_with_digits)
+TEST(TestLexer, test_token_end_with_digits)
 {
   // Tokens may end with digits
   EXPECT_LEX(RCL_LEXEME_TOKEN, "_0", "_0");
@@ -207,7 +188,7 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_end_with_digi
   EXPECT_LEX(RCL_LEXEME_TOKEN, "a9", "a9");
 }
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_close_to_url_scheme)
+TEST(TestLexer, test_token_close_to_url_scheme)
 {
   // Things that almost look like a url scheme but are actually tokens
   EXPECT_LEX(RCL_LEXEME_TOKEN, "ro", "ro");
@@ -234,7 +215,7 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_close_to_url_
   EXPECT_LEX(RCL_LEXEME_TOKEN, "rostopic", "rostopic:/a");
 }
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_upper_case)
+TEST(TestLexer, test_token_upper_case)
 {
   // Tokens may contain uppercase characters
   EXPECT_LEX(RCL_LEXEME_TOKEN, "ABC", "ABC");
@@ -242,7 +223,7 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_token_upper_case)
   EXPECT_LEX(RCL_LEXEME_TOKEN, "_GHI_", "_GHI_");
 }
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_url_scheme)
+TEST(TestLexer, test_url_scheme)
 {
   // No text after scheme
   EXPECT_LEX(RCL_LEXEME_URL_SERVICE, "rosservice://", "rosservice://");
@@ -255,7 +236,7 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_url_scheme)
   EXPECT_LEX(RCL_LEXEME_URL_TOPIC, "rostopic://", "rostopic:///");
 }
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_backreferences)
+TEST(TestLexer, test_backreferences)
 {
   // No text after backreference
   EXPECT_LEX(RCL_LEXEME_BR1, "\\1", "\\1");
@@ -286,14 +267,14 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_backreferences)
   EXPECT_LEX(RCL_LEXEME_NONE, "\\_", "\\_");
 }
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_forward_slash)
+TEST(TestLexer, test_forward_slash)
 {
   EXPECT_LEX(RCL_LEXEME_FORWARD_SLASH, "/", "/");
   EXPECT_LEX(RCL_LEXEME_FORWARD_SLASH, "/", "//");
   EXPECT_LEX(RCL_LEXEME_FORWARD_SLASH, "/", "/_");
 }
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_wildcards)
+TEST(TestLexer, test_wildcards)
 {
   EXPECT_LEX(RCL_LEXEME_WILD_ONE, "*", "*");
   EXPECT_LEX(RCL_LEXEME_WILD_ONE, "*", "*/");
@@ -301,19 +282,19 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_wildcards)
   EXPECT_LEX(RCL_LEXEME_WILD_MULTI, "**", "**/");
 }
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_colon)
+TEST(TestLexer, test_colon)
 {
   EXPECT_LEX(RCL_LEXEME_COLON, ":", ":");
   EXPECT_LEX(RCL_LEXEME_COLON, ":", ":r");
 }
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_separator)
+TEST(TestLexer, test_separator)
 {
   EXPECT_LEX(RCL_LEXEME_SEPARATOR, ":=", ":=");
   EXPECT_LEX(RCL_LEXEME_SEPARATOR, ":=", ":=0");
 }
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_ns)
+TEST(TestLexer, test_ns)
 {
   // Has __ns
   EXPECT_LEX(RCL_LEXEME_NS, "__ns", "__ns");
@@ -325,7 +306,7 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_ns)
   EXPECT_LEX(RCL_LEXEME_NONE, "__n!", "__n!");
 }
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_name)
+TEST(TestLexer, test_name)
 {
   // Has __name
   EXPECT_LEX(RCL_LEXEME_NODE, "__name", "__name");
@@ -338,7 +319,7 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_name)
   EXPECT_LEX(RCL_LEXEME_NONE, "__nama", "__nama");
 }
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_node)
+TEST(TestLexer, test_node)
 {
   // Has __node
   EXPECT_LEX(RCL_LEXEME_NODE, "__node", "__node");
@@ -354,7 +335,7 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_node)
   EXPECT_LEX(RCL_LEXEME_NONE, "__noda", "__noda");
 }
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_tilde_slash)
+TEST(TestLexer, test_tilde_slash)
 {
   EXPECT_LEX(RCL_LEXEME_TILDE_SLASH, "~/", "~/");
   EXPECT_LEX(RCL_LEXEME_TILDE_SLASH, "~/", "~//");
@@ -362,7 +343,7 @@ TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_tilde_slash)
   EXPECT_LEX(RCL_LEXEME_NONE, "~!", "~!");
 }
 
-TEST_F(CLASSNAME(TestLexerFixture, RMW_IMPLEMENTATION), test_eof)
+TEST(TestLexer, test_eof)
 {
   EXPECT_LEX(RCL_LEXEME_EOF, "", "");
 }

--- a/rcl/test/rcl/test_lexer_lookahead.cpp
+++ b/rcl/test/rcl/test_lexer_lookahead.cpp
@@ -21,25 +21,6 @@
 #include "rcl/error_handling.h"
 #include "rcl/lexer_lookahead.h"
 
-#ifdef RMW_IMPLEMENTATION
-# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
-# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
-#else
-# define CLASSNAME(NAME, SUFFIX) NAME
-#endif
-
-class CLASSNAME (TestLexerLookaheadFixture, RMW_IMPLEMENTATION) : public ::testing::Test
-{
-public:
-  void SetUp()
-  {
-  }
-
-  void TearDown()
-  {
-  }
-};
-
 #define SCOPE_LOOKAHEAD2(name, text) \
   { \
     name = rcl_get_zero_initialized_lexer_lookahead2(); \
@@ -52,7 +33,7 @@ public:
       ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str; \
     })
 
-TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_init_fini_twice)
+TEST(TestLexerLookahead, test_init_fini_twice)
 {
   rcl_lexer_lookahead2_t buffer = rcl_get_zero_initialized_lexer_lookahead2();
   rcl_ret_t ret = rcl_lexer_lookahead2_init(&buffer, "foobar", rcl_get_default_allocator());
@@ -66,7 +47,7 @@ TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_init_fini_
   rcl_reset_error();
 }
 
-TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_init_not_zero_initialized)
+TEST(TestLexerLookahead, test_init_not_zero_initialized)
 {
   rcl_lexer_lookahead2_t buffer;
   int not_zero = 1;
@@ -76,7 +57,7 @@ TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_init_not_z
   rcl_reset_error();
 }
 
-TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_peek)
+TEST(TestLexerLookahead, test_peek)
 {
   rcl_ret_t ret;
   rcl_lexer_lookahead2_t buffer;
@@ -95,7 +76,7 @@ TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_peek)
   EXPECT_EQ(RCL_LEXEME_TOKEN, lexeme);
 }
 
-TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_peek2)
+TEST(TestLexerLookahead, test_peek2)
 {
   rcl_ret_t ret;
   rcl_lexer_lookahead2_t buffer;
@@ -118,7 +99,7 @@ TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_peek2)
   EXPECT_EQ(RCL_LEXEME_FORWARD_SLASH, lexeme2);
 }
 
-TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_peek2_no_lexeme)
+TEST(TestLexerLookahead, test_peek2_no_lexeme)
 {
   rcl_ret_t ret;
   rcl_lexer_lookahead2_t buffer;
@@ -133,7 +114,7 @@ TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_peek2_no_l
   EXPECT_EQ(RCL_LEXEME_NONE, lexeme2);
 }
 
-TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_peek2_no_lexeme_eof)
+TEST(TestLexerLookahead, test_peek2_no_lexeme_eof)
 {
   rcl_ret_t ret;
   rcl_lexer_lookahead2_t buffer;
@@ -148,7 +129,7 @@ TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_peek2_no_l
   EXPECT_EQ(RCL_LEXEME_NONE, lexeme2);
 }
 
-TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_peek2_eof)
+TEST(TestLexerLookahead, test_peek2_eof)
 {
   rcl_ret_t ret;
   rcl_lexer_lookahead2_t buffer;
@@ -163,7 +144,7 @@ TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_peek2_eof)
   EXPECT_EQ(RCL_LEXEME_EOF, lexeme2);
 }
 
-TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_eof)
+TEST(TestLexerLookahead, test_eof)
 {
   rcl_ret_t ret;
   rcl_lexer_lookahead2_t buffer;
@@ -194,7 +175,7 @@ TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_eof)
 }
 
 
-TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_accept)
+TEST(TestLexerLookahead, test_accept)
 {
   rcl_ret_t ret;
   rcl_lexer_lookahead2_t buffer;
@@ -240,7 +221,7 @@ TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_accept)
   EXPECT_EQ(RCL_LEXEME_EOF, lexeme);
 }
 
-TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_accept_bad_arg)
+TEST(TestLexerLookahead, test_accept_bad_arg)
 {
   rcl_lexer_lookahead2_t buffer;
   rcl_lexer_lookahead2_t buffer_not_ini = rcl_get_zero_initialized_lexer_lookahead2();
@@ -281,7 +262,7 @@ TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_accept_bad
   rcl_reset_error();
 }
 
-TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_expect)
+TEST(TestLexerLookahead, test_expect)
 {
   rcl_ret_t ret;
   rcl_lexer_lookahead2_t buffer;
@@ -311,7 +292,7 @@ TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_expect)
     EXPECT_STREQ(expected_text, std::string(lexeme_text, lexeme_text_length).c_str()); \
   } while (false)
 
-TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_lex_long_string)
+TEST(TestLexerLookahead, test_lex_long_string)
 {
   rcl_ret_t ret;
   rcl_lexer_lookahead2_t buffer;
@@ -332,7 +313,7 @@ TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_lex_long_s
   EXPECT_LOOKAHEAD(RCL_LEXEME_EOF, "", buffer);
 }
 
-TEST_F(CLASSNAME(TestLexerLookaheadFixture, RMW_IMPLEMENTATION), test_lex_remap_rules)
+TEST(TestLexerLookahead, test_lex_remap_rules)
 {
   rcl_ret_t ret;
   rcl_lexer_lookahead2_t buffer;

--- a/rcl/test/rcl/test_time.cpp
+++ b/rcl/test/rcl/test_time.cpp
@@ -26,19 +26,12 @@
 
 #include "./allocator_testing_utils.h"
 
-#ifdef RMW_IMPLEMENTATION
-# define CLASSNAME_(NAME, SUFFIX) NAME ## __ ## SUFFIX
-# define CLASSNAME(NAME, SUFFIX) CLASSNAME_(NAME, SUFFIX)
-#else
-# define CLASSNAME(NAME, SUFFIX) NAME
-#endif
-
 using osrf_testing_tools_cpp::memory_tools::on_unexpected_malloc;
 using osrf_testing_tools_cpp::memory_tools::on_unexpected_realloc;
 using osrf_testing_tools_cpp::memory_tools::on_unexpected_calloc;
 using osrf_testing_tools_cpp::memory_tools::on_unexpected_free;
 
-class CLASSNAME (TestTimeFixture, RMW_IMPLEMENTATION) : public ::testing::Test
+class TestTimeFixture : public ::testing::Test
 {
 public:
   void SetUp()
@@ -57,7 +50,7 @@ public:
 };
 
 // Tests the rcl_set_ros_time_override() function.
-TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_ros_time_set_override) {
+TEST_F(TestTimeFixture, test_rcl_ros_time_set_override) {
   osrf_testing_tools_cpp::memory_tools::enable_monitoring_in_all_threads();
   rcl_clock_t ros_clock;
   rcl_allocator_t allocator = rcl_get_default_allocator();
@@ -161,7 +154,7 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_ros_time_set_ove
   }
 }
 
-TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_init_for_clock_and_point) {
+TEST_F(TestTimeFixture, test_rcl_init_for_clock_and_point) {
   rcl_ret_t ret;
   rcl_allocator_t allocator = rcl_get_default_allocator();
   // Check for invalid argument error condition (allowed to alloc).
@@ -191,7 +184,7 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_rcl_init_for_clock_a
   });
 }
 
-TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_ros_clock_initially_zero) {
+TEST_F(TestTimeFixture, test_ros_clock_initially_zero) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_clock_t ros_clock;
   ASSERT_EQ(RCL_RET_OK, rcl_ros_clock_init(&ros_clock, &allocator)) << rcl_get_error_string().str;
@@ -205,7 +198,7 @@ TEST_F(CLASSNAME(TestTimeFixture, RMW_IMPLEMENTATION), test_ros_clock_initially_
   EXPECT_EQ(0, query_now);
 }
 
-TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), clock_validation) {
+TEST(rcl_time, clock_validation) {
   ASSERT_FALSE(rcl_clock_valid(NULL));
   rcl_clock_t uninitialized;
   // Not reliably detectable due to random values.
@@ -220,7 +213,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), clock_validation) {
   });
 }
 
-TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), default_clock_instanciation) {
+TEST(rcl_time, default_clock_instanciation) {
   rcl_clock_t ros_clock;
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_ret_t retval = rcl_ros_clock_init(&ros_clock, &allocator);
@@ -261,7 +254,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), default_clock_instanciation) {
   ASSERT_TRUE(rcl_clock_valid(system_clock));
 }
 
-TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), specific_clock_instantiation) {
+TEST(rcl_time, specific_clock_instantiation) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   {
     rcl_clock_t uninitialized_clock;
@@ -318,7 +311,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), specific_clock_instantiation) {
   }
 }
 
-TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_clock_time_started) {
+TEST(rcl_time, rcl_clock_time_started) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   {
     rcl_clock_t ros_clock;
@@ -353,7 +346,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_clock_time_started) {
   }
 }
 
-TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_difference) {
+TEST(rcl_time, rcl_time_difference) {
   rcl_ret_t ret;
   rcl_time_point_t a, b;
 
@@ -377,7 +370,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_difference) {
   rcl_reset_error();
 }
 
-TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_difference_signed) {
+TEST(rcl_time, rcl_time_difference_signed) {
   rcl_time_point_t a, b;
   a.nanoseconds = RCL_S_TO_NS(0LL) + 0LL;
   b.nanoseconds = RCL_S_TO_NS(10LL) + 0LL;
@@ -446,7 +439,7 @@ void reset_callback_triggers(void)
   post_callback_called = false;
 }
 
-TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_clock_change_callbacks) {
+TEST(rcl_time, rcl_time_clock_change_callbacks) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_clock_t ros_clock;
   rcl_ret_t ret = rcl_ros_clock_init(&ros_clock, &allocator);
@@ -506,7 +499,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_clock_change_callbacks) {
   reset_callback_triggers();
 }
 
-TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_fail_set_jump_callbacks) {
+TEST(rcl_time, rcl_time_fail_set_jump_callbacks) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_clock_t fail_clock;
   rcl_time_jump_t time_jump;
@@ -533,7 +526,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_fail_set_jump_callbacks) 
   rcl_reset_error();
 }
 
-TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_forward_jump_callbacks) {
+TEST(rcl_time, rcl_time_forward_jump_callbacks) {
   rcl_clock_t ros_clock;
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_ret_t ret = rcl_ros_clock_init(&ros_clock, &allocator);
@@ -597,7 +590,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_forward_jump_callbacks) {
   EXPECT_FALSE(post_callback_called);
 }
 
-TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_backward_jump_callbacks) {
+TEST(rcl_time, rcl_time_backward_jump_callbacks) {
   rcl_clock_t ros_clock;
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_ret_t ret = rcl_ros_clock_init(&ros_clock, &allocator);
@@ -660,7 +653,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_time_backward_jump_callbacks) 
   EXPECT_FALSE(post_callback_called);
 }
 
-TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_clock_add_jump_callback) {
+TEST(rcl_time, rcl_clock_add_jump_callback) {
   rcl_clock_t clock;
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_ret_t ret = rcl_ros_clock_init(&clock, &allocator);
@@ -694,7 +687,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_clock_add_jump_callback) {
   EXPECT_EQ(2u, clock.num_jump_callbacks);
 }
 
-TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_clock_remove_jump_callback) {
+TEST(rcl_time, rcl_clock_remove_jump_callback) {
   rcl_clock_t clock;
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_ret_t ret = rcl_ros_clock_init(&clock, &allocator);
@@ -739,7 +732,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), rcl_clock_remove_jump_callback) {
   EXPECT_EQ(0u, clock.num_jump_callbacks);
 }
 
-TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), add_remove_add_jump_callback) {
+TEST(rcl_time, add_remove_add_jump_callback) {
   rcl_allocator_t failing_allocator = get_failing_allocator();
   set_failing_allocator_is_failing(failing_allocator, false);
 
@@ -790,7 +783,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), add_remove_add_jump_callback) {
   EXPECT_EQ(1u, clock.num_jump_callbacks);
 }
 
-TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), failed_get_now) {
+TEST(rcl_time, failed_get_now) {
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_clock_t uninitialized_clock;
   rcl_time_point_value_t query_now;
@@ -802,7 +795,7 @@ TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), failed_get_now) {
   rcl_reset_error();
 }
 
-TEST(CLASSNAME(rcl_time, RMW_IMPLEMENTATION), fail_ros_time_override) {
+TEST(rcl_time, fail_ros_time_override) {
   bool result;
   rcl_time_point_value_t set_point = 1000000000ull;
 


### PR DESCRIPTION
The rcl APIs for arguments, time, and lexing never touch the RMW layer at all.  Therefore, there is no need to run the tests for them against all of the individual RMWs; we can get away with just running them once.  This should (slightly) speed up our compilations and tests.