### PR TITLE
Remove unnecessary macros.

### DIFF
--- a/rcl/src/rcl/client.c
+++ b/rcl/src/rcl/client.c
@@ -295,15 +295,13 @@ rcl_client_get_service_name(const rcl_client_t * client)
   return client->impl->rmw_handle->service_name;
 }
 
-#define _client_get_options(client) & client->impl->options;
-
 const rcl_client_options_t *
 rcl_client_get_options(const rcl_client_t * client)
 {
   if (!rcl_client_is_valid(client)) {
     return NULL;  // error already set
   }
-  return _client_get_options(client);
+  return &client->impl->options;
 }
 
 rmw_client_t *

--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -385,15 +385,13 @@ rcl_publisher_get_topic_name(const rcl_publisher_t * publisher)
   return publisher->impl->rmw_handle->topic_name;
 }
 
-#define _publisher_get_options(pub) & pub->impl->options
-
 const rcl_publisher_options_t *
 rcl_publisher_get_options(const rcl_publisher_t * publisher)
 {
   if (!rcl_publisher_is_valid_except_context(publisher)) {
     return NULL;  // error already set
   }
-  return _publisher_get_options(publisher);
+  return &publisher->impl->options;
 }
 
 rmw_publisher_t *

--- a/rcl/src/rcl/service.c
+++ b/rcl/src/rcl/service.c
@@ -303,15 +303,13 @@ rcl_service_get_service_name(const rcl_service_t * service)
   return service->impl->rmw_handle->service_name;
 }
 
-#define _service_get_options(service) & service->impl->options
-
 const rcl_service_options_t *
 rcl_service_get_options(const rcl_service_t * service)
 {
   if (!rcl_service_is_valid(service)) {
     return NULL;  // error already set
   }
-  return _service_get_options(service);
+  return &service->impl->options;
 }
 
 rmw_service_t *

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -742,15 +742,13 @@ rcl_subscription_get_topic_name(const rcl_subscription_t * subscription)
   return subscription->impl->rmw_handle->topic_name;
 }
 
-#define _subscription_get_options(subscription) & subscription->impl->options
-
 const rcl_subscription_options_t *
 rcl_subscription_get_options(const rcl_subscription_t * subscription)
 {
   if (!rcl_subscription_is_valid(subscription)) {
     return NULL;  // error already set
   }
-  return _subscription_get_options(subscription);
+  return &subscription->impl->options;
 }
 
 rmw_subscription_t *


### PR DESCRIPTION
These really don't add anything, and allows us to
avoid some changes in macro formatting between Ubuntu 22.04 and Ubuntu 24.04.