### PR TITLE
Add tracepoint for publish_serialized_publish

### DIFF
--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -297,6 +297,7 @@ rcl_publish_serialized_message(
     return RCL_RET_PUBLISHER_INVALID;  // error already set
   }
   RCL_CHECK_ARGUMENT_FOR_NULL(serialized_message, RCL_RET_INVALID_ARGUMENT);
+  TRACETOOLS_TRACEPOINT(rcl_publish, (const void *)publisher, (const void *)serialized_message);
   rmw_ret_t ret = rmw_publish_serialized_message(
     publisher->impl->rmw_handle, serialized_message, allocation);
   if (ret != RMW_RET_OK) {

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -644,6 +644,7 @@ rcl_take_serialized_message(
   }
   RCUTILS_LOG_DEBUG_NAMED(
     ROS_PACKAGE_NAME, "Subscription serialized take succeeded: %s", taken ? "true" : "false");
+  TRACETOOLS_TRACEPOINT(rcl_take, (const void *)serialized_message);
   if (!taken) {
     return RCL_RET_SUBSCRIPTION_TAKE_FAILED;
   }


### PR DESCRIPTION
Please, refer to https://github.com/ros2/rclcpp/pull/2448.

I have added the following trace points.
- `rcl_publish_serialized_message()`
  - tracepoint : rcl_publish
