### PR TITLE
Return service from node_type_description_service_init

### DIFF
--- a/rcl/include/rcl/node.h
+++ b/rcl/include/rcl/node.h
@@ -562,10 +562,8 @@ rcl_get_disable_loaned_message(bool * disable_loaned_message);
  * must register rcl_node_type_description_service_handle_request or a custom callback
  * to handle incoming requests, via that client's executor/waitset capabilities.
  *
- * Note that the underlying service must be cleaned up by the caller by calling
- * rcl_node_get_type_description_service and rcl_service_fini.
- *
- * This will initialize the node's type cache, if it has not been initialized already.
+ * Note that the returned service must be cleaned up by the caller by calling
+ * rcl_service_fini.
  *
  * <hr>
  * Attribute          | Adherence
@@ -584,62 +582,8 @@ rcl_get_disable_loaned_message(bool * disable_loaned_message);
  */
 RCL_PUBLIC
 RCL_WARN_UNUSED
-rcl_ret_t rcl_node_type_description_service_init(rcl_node_t * node);
-
-/// Finalizes the node's ~/get_type_description service.
-/**
- * This function finalizes the node's private ~/get_type_description service.
- *
- * <hr>
- * Attribute          | Adherence
- * ------------------ | -------------
- * Allocates Memory   | No
- * Thread-Safe        | No
- * Uses Atomics       | No
- * Lock-Free          | Yes
- *
- * \param[in] node the handle to the node whose type cache should be initialized
- * \return #RCL_RET_OK if service was deinitialized successfully, or
- * \return #RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or
- * \return #RCL_RET_SERVICE_INVALID if the service is invalid, or
- * \return #RCL_RET_NODE_INVALID if the node is invalid, or
- * \return #RCL_RET_ERROR if an unspecified error occurs.
- */
-RCL_PUBLIC
-RCL_WARN_UNUSED
-rcl_ret_t rcl_node_type_description_service_fini(rcl_node_t * node);
-
-
-/// Returns a pointer to the node's ~/get_type_description service.
-/**
- * On success, sets service_out to the initialized service.
- * rcl_node_type_description_service_init must be called before this.
- *
- * Note the caller of this function is responsible for calling 
- * rcl_service_fini on the returned service.
- *
- * <hr>
- * Attribute          | Adherence
- * ------------------ | -------------
- * Allocates Memory   | No
- * Thread-Safe        | No
- * Uses Atomics       | No
- * Lock-Free          | Yes
- *
- * \param[in] node the handle to the node
- * \param[out] service_out Handle to pointer that will be set
- * \return #RCL_RET_OK if valid service was returned successfully, or
- * \return #RCL_RET_NODE_INVALID if node is invalid, or
- * \return #RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or
- * \return #RCL_RET_NOT_INIT if the service hasn't yet been initialized, or
- * \return #RCL_RET_ERROR if an unspecified error occurs.
- */
-RCL_PUBLIC
-RCL_WARN_UNUSED
-rcl_ret_t rcl_node_get_type_description_service(
-  const rcl_node_t * node,
-  rcl_service_t ** service_out);
-
+rcl_ret_t rcl_node_type_description_service_init(rcl_service_t * service,
+                                                 const rcl_node_t * node);
 
 /// Process a single pending request to the GetTypeDescription service.
 /**

--- a/rcl/include/rcl/node.h
+++ b/rcl/include/rcl/node.h
@@ -562,6 +562,9 @@ rcl_get_disable_loaned_message(bool * disable_loaned_message);
  * must register rcl_node_type_description_service_handle_request or a custom callback
  * to handle incoming requests, via that client's executor/waitset capabilities.
  *
+ * Note that the underlying service must be cleaned up by the caller by calling
+ * rcl_node_get_type_description_service and rcl_service_fini.
+ *
  * This will initialize the node's type cache, if it has not been initialized already.
  *
  * <hr>
@@ -611,6 +614,9 @@ rcl_ret_t rcl_node_type_description_service_fini(rcl_node_t * node);
 /**
  * On success, sets service_out to the initialized service.
  * rcl_node_type_description_service_init must be called before this.
+ *
+ * Note the caller of this function is responsible for calling 
+ * rcl_service_fini on the returned service.
  *
  * <hr>
  * Attribute          | Adherence

--- a/rcl/include/rcl/node.h
+++ b/rcl/include/rcl/node.h
@@ -573,6 +573,7 @@ rcl_get_disable_loaned_message(bool * disable_loaned_message);
  * Uses Atomics       | No
  * Lock-Free          | Yes
  *
+ * \param[in] service the handle to the type description service to be initialized
  * \param[in] node handle to the node for which to initialize the service
  * \return #RCL_RET_OK if the service was successfully initialized, or
  * \return #RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or

--- a/rcl/include/rcl/node.h
+++ b/rcl/include/rcl/node.h
@@ -582,8 +582,9 @@ rcl_get_disable_loaned_message(bool * disable_loaned_message);
  */
 RCL_PUBLIC
 RCL_WARN_UNUSED
-rcl_ret_t rcl_node_type_description_service_init(rcl_service_t * service,
-                                                 const rcl_node_t * node);
+rcl_ret_t rcl_node_type_description_service_init(
+  rcl_service_t * service,
+  const rcl_node_t * node);
 
 /// Process a single pending request to the GetTypeDescription service.
 /**

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -628,13 +628,7 @@ rcl_ret_t rcl_node_type_description_service_fini(rcl_node_t * node)
     return RCL_RET_NOT_INIT;
   }
 
-  const rcl_ret_t ret =
-    rcl_service_fini(&node->impl->get_type_description_service, node);
-  if (RCL_RET_OK == ret) {
-    node->impl->get_type_description_service = rcl_get_zero_initialized_service();
-  }
-
-  return ret;
+  return RCL_RET_OK;
 }
 
 rcl_ret_t rcl_node_get_type_description_service(

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -579,8 +579,9 @@ void rcl_node_type_description_service_handle_request(
   response->successful = true;
 }
 
-rcl_ret_t rcl_node_type_description_service_init(rcl_service_t * service,
-                                                 const rcl_node_t * node)
+rcl_ret_t rcl_node_type_description_service_init(
+  rcl_service_t * service,
+  const rcl_node_t * node)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(service, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_INVALID_ARGUMENT);

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -194,7 +194,6 @@ rcl_node_init(
     node->impl, "allocating memory failed", ret = RCL_RET_BAD_ALLOC; goto fail);
   node->impl->options = rcl_node_get_default_options();
   node->impl->registered_types_by_type_hash = rcutils_get_zero_initialized_hash_map();
-  node->impl->get_type_description_service = rcl_get_zero_initialized_service();
   node->context = context;
   // Initialize node impl.
   ret = rcl_node_options_copy(options, &(node->impl->options));
@@ -580,14 +579,14 @@ void rcl_node_type_description_service_handle_request(
   response->successful = true;
 }
 
-rcl_ret_t rcl_node_type_description_service_init(rcl_node_t * node)
+rcl_ret_t rcl_node_type_description_service_init(rcl_service_t * service,
+                                                 const rcl_node_t * node)
 {
+  RCL_CHECK_ARGUMENT_FOR_NULL(service, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(node->impl, RCL_RET_NODE_INVALID);
 
-  rcl_ret_t ret;
-
-  if (rcl_service_is_valid(&node->impl->get_type_description_service)) {
+  if (rcl_service_is_valid(service)) {
     return RCL_RET_ALREADY_INIT;
   }
   rcl_reset_error();  // Reset the error message set by rcl_service_is_valid()
@@ -601,7 +600,7 @@ rcl_ret_t rcl_node_type_description_service_init(rcl_node_t * node)
   rcl_allocator_t allocator = node->context->impl->allocator;
 
   // Construct service name
-  ret = rcl_node_resolve_name(
+  rcl_ret_t ret = rcl_node_resolve_name(
     node, "~/get_type_description",
     allocator, true, true, &service_name);
   if (RCL_RET_OK != ret) {
@@ -612,37 +611,9 @@ rcl_ret_t rcl_node_type_description_service_init(rcl_node_t * node)
 
   // Initialize service
   ret = rcl_service_init(
-    &node->impl->get_type_description_service, node,
+    service, node,
     type_support, service_name, &service_ops);
   allocator.deallocate(service_name, allocator.state);
 
   return ret;
-}
-
-rcl_ret_t rcl_node_type_description_service_fini(rcl_node_t * node)
-{
-  RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_INVALID_ARGUMENT);
-  RCL_CHECK_ARGUMENT_FOR_NULL(node->impl, RCL_RET_NODE_INVALID);
-  if (!rcl_service_is_valid(&node->impl->get_type_description_service)) {
-    rcl_reset_error();
-    return RCL_RET_NOT_INIT;
-  }
-
-  return RCL_RET_OK;
-}
-
-rcl_ret_t rcl_node_get_type_description_service(
-  const rcl_node_t * node,
-  rcl_service_t ** service_out)
-{
-  RCL_CHECK_ARGUMENT_FOR_NULL(node, RCL_RET_INVALID_ARGUMENT);
-  RCL_CHECK_ARGUMENT_FOR_NULL(node->impl, RCL_RET_NODE_INVALID);
-  RCL_CHECK_ARGUMENT_FOR_NULL(service_out, RCL_RET_SERVICE_INVALID);
-
-  if (!rcl_service_is_valid(&node->impl->get_type_description_service)) {
-    return RCL_RET_NOT_INIT;
-  }
-
-  *service_out = &node->impl->get_type_description_service;
-  return RCL_RET_OK;
 }

--- a/rcl/src/rcl/node_impl.h
+++ b/rcl/src/rcl/node_impl.h
@@ -31,7 +31,6 @@ struct rcl_node_impl_s
   const char * logger_name;
   const char * fq_name;
   rcutils_hash_map_t registered_types_by_type_hash;
-  rcl_service_t get_type_description_service;
 };
 
 #endif  // RCL__NODE_IMPL_H_

--- a/rcl/test/rcl/test_get_type_description_service.cpp
+++ b/rcl/test/rcl/test_get_type_description_service.cpp
@@ -201,18 +201,22 @@ TEST_F(
       this->node_ptr, this->get_type_description_service_name,
       GET_TYPE_DESCRIPTION_SRV_TYPE_NAME, std::chrono::seconds(5)));
 
+  // Once the type descrition service is init, then it appear in the graph
   EXPECT_EQ(RCL_RET_OK, rcl_node_type_description_service_init(&service, this->node_ptr));
   EXPECT_TRUE(
     service_exists(
       this->node_ptr, this->get_type_description_service_name,
       GET_TYPE_DESCRIPTION_SRV_TYPE_NAME, std::chrono::seconds(5)));
 
+  // Once the type description service is fini, then it no longer appears in the graph
   EXPECT_EQ(RCL_RET_OK, rcl_service_fini(&service, this->node_ptr));
   EXPECT_TRUE(
     service_not_exists(
       this->node_ptr, this->get_type_description_service_name,
       GET_TYPE_DESCRIPTION_SRV_TYPE_NAME, std::chrono::seconds(5)));
-  EXPECT_EQ(RCL_RET_NOT_INIT, rcl_service_fini(&service, this->node_ptr));
+
+  // Repeatedly destroying the service should not cause faults.
+  EXPECT_EQ(RCL_RET_OK, rcl_service_fini(&service, this->node_ptr));
 }
 
 /* Basic nominal test of the ~/get_type_description service. */


### PR DESCRIPTION
This changes the mechanism of `rcl_node_type_description_service_init` to populate a user-provided service.

This makes it the calling user's responsibility to call `rcl_service_fini` on the returned service, making it more in line with the rest of the `rcl` API.

This was discovered when working with the new `rclcpp::WaitSet` implementation.  

The main issue is that the executor needs to share ownership with objects that it is `wait`-ing on for the entire duration of the `wait`, even if a node is removed from the executor at that time.  That is, the executor doesn't have knowledge of the nodes so much as the waitable objects in the collection.  

In this current implementation, the type_description was being `fini`-ed during the `NodeTypeDescriptions` destructor here: https://github.com/ros2/rclcpp/blob/fcbe64cff4bea3109531254ceb2955dc4b1bb320/rclcpp/src/rclcpp/node_interfaces/node_type_descriptions.cpp#L128-L139.  This could cause a situation where a service is cleaned up while we are still waiting on it, and yields a segfault afterwards.

After discussion with @clalancette, it seems the better approach is to have the user init the service and then be responsible for managing the lifetime of that service through their client library (eg `rclcpp::Service`)