### PR TITLE
Added `rcl_publisher_get_non_local_subscription_count`

### DIFF
--- a/rcl/include/rcl/publisher.h
+++ b/rcl/include/rcl/publisher.h
@@ -654,6 +654,33 @@ rcl_publisher_get_subscription_count(
   const rcl_publisher_t * publisher,
   size_t * subscription_count);
 
+/// Get the number of non local subscriptions matched to a publisher.
+/**
+ * Used to get the internal count of non local subscriptions matched to a publisher.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | Yes
+ * Uses Atomics       | Maybe [1]
+ * Lock-Free          | Maybe [1]
+ * <i>[1] only if the underlying rmw doesn't make use of this feature </i>
+ *
+ * \param[in] publisher pointer to the rcl publisher
+ * \param[out] non_local_subscription_count number of non local matched subscriptions
+ * \return #RCL_RET_OK if the count was retrieved, or
+ * \return #RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or
+ * \return #RCL_RET_PUBLISHER_INVALID if the publisher is invalid, or
+ * \return #RCL_RET_ERROR if an unspecified error occurs.
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_publisher_get_non_local_subscription_count(
+  const rcl_publisher_t * publisher,
+  size_t * non_local_subscription_count);
+
 /// Get the actual qos settings of the publisher.
 /**
  * Used to get the actual qos settings of the publisher.

--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -460,6 +460,26 @@ rcl_publisher_get_subscription_count(
   return RCL_RET_OK;
 }
 
+rcl_ret_t
+rcl_publisher_get_non_local_subscription_count(
+  const rcl_publisher_t * publisher,
+  size_t * non_local_subscription_count)
+{
+  if (!rcl_publisher_is_valid(publisher)) {
+    return RCL_RET_PUBLISHER_INVALID;
+  }
+  RCL_CHECK_ARGUMENT_FOR_NULL(non_local_subscription_count, RCL_RET_INVALID_ARGUMENT);
+
+  rmw_ret_t ret = rmw_publisher_count_non_local_matched_subscriptions(
+    publisher->impl->rmw_handle, non_local_subscription_count);
+
+  if (ret != RMW_RET_OK) {
+    RCL_SET_ERROR_MSG(rmw_get_error_string().str);
+    return rcl_convert_rmw_ret_to_rcl_ret(ret);
+  }
+  return RCL_RET_OK;
+}
+
 const rmw_qos_profile_t *
 rcl_publisher_get_actual_qos(const rcl_publisher_t * publisher)
 {


### PR DESCRIPTION
Adds function that returns the number of matched subscriptions that are not in the same context as the publisher.

Depends on https://github.com/ros2/rmw/pull/358

Part of https://github.com/ros2/rclcpp/issues/2202

full repos file [here](https://gist.github.com/MiguelCompany/c92eb293f97ad82ced4aa1f4b0c60d5e/raw/fe4f53f423377908cf2cebfd7bc666c3d67a356f/count_non_local_subscriptions_rolling.repos)