### PR TITLE
Change the starting time of the goal expiration timeout

### DIFF
--- a/rcl/include/rcl/types.h
+++ b/rcl/include/rcl/types.h
@@ -128,7 +128,7 @@ typedef rmw_ret_t rcl_ret_t;
 
 // rcl action specific ret codes in 40XX
 /// No terminal timestamp for the goal as it has not reached a terminal state.
-#define RCL_RET_NOT_TERMINATED_YET 4001
+#define RCL_ACTION_RET_NOT_TERMINATED_YET 4001
 
 /// typedef for rmw_serialized_message_t;
 typedef rmw_serialized_message_t rcl_serialized_message_t;

--- a/rcl/include/rcl/types.h
+++ b/rcl/include/rcl/types.h
@@ -126,6 +126,10 @@ typedef rmw_ret_t rcl_ret_t;
 /// rcl_lifecycle state not registered
 #define RCL_RET_LIFECYCLE_STATE_NOT_REGISTERED 3001
 
+// rcl action specific ret codes in 40XX
+/// No terminal timestamp for the goal as it has not reached a terminal state.
+#define RCL_RET_NOT_TERMINATED_YET 4001
+
 /// typedef for rmw_serialized_message_t;
 typedef rmw_serialized_message_t rcl_serialized_message_t;
 

--- a/rcl_action/include/rcl_action/goal_handle.h
+++ b/rcl_action/include/rcl_action/goal_handle.h
@@ -24,6 +24,7 @@ extern "C"
 #include "rcl_action/types.h"
 #include "rcl_action/visibility_control.h"
 #include "rcl/allocator.h"
+#include "rcl/time.h"
 
 
 /// Internal rcl action goal implementation struct.
@@ -190,6 +191,56 @@ rcl_action_goal_handle_get_status(
   const rcl_action_goal_handle_t * goal_handle,
   rcl_action_goal_state_t * status);
 
+/// Get the goal terminal timestamp.
+/**
+ * This is a non-blocking call.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | No
+ *
+ * \param[in] goal_handle struct containing the goal and metadata
+ * \param[out] timestamp a preallocated struct where goal terminal timestamp is copied
+ * \return `RCL_RET_OK` if the goal ID was accessed successfully, or
+ * \return `RCL_RET_ACTION_GOAL_HANDLE_INVALID` if the goal handle is invalid, or
+ * \return `RCL_RET_INVALID_ARGUMENT` if the timestamp argument is invalid
+ */
+RCL_ACTION_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_action_goal_handle_get_goal_terminal_timestamp(
+  const rcl_action_goal_handle_t * goal_handle,
+  rcl_time_point_value_t * timestamp);
+
+/// Set the goal terminal timestamp.
+/**
+ * This is a non-blocking call.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | No
+ *
+ * \param[in] goal_handle struct containing the goal and metadata
+ * \param[in] timestamp The timestamp of goal termination
+ * \return `RCL_RET_OK` if the goal ID was accessed successfully, or
+ * \return `RCL_RET_ACTION_GOAL_HANDLE_INVALID` if the goal handle is invalid, or
+ * \return `RCL_RET_INVALID_ARGUMENT` if the timestamp argument is invalid
+ */
+RCL_ACTION_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_action_goal_handle_set_goal_terminal_timestamp(
+  const rcl_action_goal_handle_t * goal_handle,
+  rcl_time_point_value_t timestamp);
+
 /// Check if a goal is active using a rcl_action_goal_handle_t.
 /**
  * This is a non-blocking call.
@@ -200,7 +251,7 @@ rcl_action_goal_handle_get_status(
  * Allocates Memory   | No
  * Thread-Safe        | No
  * Uses Atomics       | No
- * Lock-Free          | Yes
+ * Lock-Free          | No
  *
  * \param[in] goal_handle struct containing the goal and metadata
  * \return `true` if the goal is in one of the following states: ACCEPTED, EXECUTING, or CANCELING, or
@@ -222,7 +273,7 @@ rcl_action_goal_handle_is_active(const rcl_action_goal_handle_t * goal_handle);
  * Allocates Memory   | No
  * Thread-Safe        | No
  * Uses Atomics       | No
- * Lock-Free          | Yes
+ * Lock-Free          | No
  *
  * \param[in] goal_handle struct containing the goal and metadata
  * \return `true` if the goal can be transitioned to CANCELING from its current state, or

--- a/rcl_action/include/rcl_action/goal_handle.h
+++ b/rcl_action/include/rcl_action/goal_handle.h
@@ -201,7 +201,7 @@ rcl_action_goal_handle_get_status(
  * Allocates Memory   | No
  * Thread-Safe        | No
  * Uses Atomics       | No
- * Lock-Free          | No
+ * Lock-Free          | Yes
  *
  * \param[in] goal_handle struct containing the goal and metadata
  * \param[out] timestamp a preallocated struct where goal terminal timestamp is copied
@@ -226,7 +226,7 @@ rcl_action_goal_handle_get_goal_terminal_timestamp(
  * Allocates Memory   | No
  * Thread-Safe        | No
  * Uses Atomics       | No
- * Lock-Free          | No
+ * Lock-Free          | Yes
  *
  * \param[in] goal_handle struct containing the goal and metadata
  * \param[in] timestamp The timestamp of goal termination
@@ -251,7 +251,7 @@ rcl_action_goal_handle_set_goal_terminal_timestamp(
  * Allocates Memory   | No
  * Thread-Safe        | No
  * Uses Atomics       | No
- * Lock-Free          | No
+ * Lock-Free          | Yes
  *
  * \param[in] goal_handle struct containing the goal and metadata
  * \return `true` if the goal is in one of the following states: ACCEPTED, EXECUTING, or CANCELING, or
@@ -273,7 +273,7 @@ rcl_action_goal_handle_is_active(const rcl_action_goal_handle_t * goal_handle);
  * Allocates Memory   | No
  * Thread-Safe        | No
  * Uses Atomics       | No
- * Lock-Free          | No
+ * Lock-Free          | Yes
  *
  * \param[in] goal_handle struct containing the goal and metadata
  * \return `true` if the goal can be transitioned to CANCELING from its current state, or

--- a/rcl_action/include/rcl_action/goal_handle.h
+++ b/rcl_action/include/rcl_action/goal_handle.h
@@ -38,7 +38,7 @@ typedef struct rcl_action_goal_handle_s
 } rcl_action_goal_handle_t;
 
 /// Define invaild value for goal terminal timestamp
-#define INVAILD_GOAL_TERMINAL_TIMESTAMP 0
+#define INVAILD_GOAL_TERMINAL_TIMESTAMP -1
 
 /// Return a rcl_action_goal_handle_t struct with members set to `NULL`.
 /**
@@ -208,7 +208,7 @@ rcl_action_goal_handle_get_status(
  *
  * \param[in] goal_handle struct containing the goal and metadata
  * \param[out] timestamp a preallocated struct where goal terminal timestamp is copied.
-     Return `INVAILD_GOAL_TERMINAL_TIMESTAMP` if goal terminal timestamp isn't set.
+     Return `INVAILD_GOAL_TERMINAL_TIMESTAMP` if the goal has not reached terminal state.
  * \return `RCL_RET_OK` if the goal ID was accessed successfully, or
  * \return `RCL_RET_ACTION_GOAL_HANDLE_INVALID` if the goal handle is invalid, or
  * \return `RCL_RET_INVALID_ARGUMENT` if the timestamp argument is invalid
@@ -219,31 +219,6 @@ rcl_ret_t
 rcl_action_goal_handle_get_goal_terminal_timestamp(
   const rcl_action_goal_handle_t * goal_handle,
   rcl_time_point_value_t * timestamp);
-
-/// Set the goal terminal timestamp.
-/**
- * This is a non-blocking call.
- *
- * <hr>
- * Attribute          | Adherence
- * ------------------ | -------------
- * Allocates Memory   | No
- * Thread-Safe        | No
- * Uses Atomics       | No
- * Lock-Free          | Yes
- *
- * \param[in] goal_handle struct containing the goal and metadata
- * \param[in] timestamp The timestamp of goal termination
- * \return `RCL_RET_OK` if the goal ID was accessed successfully, or
- * \return `RCL_RET_ACTION_GOAL_HANDLE_INVALID` if the goal handle is invalid, or
- * \return `RCL_RET_INVALID_ARGUMENT` if the timestamp argument is invalid
- */
-RCL_ACTION_LOCAL
-RCL_WARN_UNUSED
-rcl_ret_t
-rcl_action_goal_handle_set_goal_terminal_timestamp(
-  const rcl_action_goal_handle_t * goal_handle,
-  rcl_time_point_value_t timestamp);
 
 /// Check if a goal is active using a rcl_action_goal_handle_t.
 /**

--- a/rcl_action/include/rcl_action/goal_handle.h
+++ b/rcl_action/include/rcl_action/goal_handle.h
@@ -208,10 +208,10 @@ rcl_action_goal_handle_get_status(
  *
  * \param[in] goal_handle struct containing the goal and metadata
  * \param[out] timestamp a preallocated struct where goal terminal timestamp is copied.
-     Return `INVAILD_GOAL_TERMINAL_TIMESTAMP` if the goal has not reached terminal state.
  * \return `RCL_RET_OK` if the goal ID was accessed successfully, or
  * \return `RCL_RET_ACTION_GOAL_HANDLE_INVALID` if the goal handle is invalid, or
- * \return `RCL_RET_INVALID_ARGUMENT` if the timestamp argument is invalid
+ * \return `RCL_RET_INVALID_ARGUMENT` if the timestamp argument is invalid or
+ * \return `RCL_RET_NOT_TERMINATED_YET` if the goal has not reached terminal state
  */
 RCL_ACTION_PUBLIC
 RCL_WARN_UNUSED

--- a/rcl_action/include/rcl_action/goal_handle.h
+++ b/rcl_action/include/rcl_action/goal_handle.h
@@ -37,6 +37,9 @@ typedef struct rcl_action_goal_handle_s
   rcl_action_goal_handle_impl_t * impl;
 } rcl_action_goal_handle_t;
 
+/// Define invaild value for goal terminal timestamp
+#define INVAILD_GOAL_TERMINAL_TIMESTAMP 0
+
 /// Return a rcl_action_goal_handle_t struct with members set to `NULL`.
 /**
  * Should be called to get a null rcl_action_goal_handle_t before passing to
@@ -204,7 +207,8 @@ rcl_action_goal_handle_get_status(
  * Lock-Free          | Yes
  *
  * \param[in] goal_handle struct containing the goal and metadata
- * \param[out] timestamp a preallocated struct where goal terminal timestamp is copied
+ * \param[out] timestamp a preallocated struct where goal terminal timestamp is copied.
+     Return `INVAILD_GOAL_TERMINAL_TIMESTAMP` if goal terminal timestamp isn't set.
  * \return `RCL_RET_OK` if the goal ID was accessed successfully, or
  * \return `RCL_RET_ACTION_GOAL_HANDLE_INVALID` if the goal handle is invalid, or
  * \return `RCL_RET_INVALID_ARGUMENT` if the timestamp argument is invalid
@@ -234,7 +238,7 @@ rcl_action_goal_handle_get_goal_terminal_timestamp(
  * \return `RCL_RET_ACTION_GOAL_HANDLE_INVALID` if the goal handle is invalid, or
  * \return `RCL_RET_INVALID_ARGUMENT` if the timestamp argument is invalid
  */
-RCL_ACTION_PUBLIC
+RCL_ACTION_LOCAL
 RCL_WARN_UNUSED
 rcl_ret_t
 rcl_action_goal_handle_set_goal_terminal_timestamp(

--- a/rcl_action/include/rcl_action/goal_handle.h
+++ b/rcl_action/include/rcl_action/goal_handle.h
@@ -211,7 +211,7 @@ rcl_action_goal_handle_get_status(
  * \return `RCL_RET_OK` if the goal ID was accessed successfully, or
  * \return `RCL_RET_ACTION_GOAL_HANDLE_INVALID` if the goal handle is invalid, or
  * \return `RCL_RET_INVALID_ARGUMENT` if the timestamp argument is invalid or
- * \return `RCL_RET_NOT_TERMINATED_YET` if the goal has not reached terminal state
+ * \return `RCL_ACTION_RET_NOT_TERMINATED_YET` if the goal has not reached terminal state
  */
 RCL_ACTION_PUBLIC
 RCL_WARN_UNUSED

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -631,6 +631,7 @@ rcl_action_expire_goals(
   rcl_ret_t ret_final = RCL_RET_OK;
   const int64_t timeout = (int64_t)action_server->impl->options.result_timeout.nanoseconds;
   rcl_action_goal_handle_t * goal_handle;
+  rcl_action_goal_info_t goal_info;
   rcl_time_point_value_t goal_terminal_timestamp;
   size_t num_goal_handles = action_server->impl->num_goal_handles;
   for (size_t i = 0u; i < num_goal_handles; ++i) {
@@ -639,6 +640,19 @@ rcl_action_expire_goals(
       break;
     }
     goal_handle = action_server->impl->goal_handles[i];
+    // Expiration only applys to terminated goals
+    if (rcl_action_goal_handle_is_active(goal_handle)) {
+      continue;
+    }
+    rcl_action_goal_info_t * info_ptr = &goal_info;
+    if (output_expired) {
+      info_ptr = &(expired_goals[num_goals_expired]);
+    }
+    ret = rcl_action_goal_handle_get_info(goal_handle, info_ptr);
+    if (RCL_RET_OK != ret) {
+      ret_final = RCL_RET_ERROR;
+      continue;
+    }
 
     ret = rcl_action_goal_handle_get_goal_terminal_timestamp(goal_handle, &goal_terminal_timestamp);
     if (RCL_RET_NOT_TERMINATED_YET == ret) {

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -631,7 +631,6 @@ rcl_action_expire_goals(
   rcl_ret_t ret_final = RCL_RET_OK;
   const int64_t timeout = (int64_t)action_server->impl->options.result_timeout.nanoseconds;
   rcl_action_goal_handle_t * goal_handle;
-  rcl_action_goal_info_t goal_info;
   rcl_time_point_value_t goal_terminal_timestamp;
   size_t num_goal_handles = action_server->impl->num_goal_handles;
   for (size_t i = 0u; i < num_goal_handles; ++i) {
@@ -640,19 +639,6 @@ rcl_action_expire_goals(
       break;
     }
     goal_handle = action_server->impl->goal_handles[i];
-    // Expiration only applys to terminated goals
-    if (rcl_action_goal_handle_is_active(goal_handle)) {
-      continue;
-    }
-    rcl_action_goal_info_t * info_ptr = &goal_info;
-    if (output_expired) {
-      info_ptr = &(expired_goals[num_goals_expired]);
-    }
-    ret = rcl_action_goal_handle_get_info(goal_handle, info_ptr);
-    if (RCL_RET_OK != ret) {
-      ret_final = RCL_RET_ERROR;
-      continue;
-    }
 
     ret = rcl_action_goal_handle_get_goal_terminal_timestamp(goal_handle, &goal_terminal_timestamp);
     if (RCL_RET_NOT_TERMINATED_YET == ret) {

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -458,7 +458,7 @@ _recalculate_expire_timer(
       rcl_time_point_value_t goal_terminal_timestamp;
       ret = rcl_action_goal_handle_get_goal_terminal_timestamp(
         goal_handle, &goal_terminal_timestamp);
-      if (RCL_RET_NOT_TERMINATED_YET == ret) {
+      if (RCL_ACTION_RET_NOT_TERMINATED_YET == ret) {
         continue;
       }
       if (RCL_RET_OK != ret) {
@@ -654,7 +654,7 @@ rcl_action_expire_goals(
     }
 
     ret = rcl_action_goal_handle_get_goal_terminal_timestamp(goal_handle, &goal_terminal_timestamp);
-    if (RCL_RET_NOT_TERMINATED_YET == ret) {
+    if (RCL_ACTION_RET_NOT_TERMINATED_YET == ret) {
       continue;
     }
     if (RCL_RET_OK != ret) {
@@ -737,7 +737,7 @@ rcl_action_notify_goal_done(
       rcl_time_point_value_t goal_terminal_timestamp;
       rcl_ret_t ret = rcl_action_goal_handle_get_goal_terminal_timestamp(
         goal_handle, &goal_terminal_timestamp);
-      if (RCL_RET_NOT_TERMINATED_YET == ret) {
+      if (RCL_ACTION_RET_NOT_TERMINATED_YET == ret) {
         ret = rcl_action_goal_handle_set_goal_terminal_timestamp(goal_handle, current_time);
         if (RCL_RET_OK != ret) {
           return RCL_RET_ERROR;

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -631,7 +631,6 @@ rcl_action_expire_goals(
   rcl_ret_t ret_final = RCL_RET_OK;
   const int64_t timeout = (int64_t)action_server->impl->options.result_timeout.nanoseconds;
   rcl_action_goal_handle_t * goal_handle;
-  rcl_action_goal_info_t goal_info;
   rcl_time_point_value_t goal_terminal_timestamp;
   size_t num_goal_handles = action_server->impl->num_goal_handles;
   for (size_t i = 0u; i < num_goal_handles; ++i) {
@@ -644,14 +643,14 @@ rcl_action_expire_goals(
     if (rcl_action_goal_handle_is_active(goal_handle)) {
       continue;
     }
-    rcl_action_goal_info_t * info_ptr = &goal_info;
+
+    // Retrieve the information of expired goals for output
     if (output_expired) {
-      info_ptr = &(expired_goals[num_goals_expired]);
-    }
-    ret = rcl_action_goal_handle_get_info(goal_handle, info_ptr);
-    if (RCL_RET_OK != ret) {
-      ret_final = RCL_RET_ERROR;
-      continue;
+      ret = rcl_action_goal_handle_get_info(goal_handle, &(expired_goals[num_goals_expired]));
+      if (RCL_RET_OK != ret) {
+        ret_final = RCL_RET_ERROR;
+        continue;
+      }
     }
 
     ret = rcl_action_goal_handle_get_goal_terminal_timestamp(goal_handle, &goal_terminal_timestamp);

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -458,6 +458,9 @@ _recalculate_expire_timer(
       rcl_time_point_value_t goal_terminal_timestamp;
       ret = rcl_action_goal_handle_get_goal_terminal_timestamp(
         goal_handle, &goal_terminal_timestamp);
+      if (RCL_RET_NOT_TERMINATED_YET == ret) {
+        continue;
+      }
       if (RCL_RET_OK != ret) {
         return RCL_RET_ERROR;
       }
@@ -652,12 +655,15 @@ rcl_action_expire_goals(
     }
 
     ret = rcl_action_goal_handle_get_goal_terminal_timestamp(goal_handle, &goal_terminal_timestamp);
+    if (RCL_RET_NOT_TERMINATED_YET == ret) {
+      continue;
+    }
     if (RCL_RET_OK != ret) {
       ret_final = RCL_RET_ERROR;
       continue;
     }
 
-    if ((goal_terminal_timestamp != 0) && (current_time - goal_terminal_timestamp) > timeout) {
+    if ((current_time - goal_terminal_timestamp) > timeout) {
       // Deallocate space used to store pointer to goal handle
       allocator.deallocate(action_server->impl->goal_handles[i], allocator.state);
       action_server->impl->goal_handles[i] = NULL;
@@ -732,15 +738,15 @@ rcl_action_notify_goal_done(
       rcl_time_point_value_t goal_terminal_timestamp;
       rcl_ret_t ret = rcl_action_goal_handle_get_goal_terminal_timestamp(
         goal_handle, &goal_terminal_timestamp);
-      if (RCL_RET_OK != ret) {
-        return RCL_RET_ERROR;
-      }
-
-      if (goal_terminal_timestamp == INVAILD_GOAL_TERMINAL_TIMESTAMP) {
+      if (RCL_RET_NOT_TERMINATED_YET == ret) {
         ret = rcl_action_goal_handle_set_goal_terminal_timestamp(goal_handle, current_time);
         if (RCL_RET_OK != ret) {
           return RCL_RET_ERROR;
         }
+        continue;
+      }
+      if (RCL_RET_OK != ret) {
+        return RCL_RET_ERROR;
       }
     }
   }

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -667,7 +667,7 @@ rcl_action_expire_goals(
       continue;
     }
 
-    if ((current_time - goal_terminal_timestamp) > timeout) {
+    if ((goal_terminal_timestamp != 0) && (current_time - goal_terminal_timestamp) > timeout) {
       // Deallocate space used to store pointer to goal handle
       allocator.deallocate(action_server->impl->goal_handles[i], allocator.state);
       action_server->impl->goal_handles[i] = NULL;

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -463,7 +463,7 @@ _recalculate_expire_timer(
       // This function is called in rcl_action_notify_goal_done().
       // If goal_terminal_timestamp of goal is invaild, this goal is just in terminal state.
       // So current time is set to goal_terminal_timestamp of this goal.
-      if (goal_terminal_timestamp == INT64_MAX) {
+      if (goal_terminal_timestamp == 0) {
         goal_terminal_timestamp = current_time;
         ret = rcl_action_goal_handle_set_goal_terminal_timestamp(
           goal_handle, goal_terminal_timestamp);

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -451,13 +451,28 @@ _recalculate_expire_timer(
     if (!rcl_action_goal_handle_is_active(goal_handle)) {
       ++num_inactive_goals;
 
-      rcl_action_goal_info_t goal_info;
-      ret = rcl_action_goal_handle_get_info(goal_handle, &goal_info);
+      rcl_time_point_value_t goal_terminal_timestamp;
+      ret = rcl_action_goal_handle_get_goal_terminal_timestamp(
+        goal_handle, &goal_terminal_timestamp);
       if (RCL_RET_OK != ret) {
         return RCL_RET_ERROR;
       }
 
-      int64_t delta = timeout - (current_time - _goal_info_stamp_to_nanosec(&goal_info));
+      // After state of goal is updated to terminal state (success or cancel or abort),
+      // rcl_action_notify_goal_done() is called.
+      // This function is called in rcl_action_notify_goal_done().
+      // If goal_terminal_timestamp of goal is invaild, this goal is just in terminal state.
+      // So current time is set to goal_terminal_timestamp of this goal.
+      if (goal_terminal_timestamp == INT64_MAX) {
+        goal_terminal_timestamp = current_time;
+        ret = rcl_action_goal_handle_set_goal_terminal_timestamp(
+          goal_handle, goal_terminal_timestamp);
+        if (RCL_RET_OK != ret) {
+          return RCL_RET_ERROR;
+        }
+      }
+
+      int64_t delta = timeout - (current_time - goal_terminal_timestamp);
       if (delta < minimum_period) {
         minimum_period = delta;
       }
@@ -624,7 +639,7 @@ rcl_action_expire_goals(
   const int64_t timeout = (int64_t)action_server->impl->options.result_timeout.nanoseconds;
   rcl_action_goal_handle_t * goal_handle;
   rcl_action_goal_info_t goal_info;
-  int64_t goal_time;
+  rcl_time_point_value_t goal_terminal_timestamp;
   size_t num_goal_handles = action_server->impl->num_goal_handles;
   for (size_t i = 0u; i < num_goal_handles; ++i) {
     if (output_expired && num_goals_expired >= expired_goals_capacity) {
@@ -645,8 +660,14 @@ rcl_action_expire_goals(
       ret_final = RCL_RET_ERROR;
       continue;
     }
-    goal_time = _goal_info_stamp_to_nanosec(info_ptr);
-    if ((current_time - goal_time) > timeout) {
+
+    ret = rcl_action_goal_handle_get_goal_terminal_timestamp(goal_handle, &goal_terminal_timestamp);
+    if (RCL_RET_OK != ret) {
+      ret_final = RCL_RET_ERROR;
+      continue;
+    }
+
+    if ((current_time - goal_terminal_timestamp) > timeout) {
       // Deallocate space used to store pointer to goal handle
       allocator.deallocate(action_server->impl->goal_handles[i], allocator.state);
       action_server->impl->goal_handles[i] = NULL;

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -36,6 +36,10 @@ extern "C"
 
 #include "rmw/rmw.h"
 
+extern rcl_ret_t
+rcl_action_goal_handle_set_goal_terminal_timestamp(
+  const rcl_action_goal_handle_t * goal_handle,
+  rcl_time_point_value_t timestamp);
 
 rcl_action_server_t
 rcl_action_get_zero_initialized_server(void)
@@ -458,20 +462,6 @@ _recalculate_expire_timer(
         return RCL_RET_ERROR;
       }
 
-      // After state of goal is updated to terminal state (success or cancel or abort),
-      // rcl_action_notify_goal_done() is called.
-      // This function is called in rcl_action_notify_goal_done().
-      // If goal_terminal_timestamp of goal is invaild, this goal is just in terminal state.
-      // So current time is set to goal_terminal_timestamp of this goal.
-      if (goal_terminal_timestamp == 0) {
-        goal_terminal_timestamp = current_time;
-        ret = rcl_action_goal_handle_set_goal_terminal_timestamp(
-          goal_handle, goal_terminal_timestamp);
-        if (RCL_RET_OK != ret) {
-          return RCL_RET_ERROR;
-        }
-      }
-
       int64_t delta = timeout - (current_time - goal_terminal_timestamp);
       if (delta < minimum_period) {
         minimum_period = delta;
@@ -727,6 +717,34 @@ rcl_action_notify_goal_done(
   if (!rcl_action_server_is_valid(action_server)) {
     return RCL_RET_ACTION_SERVER_INVALID;
   }
+
+  // Get current time (nanosec)
+  int64_t current_time;
+  rcl_ret_t ret = rcl_clock_get_now(action_server->impl->clock, &current_time);
+  if (RCL_RET_OK != ret) {
+    return RCL_RET_ERROR;
+  }
+
+  // Set current time to goal_terminal_timestamp of goal which has reached terminal state
+  for (size_t i = 0; i < action_server->impl->num_goal_handles; ++i) {
+    rcl_action_goal_handle_t * goal_handle = action_server->impl->goal_handles[i];
+    if (!rcl_action_goal_handle_is_active(goal_handle)) {
+      rcl_time_point_value_t goal_terminal_timestamp;
+      rcl_ret_t ret = rcl_action_goal_handle_get_goal_terminal_timestamp(
+        goal_handle, &goal_terminal_timestamp);
+      if (RCL_RET_OK != ret) {
+        return RCL_RET_ERROR;
+      }
+
+      if (goal_terminal_timestamp == INVAILD_GOAL_TERMINAL_TIMESTAMP) {
+        ret = rcl_action_goal_handle_set_goal_terminal_timestamp(goal_handle, current_time);
+        if (RCL_RET_OK != ret) {
+          return RCL_RET_ERROR;
+        }
+      }
+    }
+  }
+
   return _recalculate_expire_timer(
     &action_server->impl->expire_timer,
     action_server->impl->options.result_timeout.nanoseconds,

--- a/rcl_action/src/rcl_action/goal_handle.c
+++ b/rcl_action/src/rcl_action/goal_handle.c
@@ -69,8 +69,8 @@ rcl_action_goal_handle_init(
   goal_handle->impl->state = GOAL_STATE_ACCEPTED;
   // Copy the allocator
   goal_handle->impl->allocator = allocator;
-  // Set invaild time
-  goal_handle->impl->goal_terminal_timestamp = INT64_MAX;
+  // Set invalid time
+  goal_handle->impl->goal_terminal_timestamp = 0;
   return RCL_RET_OK;
 }
 

--- a/rcl_action/src/rcl_action/goal_handle.c
+++ b/rcl_action/src/rcl_action/goal_handle.c
@@ -26,6 +26,7 @@ typedef struct rcl_action_goal_handle_impl_s
 {
   rcl_action_goal_info_t info;
   rcl_action_goal_state_t state;
+  rcl_time_point_value_t goal_terminal_timestamp;
   rcl_allocator_t allocator;
 } rcl_action_goal_handle_impl_t;
 
@@ -68,6 +69,8 @@ rcl_action_goal_handle_init(
   goal_handle->impl->state = GOAL_STATE_ACCEPTED;
   // Copy the allocator
   goal_handle->impl->allocator = allocator;
+  // Set invaild time
+  goal_handle->impl->goal_terminal_timestamp = INT64_MAX;
   return RCL_RET_OK;
 }
 
@@ -170,6 +173,42 @@ rcl_action_goal_handle_is_valid(const rcl_action_goal_handle_t * goal_handle)
   RCL_CHECK_FOR_NULL_WITH_MSG(
     goal_handle->impl, "goal handle implementation is invalid", return false);
   return true;
+}
+
+rcl_ret_t
+rcl_action_goal_handle_get_goal_terminal_timestamp(
+  const rcl_action_goal_handle_t * goal_handle,
+  rcl_time_point_value_t * timestamp)
+{
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RCL_RET_ACTION_GOAL_HANDLE_INVALID);
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RCL_RET_INVALID_ARGUMENT);
+
+  if (!rcl_action_goal_handle_is_valid(goal_handle)) {
+    return RCL_RET_ACTION_GOAL_HANDLE_INVALID;  // error message is set
+  }
+  RCL_CHECK_ARGUMENT_FOR_NULL(timestamp, RCL_RET_INVALID_ARGUMENT);
+  *timestamp = goal_handle->impl->goal_terminal_timestamp;
+  return RCL_RET_OK;
+}
+
+rcl_ret_t
+rcl_action_goal_handle_set_goal_terminal_timestamp(
+  const rcl_action_goal_handle_t * goal_handle,
+  rcl_time_point_value_t timestamp)
+{
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RCL_RET_ACTION_GOAL_HANDLE_INVALID);
+  RCUTILS_CAN_RETURN_WITH_ERROR_OF(RCL_RET_INVALID_ARGUMENT);
+
+  if (!rcl_action_goal_handle_is_valid(goal_handle)) {
+    return RCL_RET_ACTION_GOAL_HANDLE_INVALID;  // error message is set
+  }
+
+  if (timestamp == INT64_MAX) {
+    RCL_SET_ERROR_MSG("Timestamp argument is invaild !");
+    return RCL_RET_INVALID_ARGUMENT;
+  }
+  goal_handle->impl->goal_terminal_timestamp = timestamp;
+  return RCL_RET_OK;
 }
 
 #ifdef __cplusplus

--- a/rcl_action/src/rcl_action/goal_handle.c
+++ b/rcl_action/src/rcl_action/goal_handle.c
@@ -26,7 +26,8 @@ typedef struct rcl_action_goal_handle_impl_s
 {
   rcl_action_goal_info_t info;
   rcl_action_goal_state_t state;
-  // If goal_terminal_timestamp isn't set, INVAILD_GOAL_TERMINAL_TIMESTAMP is the initial value.
+  // As long as the goal has not reached terminal state, this variable is set to
+  // INVAILD_GOAL_TERMINAL_TIMESTAMP
   rcl_time_point_value_t goal_terminal_timestamp;
   rcl_allocator_t allocator;
 } rcl_action_goal_handle_impl_t;

--- a/rcl_action/src/rcl_action/goal_handle.c
+++ b/rcl_action/src/rcl_action/goal_handle.c
@@ -26,6 +26,7 @@ typedef struct rcl_action_goal_handle_impl_s
 {
   rcl_action_goal_info_t info;
   rcl_action_goal_state_t state;
+  // If goal_terminal_timestamp isn't set, INVAILD_GOAL_TERMINAL_TIMESTAMP is the initial value.
   rcl_time_point_value_t goal_terminal_timestamp;
   rcl_allocator_t allocator;
 } rcl_action_goal_handle_impl_t;
@@ -70,7 +71,7 @@ rcl_action_goal_handle_init(
   // Copy the allocator
   goal_handle->impl->allocator = allocator;
   // Set invalid time
-  goal_handle->impl->goal_terminal_timestamp = 0;
+  goal_handle->impl->goal_terminal_timestamp = INVAILD_GOAL_TERMINAL_TIMESTAMP;
   return RCL_RET_OK;
 }
 
@@ -203,7 +204,7 @@ rcl_action_goal_handle_set_goal_terminal_timestamp(
     return RCL_RET_ACTION_GOAL_HANDLE_INVALID;  // error message is set
   }
 
-  if (timestamp == INT64_MAX) {
+  if (timestamp == INVAILD_GOAL_TERMINAL_TIMESTAMP) {
     RCL_SET_ERROR_MSG("Timestamp argument is invaild !");
     return RCL_RET_INVALID_ARGUMENT;
   }

--- a/rcl_action/src/rcl_action/goal_handle.c
+++ b/rcl_action/src/rcl_action/goal_handle.c
@@ -189,7 +189,13 @@ rcl_action_goal_handle_get_goal_terminal_timestamp(
     return RCL_RET_ACTION_GOAL_HANDLE_INVALID;  // error message is set
   }
   RCL_CHECK_ARGUMENT_FOR_NULL(timestamp, RCL_RET_INVALID_ARGUMENT);
+
+  if (goal_handle->impl->goal_terminal_timestamp == INVAILD_GOAL_TERMINAL_TIMESTAMP) {
+    return RCL_RET_NOT_TERMINATED_YET;
+  }
+
   *timestamp = goal_handle->impl->goal_terminal_timestamp;
+
   return RCL_RET_OK;
 }
 

--- a/rcl_action/src/rcl_action/goal_handle.c
+++ b/rcl_action/src/rcl_action/goal_handle.c
@@ -191,7 +191,7 @@ rcl_action_goal_handle_get_goal_terminal_timestamp(
   RCL_CHECK_ARGUMENT_FOR_NULL(timestamp, RCL_RET_INVALID_ARGUMENT);
 
   if (goal_handle->impl->goal_terminal_timestamp == INVAILD_GOAL_TERMINAL_TIMESTAMP) {
-    return RCL_RET_NOT_TERMINATED_YET;
+    return RCL_ACTION_RET_NOT_TERMINATED_YET;
   }
 
   *timestamp = goal_handle->impl->goal_terminal_timestamp;
@@ -211,7 +211,7 @@ rcl_action_goal_handle_set_goal_terminal_timestamp(
     return RCL_RET_ACTION_GOAL_HANDLE_INVALID;  // error message is set
   }
 
-  if (timestamp == INVAILD_GOAL_TERMINAL_TIMESTAMP) {
+  if (timestamp <= INVAILD_GOAL_TERMINAL_TIMESTAMP) {
     RCL_SET_ERROR_MSG("Timestamp argument is invaild !");
     return RCL_RET_INVALID_ARGUMENT;
   }

--- a/rcl_action/test/rcl_action/test_action_server.cpp
+++ b/rcl_action/test/rcl_action/test_action_server.cpp
@@ -592,6 +592,9 @@ TEST_F(TestActionServer, test_action_clear_expired_goals)
   ASSERT_EQ(RCL_RET_OK, rcl_action_update_goal_state(goal_handle, GOAL_EVENT_EXECUTE));
   ASSERT_EQ(RCL_RET_OK, rcl_action_update_goal_state(goal_handle, GOAL_EVENT_ABORT));
 
+  // recalculate the expired goal timer after entering terminal state
+  ASSERT_EQ(RCL_RET_OK, rcl_action_notify_goal_done(&this->action_server));
+
   // Set time to something far in the future
   ASSERT_EQ(RCL_RET_OK, rcl_set_ros_time_override(&this->clock, RCUTILS_S_TO_NS(99999)));
 

--- a/rcl_action/test/rcl_action/test_goal_handle.cpp
+++ b/rcl_action/test/rcl_action/test_goal_handle.cpp
@@ -170,6 +170,58 @@ TEST(TestGoalHandle, test_goal_handle_update_state_invalid)
   EXPECT_EQ(RCL_RET_OK, rcl_action_goal_handle_fini(&goal_handle));
 }
 
+TEST(TestGoalHandle, rcl_action_goal_handle_get_goal_terminal_timestamp)
+{
+  rcl_time_point_value_t time;
+
+  // Check with null argument
+  rcl_ret_t ret = rcl_action_goal_handle_get_goal_terminal_timestamp(nullptr, &time);
+  EXPECT_EQ(ret, RCL_RET_ACTION_GOAL_HANDLE_INVALID) << rcl_get_error_string().str;
+  rcl_reset_error();
+
+  // Check with invalid goal handle
+  rcl_action_goal_handle_t goal_handle = rcl_action_get_zero_initialized_goal_handle();
+  ret = rcl_action_goal_handle_get_goal_terminal_timestamp(&goal_handle, &time);
+  EXPECT_EQ(ret, RCL_RET_ACTION_GOAL_HANDLE_INVALID) << rcl_get_error_string().str;
+  rcl_reset_error();
+
+  // Check with null timestamp
+  rcl_action_goal_info_t goal_info = rcl_action_get_zero_initialized_goal_info();
+  ret = rcl_action_goal_handle_init(&goal_handle, &goal_info, rcl_get_default_allocator());
+  EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+  ret = rcl_action_goal_handle_get_goal_terminal_timestamp(&goal_handle, nullptr);
+  EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT) << rcl_get_error_string().str;
+  rcl_reset_error();
+
+  EXPECT_EQ(RCL_RET_OK, rcl_action_goal_handle_fini(&goal_handle));
+}
+
+TEST(TestGoalHandle, rcl_action_goal_handle_set_goal_terminal_timestamp)
+{
+  rcl_time_point_value_t invaild_time = INT64_MAX;
+
+  // Check with null argument
+  rcl_ret_t ret = rcl_action_goal_handle_set_goal_terminal_timestamp(nullptr, 100);
+  EXPECT_EQ(ret, RCL_RET_ACTION_GOAL_HANDLE_INVALID) << rcl_get_error_string().str;
+  rcl_reset_error();
+
+  // Check with invalid goal handle
+  rcl_action_goal_handle_t goal_handle = rcl_action_get_zero_initialized_goal_handle();
+  ret = rcl_action_goal_handle_set_goal_terminal_timestamp(&goal_handle, 100);
+  EXPECT_EQ(ret, RCL_RET_ACTION_GOAL_HANDLE_INVALID) << rcl_get_error_string().str;
+  rcl_reset_error();
+
+  // Check with invalid timestamp
+  rcl_action_goal_info_t goal_info = rcl_action_get_zero_initialized_goal_info();
+  ret = rcl_action_goal_handle_init(&goal_handle, &goal_info, rcl_get_default_allocator());
+  EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+  ret = rcl_action_goal_handle_set_goal_terminal_timestamp(&goal_handle, invaild_time);
+  EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT) << rcl_get_error_string().str;
+  rcl_reset_error();
+
+  EXPECT_EQ(RCL_RET_OK, rcl_action_goal_handle_fini(&goal_handle));
+}
+
 using EventStateActiveCancelableTuple =
   std::tuple<rcl_action_goal_event_t, rcl_action_goal_state_t, bool, bool>;
 using StateTransitionSequence = std::vector<EventStateActiveCancelableTuple>;

--- a/rcl_action/test/rcl_action/test_goal_handle.cpp
+++ b/rcl_action/test/rcl_action/test_goal_handle.cpp
@@ -193,6 +193,11 @@ TEST(TestGoalHandle, rcl_action_goal_handle_get_goal_terminal_timestamp)
   EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT) << rcl_get_error_string().str;
   rcl_reset_error();
 
+  rcl_time_point_value_t timestamp;
+  ret = rcl_action_goal_handle_get_goal_terminal_timestamp(&goal_handle, &timestamp);
+  EXPECT_EQ(ret, RCL_RET_NOT_TERMINATED_YET) << rcl_get_error_string().str;
+  rcl_reset_error();
+
   EXPECT_EQ(RCL_RET_OK, rcl_action_goal_handle_fini(&goal_handle));
 }
 

--- a/rcl_action/test/rcl_action/test_goal_handle.cpp
+++ b/rcl_action/test/rcl_action/test_goal_handle.cpp
@@ -195,7 +195,7 @@ TEST(TestGoalHandle, rcl_action_goal_handle_get_goal_terminal_timestamp)
 
   rcl_time_point_value_t timestamp;
   ret = rcl_action_goal_handle_get_goal_terminal_timestamp(&goal_handle, &timestamp);
-  EXPECT_EQ(ret, RCL_RET_NOT_TERMINATED_YET) << rcl_get_error_string().str;
+  EXPECT_EQ(ret, RCL_ACTION_RET_NOT_TERMINATED_YET) << rcl_get_error_string().str;
   rcl_reset_error();
 
   EXPECT_EQ(RCL_RET_OK, rcl_action_goal_handle_fini(&goal_handle));

--- a/rcl_action/test/rcl_action/test_goal_handle.cpp
+++ b/rcl_action/test/rcl_action/test_goal_handle.cpp
@@ -196,32 +196,6 @@ TEST(TestGoalHandle, rcl_action_goal_handle_get_goal_terminal_timestamp)
   EXPECT_EQ(RCL_RET_OK, rcl_action_goal_handle_fini(&goal_handle));
 }
 
-TEST(TestGoalHandle, rcl_action_goal_handle_set_goal_terminal_timestamp)
-{
-  rcl_time_point_value_t invaild_time = INT64_MAX;
-
-  // Check with null argument
-  rcl_ret_t ret = rcl_action_goal_handle_set_goal_terminal_timestamp(nullptr, 100);
-  EXPECT_EQ(ret, RCL_RET_ACTION_GOAL_HANDLE_INVALID) << rcl_get_error_string().str;
-  rcl_reset_error();
-
-  // Check with invalid goal handle
-  rcl_action_goal_handle_t goal_handle = rcl_action_get_zero_initialized_goal_handle();
-  ret = rcl_action_goal_handle_set_goal_terminal_timestamp(&goal_handle, 100);
-  EXPECT_EQ(ret, RCL_RET_ACTION_GOAL_HANDLE_INVALID) << rcl_get_error_string().str;
-  rcl_reset_error();
-
-  // Check with invalid timestamp
-  rcl_action_goal_info_t goal_info = rcl_action_get_zero_initialized_goal_info();
-  ret = rcl_action_goal_handle_init(&goal_handle, &goal_info, rcl_get_default_allocator());
-  EXPECT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
-  ret = rcl_action_goal_handle_set_goal_terminal_timestamp(&goal_handle, invaild_time);
-  EXPECT_EQ(ret, RCL_RET_INVALID_ARGUMENT) << rcl_get_error_string().str;
-  rcl_reset_error();
-
-  EXPECT_EQ(RCL_RET_OK, rcl_action_goal_handle_fini(&goal_handle));
-}
-
 using EventStateActiveCancelableTuple =
   std::tuple<rcl_action_goal_event_t, rcl_action_goal_state_t, bool, bool>;
 using StateTransitionSequence = std::vector<EventStateActiveCancelableTuple>;


### PR DESCRIPTION
Address one issue mentioned #1103 

The expire timeout [is being calculated from the time the goal was accepted](https://github.com/ros2/rcl/blob/9a05fa65926673b2986175ff055215861e29bf5b/rcl_action/src/rcl_action/action_server.c#L644-L645). According to the design https://design.ros2.org/articles/actions.html#result-caching, it should be calculated from the time the goal is completed.  