### PR TITLE
Fix for incorrect integer value conversion on Windows

### DIFF
--- a/rcl_yaml_param_parser/src/parse.c
+++ b/rcl_yaml_param_parser/src/parse.c
@@ -153,7 +153,7 @@ void * get_value(
     errno = 0;
     ival = strtoll(value, &endptr, 0);
     if ((0 == errno) && (NULL != endptr)) {
-      if ((NULL != endptr) && (endptr != value)) {
+      if (endptr != value) {
         if (('\0' != *value) && ('\0' == *endptr)) {
           *val_type = DATA_TYPE_INT64;
           ret_val = allocator.zero_allocate(1U, sizeof(int64_t), allocator.state);

--- a/rcl_yaml_param_parser/src/parse.c
+++ b/rcl_yaml_param_parser/src/parse.c
@@ -151,7 +151,7 @@ void * get_value(
     style != YAML_DOUBLE_QUOTED_SCALAR_STYLE)
   {
     errno = 0;
-    ival = strtol(value, &endptr, 0);
+    ival = strtoll(value, &endptr, 0);
     if ((0 == errno) && (NULL != endptr)) {
       if ((NULL != endptr) && (endptr != value)) {
         if (('\0' != *value) && ('\0' == *endptr)) {

--- a/rcl_yaml_param_parser/test/correct_config.yaml
+++ b/rcl_yaml_param_parser/test/correct_config.yaml
@@ -18,7 +18,7 @@ lidar_ns:
         dy: 0.45
   lidar_2:
     ros__parameters:
-      id: 11
+      id: 992147483647
       name: back_lidar
       dy1: 0.003
       is_back: false

--- a/rcl_yaml_param_parser/test/test_parse_yaml.cpp
+++ b/rcl_yaml_param_parser/test/test_parse_yaml.cpp
@@ -92,7 +92,8 @@ TEST(test_parser, correct_syntax) {
     param_value = rcl_yaml_node_struct_get("lidar_ns/lidar_2", "id", params);
     ASSERT_TRUE(NULL != param_value) << rcutils_get_error_string().str;
     ASSERT_TRUE(NULL != param_value->integer_value);
-    EXPECT_EQ(11, *param_value->integer_value);
+    // Make sure that we can correctly parse bigger than LONG_MAX = 2147483647 values
+    EXPECT_EQ(992147483647, *param_value->integer_value);
     res = rcl_parse_yaml_value("lidar_ns/lidar_2", "id", "12", params);
     EXPECT_TRUE(res) << rcutils_get_error_string().str;
     ASSERT_TRUE(NULL != param_value->integer_value);


### PR DESCRIPTION
- Closes https://github.com/ros2/rcl/issues/1125

#### RCA
It turns out that we are using `ival = strtol(value, &endptr, 0);` function when trying to parse integer value.
On Linux and 64-bit, it works correctly for values bigger than `LONG_MAX = 2147483647` because `sizeof(long)` returns
**8 bytes**. However on Windows, it is not true and `sizeof(long)` is **4** bytes and `strtol(value, &endptr, 0)` can't parse values bigger than 2147483647 and we fallback to the parsing value as a floating point value with `strtod(..)` and it succeeds.

#### FIX
1. Replaced `strtol(..)` with `strtoll(..)`
2. Adjust values in the unit test to cover this use-case.