### PR TITLE
Remove most remaining uses of ament_target_dependencies.

### DIFF
--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -57,8 +57,8 @@ function(test_target_function)
     SRCS rcl/test_client.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME}
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
+    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools ${test_msgs_TARGETS}
+    AMENT_DEPENDENCIES ${rmw_implementation}
   )
 
   rcl_add_custom_gtest(test_timer${target_suffix}
@@ -81,16 +81,16 @@ function(test_target_function)
     SRCS rcl/test_get_node_names.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME}
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp"
+    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
+    AMENT_DEPENDENCIES ${rmw_implementation}
   )
 
   rcl_add_custom_gtest(test_graph${target_suffix}
     SRCS rcl/test_graph.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME}
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
+    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools ${test_msgs_TARGETS}
+    AMENT_DEPENDENCIES ${rmw_implementation}
     TIMEOUT 120
   )
 
@@ -98,24 +98,24 @@ function(test_target_function)
     SRCS rcl/test_info_by_topic.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME} wait_for_entity_helpers
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
+    LIBRARIES ${PROJECT_NAME} wait_for_entity_helpers osrf_testing_tools_cpp::memory_tools ${test_msgs_TARGETS}
+    AMENT_DEPENDENCIES ${rmw_implementation}
   )
 
   rcl_add_custom_gtest(test_count_matched${target_suffix}
     SRCS rcl/test_count_matched.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME}
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
+    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools ${test_msgs_TARGETS}
+    AMENT_DEPENDENCIES ${rmw_implementation}
   )
 
   rcl_add_custom_gtest(test_get_actual_qos${target_suffix}
     SRCS rcl/test_get_actual_qos.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME}
-    AMENT_DEPENDENCIES ${rmw_implementation} "test_msgs" "osrf_testing_tools_cpp"
+    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools ${test_msgs_TARGETS}
+    AMENT_DEPENDENCIES ${rmw_implementation}
   )
 
   rcl_add_custom_gtest(test_init${target_suffix}
@@ -141,7 +141,7 @@ function(test_target_function)
     ENV ${rmw_implementation_env_var} ${memory_tools_ld_preload_env_var} ${gtest_filter_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME} mimick osrf_testing_tools_cpp::memory_tools
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp"
+    AMENT_DEPENDENCIES ${rmw_implementation}
     TIMEOUT 240  # Large timeout to wait for fault injection tests
   )
 
@@ -150,8 +150,7 @@ function(test_target_function)
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
-    LIBRARIES ${PROJECT_NAME}
-    AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
+    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
   )
 
   rcl_add_custom_gtest(test_remap_integration${target_suffix}
@@ -159,8 +158,7 @@ function(test_target_function)
     TIMEOUT 200
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME}
-    AMENT_DEPENDENCIES "osrf_testing_tools_cpp" "test_msgs"
+    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools ${test_msgs_TARGETS}
   )
 
   rcl_add_custom_gtest(test_guard_condition${target_suffix}
@@ -168,7 +166,7 @@ function(test_target_function)
     ENV ${rmw_implementation_env_var} ${memory_tools_ld_preload_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     LIBRARIES ${PROJECT_NAME} mimick osrf_testing_tools_cpp::memory_tools
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp"
+    AMENT_DEPENDENCIES ${rmw_implementation}
   )
 
   rcl_add_custom_gtest(test_publisher${target_suffix}
@@ -176,8 +174,8 @@ function(test_target_function)
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
-    LIBRARIES ${PROJECT_NAME} mimick
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
+    LIBRARIES ${PROJECT_NAME} mimick osrf_testing_tools_cpp::memory_tools ${test_msgs_TARGETS}
+    AMENT_DEPENDENCIES ${rmw_implementation}
   )
 
   rcl_add_custom_gtest(test_publisher_wait_all_ack${target_suffix}
@@ -185,31 +183,26 @@ function(test_target_function)
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
-    LIBRARIES ${PROJECT_NAME} mimick wait_for_entity_helpers
+    LIBRARIES ${PROJECT_NAME} mimick wait_for_entity_helpers osrf_testing_tools_cpp::memory_tools rcutils::rcutils
+      rosidl_runtime_c::rosidl_runtime_c ${test_msgs_TARGETS}
     AMENT_DEPENDENCIES ${rmw_implementation}
-      "osrf_testing_tools_cpp"
-      "rcutils"
-      "rosidl_runtime_c"
-      "test_msgs"
   )
 
   rcl_add_custom_gtest(test_service${target_suffix}
     SRCS rcl/test_service.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME} mimick wait_for_entity_helpers
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
+    LIBRARIES ${PROJECT_NAME} mimick wait_for_entity_helpers osrf_testing_tools_cpp::memory_tools ${test_msgs_TARGETS}
+    AMENT_DEPENDENCIES ${rmw_implementation}
   )
 
   rcl_add_custom_gtest(test_subscription${target_suffix}
     SRCS rcl/test_subscription.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME} mimick wait_for_entity_helpers
+    LIBRARIES ${PROJECT_NAME} mimick wait_for_entity_helpers osrf_testing_tools_cpp::memory_tools rosidl_runtime_cpp::rosidl_runtime_cpp
+      ${test_msgs_TARGETS}
     AMENT_DEPENDENCIES ${rmw_implementation}
-      "osrf_testing_tools_cpp"
-      "rosidl_runtime_cpp"
-      "test_msgs"
     TIMEOUT 120
   )
   # TODO(asorbini) Enable message timestamp tests for rmw_connextdds on Windows
@@ -239,32 +232,32 @@ function(test_target_function)
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
-    LIBRARIES ${PROJECT_NAME}
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
+    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools ${test_msgs_TARGETS}
+    AMENT_DEPENDENCIES ${rmw_implementation}
   )
 
   rcl_add_custom_gtest(test_wait${target_suffix}
     SRCS rcl/test_wait.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME} mimick
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp"
+    LIBRARIES ${PROJECT_NAME} mimick osrf_testing_tools_cpp::memory_tools
+    AMENT_DEPENDENCIES ${rmw_implementation}
   )
 
   rcl_add_custom_gtest(test_logging_rosout${target_suffix}
     SRCS rcl/test_logging_rosout.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME}
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "rcl_interfaces"
+    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools ${rcl_interfaces_TARGETS}
+    AMENT_DEPENDENCIES ${rmw_implementation}
   )
 
   rcl_add_custom_gtest(test_namespace${target_suffix}
     SRCS rcl/test_namespace.cpp
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-    LIBRARIES ${PROJECT_NAME}
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
+    LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools ${test_msgs_TARGETS}
+    AMENT_DEPENDENCIES ${rmw_implementation}
   )
 
   rcl_add_custom_gtest(test_rmw_impl_id_check_func${target_suffix}
@@ -280,8 +273,8 @@ function(test_target_function)
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
-    LIBRARIES ${PROJECT_NAME} mimick
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
+    LIBRARIES ${PROJECT_NAME} mimick osrf_testing_tools_cpp::memory_tools ${test_msgs_TARGETS}
+    AMENT_DEPENDENCIES ${rmw_implementation}
   )
 
   rcl_add_custom_gtest(test_service_event_publisher${target_suffix}
@@ -289,16 +282,15 @@ function(test_target_function)
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
-    LIBRARIES ${PROJECT_NAME} mimick wait_for_entity_helpers
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
+    LIBRARIES ${PROJECT_NAME} mimick wait_for_entity_helpers osrf_testing_tools_cpp::memory_tools ${test_msgs_TARGETS}
+    AMENT_DEPENDENCIES ${rmw_implementation}
   )
 
   rcl_add_custom_gtest(test_type_description_conversions${target_suffix}
     SRCS rcl/test_type_description_conversions.cpp
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
-    LIBRARIES ${PROJECT_NAME}
-    AMENT_DEPENDENCIES "test_msgs"
+    LIBRARIES ${PROJECT_NAME} ${test_msgs_TARGETS}
   )
 
   rcl_add_custom_gtest(test_node_type_cache${target_suffix}
@@ -306,8 +298,8 @@ function(test_target_function)
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
-    LIBRARIES ${PROJECT_NAME} mimick
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
+    LIBRARIES ${PROJECT_NAME} mimick osrf_testing_tools_cpp::memory_tools ${test_msgs_TARGETS}
+    AMENT_DEPENDENCIES ${rmw_implementation}
   )
 
   rcl_add_custom_gtest(test_get_type_description_service${target_suffix}
@@ -315,22 +307,20 @@ function(test_target_function)
     ENV ${rmw_implementation_env_var}
     APPEND_LIBRARY_DIRS ${extra_lib_dirs}
     INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
-    LIBRARIES ${PROJECT_NAME} mimick wait_for_entity_helpers
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "type_description_interfaces"
+    LIBRARIES ${PROJECT_NAME} mimick wait_for_entity_helpers osrf_testing_tools_cpp::memory_tools ${type_description_interfaces_TARGETS}
+    AMENT_DEPENDENCIES ${rmw_implementation}
   )
 
   # Launch tests
 
   rcl_add_custom_executable(service_fixture${target_suffix}
     SRCS rcl/service_fixture.cpp
-    LIBRARIES ${PROJECT_NAME} wait_for_entity_helpers
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
+    LIBRARIES ${PROJECT_NAME} wait_for_entity_helpers osrf_testing_tools_cpp::memory_tools ${test_msgs_TARGETS} rcutils::rcutils
   )
 
   rcl_add_custom_executable(client_fixture${target_suffix}
     SRCS rcl/client_fixture.cpp
-    LIBRARIES ${PROJECT_NAME} wait_for_entity_helpers
-    AMENT_DEPENDENCIES ${rmw_implementation} "osrf_testing_tools_cpp" "test_msgs"
+    LIBRARIES ${PROJECT_NAME} wait_for_entity_helpers osrf_testing_tools_cpp::memory_tools ${test_msgs_TARGETS}
   )
 
   rcl_add_custom_launch_test(test_services
@@ -392,7 +382,6 @@ rcl_add_custom_gtest(test_arguments
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
   INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/
   LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
-  AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
 )
 
 rcl_add_custom_gtest(test_time
@@ -411,8 +400,7 @@ rcl_add_custom_gtest(test_lexer
 rcl_add_custom_gtest(test_lexer_lookahead
   SRCS rcl/test_lexer_lookahead.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME}
-  AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
+  LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
 )
 
 rcl_add_custom_gtest(test_validate_enclave_name
@@ -424,8 +412,7 @@ rcl_add_custom_gtest(test_validate_enclave_name
 rcl_add_custom_gtest(test_discovery_options
   SRCS rcl/test_discovery_options.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME}
-  AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
+  LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools
 )
 
 rcl_add_custom_gtest(test_domain_id
@@ -444,8 +431,7 @@ rcl_add_custom_gtest(test_logging
   SRCS rcl/test_logging.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
   LIBRARIES ${PROJECT_NAME} mimick ${rcl_interfaces_TARGETS}
-    rcl_logging_interface::rcl_logging_interface ${RCL_LOGGING_IMPL}::${RCL_LOGGING_IMPL}
-  AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
+    rcl_logging_interface::rcl_logging_interface ${RCL_LOGGING_IMPL}::${RCL_LOGGING_IMPL} osrf_testing_tools_cpp::memory_tools
 )
 
 rcl_add_custom_gtest(test_validate_topic_name
@@ -463,8 +449,7 @@ rcl_add_custom_gtest(test_expand_topic_name
 rcl_add_custom_gtest(test_security
   SRCS rcl/test_security.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME} mimick
-  AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
+  LIBRARIES ${PROJECT_NAME} mimick osrf_testing_tools_cpp::memory_tools
 )
 
 rcl_add_custom_gtest(test_common
@@ -477,15 +462,13 @@ rcl_add_custom_gtest(test_common
 rcl_add_custom_gtest(test_log_level
   SRCS rcl/test_log_level.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME} mimick
-  AMENT_DEPENDENCIES "osrf_testing_tools_cpp"
+  LIBRARIES ${PROJECT_NAME} mimick osrf_testing_tools_cpp::memory_tools
 )
 
 rcl_add_custom_gtest(test_subscription_content_filter_options
   SRCS rcl/test_subscription_content_filter_options.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME}
-  AMENT_DEPENDENCIES "osrf_testing_tools_cpp" "test_msgs"
+  LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools ${test_msgs_TARGETS}
 )
 
 rcl_add_custom_gtest(test_type_hash

--- a/rcl/test/cmake/rcl_add_custom_executable.cmake
+++ b/rcl/test/cmake/rcl_add_custom_executable.cmake
@@ -21,7 +21,7 @@ macro(rcl_add_custom_executable target)
   cmake_parse_arguments(_ARG
     "TRACE"
     ""
-    "SRCS;INCLUDE_DIRS;LIBRARIES;AMENT_DEPENDENCIES"
+    "SRCS;INCLUDE_DIRS;LIBRARIES"
     ${ARGN})
   if(_ARG_UNPARSED_ARGUMENTS)
     message(FATAL_ERROR
@@ -47,13 +47,6 @@ macro(rcl_add_custom_executable target)
       message(STATUS "  rcl_add_custom_executable() LIBRARIES: ${_ARG_LIBRARIES}")
     endif()
     target_link_libraries(${target} ${_ARG_LIBRARIES})
-  endif()
-  # Add extra ament dependencies, if any.
-  if(_ARG_AMENT_DEPENDENCIES)
-    if(_ARG_TRACE)
-      message(STATUS "  rcl_add_custom_executable() AMENT_DEPENDENCIES: ${_ARG_AMENT_DEPENDENCIES}")
-    endif()
-    ament_target_dependencies(${target} ${_ARG_AMENT_DEPENDENCIES})
   endif()
   target_compile_definitions(${target}
     PUBLIC "RMW_IMPLEMENTATION=${rmw_implementation}")

--- a/rcl_action/CMakeLists.txt
+++ b/rcl_action/CMakeLists.txt
@@ -48,12 +48,15 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
-ament_target_dependencies(${PROJECT_NAME}
-  "action_msgs"
-  "rcl"
-  "rcutils"
-  "rmw"
-  "rosidl_runtime_c"
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${action_msgs_TARGETS}
+  rcl::rcl
+  rmw::rmw
+  rosidl_runtime_c::rosidl_runtime_c
+)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  rcutils::rcutils
 )
 
 rcl_set_symbol_visibility_hidden(${PROJECT_NAME} LANGUAGE "C")
@@ -90,11 +93,10 @@ if(BUILD_TESTING)
     )
     target_link_libraries(test_action_client
       ${PROJECT_NAME}
-    )
-    ament_target_dependencies(test_action_client
-      "osrf_testing_tools_cpp"
-      "rcl"
-      "test_msgs"
+      osrf_testing_tools_cpp::memory_tools
+      rcl::rcl
+      rcutils::rcutils
+      ${test_msgs_TARGETS}
     )
     target_compile_definitions(test_action_client PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
   endif()
@@ -121,11 +123,10 @@ if(BUILD_TESTING)
           PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
       target_link_libraries(${target}${target_suffix}
         ${PROJECT_NAME}
-      )
-      ament_target_dependencies(${target}${target_suffix}
-        "osrf_testing_tools_cpp"
-        "rcl"
-        "test_msgs"
+        osrf_testing_tools_cpp::memory_tools
+        rcl::rcl
+        rosidl_runtime_c::rosidl_runtime_c
+        ${test_msgs_TARGETS}
       )
     endif()
   endfunction()
@@ -152,11 +153,10 @@ if(BUILD_TESTING)
     )
     target_link_libraries(test_action_server
       ${PROJECT_NAME}
-    )
-    ament_target_dependencies(test_action_server
-      "osrf_testing_tools_cpp"
-      "rcl"
-      "test_msgs"
+      ${action_msgs_TARGETS}
+      osrf_testing_tools_cpp::memory_tools
+      rcl::rcl
+      ${test_msgs_TARGETS}
     )
     target_compile_definitions(test_action_server PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
   endif()
@@ -166,8 +166,8 @@ if(BUILD_TESTING)
   if(TARGET test_goal_handle)
     target_link_libraries(test_goal_handle
       ${PROJECT_NAME}
+      rcl::rcl
     )
-    ament_target_dependencies(test_goal_handle "rcl")
   endif()
   ament_add_gtest(test_goal_state_machine
     test/rcl_action/test_goal_state_machine.cpp
@@ -176,7 +176,6 @@ if(BUILD_TESTING)
     target_link_libraries(test_goal_state_machine
       ${PROJECT_NAME}
     )
-    ament_target_dependencies(test_goal_state_machine  "osrf_testing_tools_cpp" "rcl")
   endif()
   ament_add_gtest(test_types
     test/rcl_action/test_types.cpp
@@ -184,8 +183,8 @@ if(BUILD_TESTING)
   if(TARGET test_types)
     target_link_libraries(test_types
       ${PROJECT_NAME}
+      rcl::rcl
     )
-    ament_target_dependencies(test_types "rcl")
   endif()
   ament_add_gtest(test_names
     test/rcl_action/test_names.cpp
@@ -193,8 +192,8 @@ if(BUILD_TESTING)
   if(TARGET test_names)
     target_link_libraries(test_names
       ${PROJECT_NAME}
+      rcl::rcl
     )
-    ament_target_dependencies(test_names "rcl")
   endif()
   ament_add_gtest(test_wait
     test/rcl_action/test_wait.cpp
@@ -202,14 +201,12 @@ if(BUILD_TESTING)
   if(TARGET test_wait)
     target_link_libraries(test_wait
       ${PROJECT_NAME}
+      osrf_testing_tools_cpp::memory_tools
+      rcl::rcl
+      ${test_msgs_TARGETS}
     )
-    target_include_directories(test_wait PUBLIC
+    target_include_directories(test_wait PRIVATE
       src
-    )
-    ament_target_dependencies(test_wait
-      "osrf_testing_tools_cpp"
-      "rcl"
-      "test_msgs"
     )
   endif()
 endif()
@@ -221,11 +218,9 @@ ament_export_libraries(${PROJECT_NAME})
 # Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
 
-# specific order: dependents before dependencies
 ament_export_dependencies(action_msgs)
-ament_export_dependencies(ament_cmake)
 ament_export_dependencies(rcl)
-ament_export_dependencies(rcutils)
 ament_export_dependencies(rmw)
 ament_export_dependencies(rosidl_runtime_c)
+
 ament_package()

--- a/rcl_lifecycle/CMakeLists.txt
+++ b/rcl_lifecycle/CMakeLists.txt
@@ -48,13 +48,15 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
-# specific order: dependents before dependencies
-ament_target_dependencies(rcl_lifecycle
-  "lifecycle_msgs"
-  "rcl"
-  "rcutils"
-  "rosidl_runtime_c"
-  "tracetools"
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  ${lifecycle_msgs_TARGETS}
+  rcl::rcl
+)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE
+  rcutils::rcutils
+  rosidl_runtime_c::rosidl_runtime_c
+  tracetools::tracetools
 )
 
 rcl_set_symbol_visibility_hidden(${PROJECT_NAME} LANGUAGE "C")
@@ -74,7 +76,6 @@ install(TARGETS rcl_lifecycle EXPORT rcl_lifecycle
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_lint_auto REQUIRED)
-  find_package(rcl REQUIRED)
   find_package(osrf_testing_tools_cpp REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
@@ -83,11 +84,13 @@ if(BUILD_TESTING)
     test/test_default_state_machine.cpp
   )
   if(TARGET test_default_state_machine)
-    ament_target_dependencies(test_default_state_machine
-      "rcl"
-      "osrf_testing_tools_cpp"
+    target_link_libraries(test_default_state_machine
+      ${PROJECT_NAME}
+      ${lifecycle_msgs_TARGETS}
+      osrf_testing_tools_cpp::memory_tools
+      rcl::rcl
+      rcutils::rcutils
     )
-    target_link_libraries(test_default_state_machine ${PROJECT_NAME})
     target_compile_definitions(test_default_state_machine
       PUBLIC RCUTILS_ENABLE_FAULT_INJECTION
     )
@@ -96,21 +99,19 @@ if(BUILD_TESTING)
     test/test_multiple_instances.cpp
   )
   if(TARGET test_multiple_instances)
-    ament_target_dependencies(test_multiple_instances
-      "rcl"
-      "osrf_testing_tools_cpp"
-    )
-    target_link_libraries(test_multiple_instances ${PROJECT_NAME})
+    target_link_libraries(test_multiple_instances ${PROJECT_NAME} ${lifecycle_msgs_TARGETS} osrf_testing_tools_cpp::memory_tools rcl::rcl)
   endif()
   ament_add_gtest(test_rcl_lifecycle
     test/test_rcl_lifecycle.cpp
   )
   if(TARGET test_rcl_lifecycle)
-    ament_target_dependencies(test_rcl_lifecycle
-      "rcl"
-      "osrf_testing_tools_cpp"
+    target_link_libraries(test_rcl_lifecycle
+      ${PROJECT_NAME}
+      ${lifecycle_msgs_TARGETS}
+      osrf_testing_tools_cpp::memory_tools
+      rcl::rcl
+      rcutils::rcutils
     )
-    target_link_libraries(test_rcl_lifecycle ${PROJECT_NAME})
     target_compile_definitions(test_rcl_lifecycle
       PUBLIC RCUTILS_ENABLE_FAULT_INJECTION
     )
@@ -119,10 +120,7 @@ if(BUILD_TESTING)
     test/test_transition_map.cpp
   )
   if(TARGET test_transition_map)
-    ament_target_dependencies(test_transition_map
-      "rcl"
-    )
-    target_link_libraries(test_transition_map ${PROJECT_NAME})
+    target_link_libraries(test_transition_map ${PROJECT_NAME} rcl::rcl)
   endif()
 endif()
 
@@ -133,13 +131,9 @@ ament_export_libraries(${PROJECT_NAME})
 # Export modern CMake targets
 ament_export_targets(${PROJECT_NAME})
 
-# specific order: dependents before dependencies
-ament_export_dependencies(ament_cmake)
 ament_export_dependencies(lifecycle_msgs)
 ament_export_dependencies(rcl)
-ament_export_dependencies(rcutils)
-ament_export_dependencies(rosidl_runtime_c)
-ament_export_dependencies(tracetools)
+
 ament_package()
 
 install(


### PR DESCRIPTION
Instead, switch to using target_link_libraries everywhere we can.  We can't do it for the rmw_implementation substitution, since the libraries aren't always called the same thing as the rmw_implementation.