### PR TITLE
Make sure to disable a test_node test on RHEL.

### DIFF
--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -234,7 +234,7 @@ function(test_target)
   if(
     "${DISTRIBUTION}" STREQUAL "\"centos\"" OR
     "${DISTRIBUTION}" STREQUAL "\"almalinux\"")
-    set(gtest_filter_env_var "GTEST_FILTER=-TestNodeFixture__*.test_rcl_node_init_with_internal_errors")
+    set(gtest_filter_env_var "GTEST_FILTER=-TestNodeFixture.test_rcl_node_init_with_internal_errors")
   else()
     set(gtest_filter_env_var "")
   endif()


### PR DESCRIPTION
This was previously disabled, but due to the recent work to simplify the tests the name of the test slightly changed.  Fix that here, which should make us start skipping the test on RHEL again.

This should fix #1123 