### PR TITLE
Populate Transitions in Transition Events

### DIFF
--- a/rcl_lifecycle/src/com_interface.c
+++ b/rcl_lifecycle/src/com_interface.c
@@ -328,7 +328,18 @@ rcl_lifecycle_com_interface_publish_notification(
   const char * transition_label, uint8_t transition_id,
   const rcl_lifecycle_state_t * start, const rcl_lifecycle_state_t * goal)
 {
-  com_interface->msg.timestamp = 0u;
+  // Get the current system time based on the rcl_clock
+  rcutils_time_point_value_t current_time;
+  rcutils_ret_t time_ret = rcutils_system_time_now(&current_time);
+  if (time_ret != RCUTILS_RET_OK) {
+    rcutils_error_string_t error = rcutils_get_error_string();
+    rcutils_reset_error();
+    RCL_SET_ERROR_MSG(error.str);
+    time_ret = RCL_RET_ERROR;
+    return time_ret;
+  }
+
+  com_interface->msg.timestamp = current_time;
   com_interface->msg.transition.id = transition_id;
   rosidl_runtime_c__String__assign(&com_interface->msg.transition.label, transition_label);
   com_interface->msg.start_state.id = start->id;

--- a/rcl_lifecycle/src/com_interface.c
+++ b/rcl_lifecycle/src/com_interface.c
@@ -324,9 +324,13 @@ rcl_lifecycle_com_interface_fini(
 
 rcl_ret_t
 rcl_lifecycle_com_interface_publish_notification(
-  rcl_lifecycle_com_interface_t * com_interface,
+  rcl_lifecycle_com_interface_t * com_interface, unsigned int timestamp,
+  const char * transition_label, uint8_t transition_id,
   const rcl_lifecycle_state_t * start, const rcl_lifecycle_state_t * goal)
 {
+  com_interface->msg.timestamp = timestamp;
+  com_interface->msg.transition.id = transition_id;
+  rosidl_runtime_c__String__assign(&com_interface->msg.transition.label, transition_label);
   com_interface->msg.start_state.id = start->id;
   rosidl_runtime_c__String__assign(&com_interface->msg.start_state.label, start->label);
   com_interface->msg.goal_state.id = goal->id;

--- a/rcl_lifecycle/src/com_interface.c
+++ b/rcl_lifecycle/src/com_interface.c
@@ -324,11 +324,11 @@ rcl_lifecycle_com_interface_fini(
 
 rcl_ret_t
 rcl_lifecycle_com_interface_publish_notification(
-  rcl_lifecycle_com_interface_t * com_interface, unsigned int timestamp,
+  rcl_lifecycle_com_interface_t * com_interface,
   const char * transition_label, uint8_t transition_id,
   const rcl_lifecycle_state_t * start, const rcl_lifecycle_state_t * goal)
 {
-  com_interface->msg.timestamp = timestamp;
+  com_interface->msg.timestamp = 0u;
   com_interface->msg.transition.id = transition_id;
   rosidl_runtime_c__String__assign(&com_interface->msg.transition.label, transition_label);
   com_interface->msg.start_state.id = start->id;

--- a/rcl_lifecycle/src/com_interface.h
+++ b/rcl_lifecycle/src/com_interface.h
@@ -21,6 +21,7 @@ extern "C"
 #endif
 
 #include "rcl/macros.h"
+#include <cstdint>
 
 #include "rcl_lifecycle/data_types.h"
 
@@ -78,7 +79,8 @@ rcl_lifecycle_com_interface_fini(
 rcl_ret_t
 RCL_WARN_UNUSED
 rcl_lifecycle_com_interface_publish_notification(
-  rcl_lifecycle_com_interface_t * com_interface,
+  rcl_lifecycle_com_interface_t * com_interface, unsigned int timestamp,
+  const char * transition_label, uint8_t transition_id,
   const rcl_lifecycle_state_t * start, const rcl_lifecycle_state_t * goal);
 
 #ifdef __cplusplus

--- a/rcl_lifecycle/src/com_interface.h
+++ b/rcl_lifecycle/src/com_interface.h
@@ -21,7 +21,6 @@ extern "C"
 #endif
 
 #include "rcl/macros.h"
-#include <cstdint>
 
 #include "rcl_lifecycle/data_types.h"
 
@@ -79,7 +78,7 @@ rcl_lifecycle_com_interface_fini(
 rcl_ret_t
 RCL_WARN_UNUSED
 rcl_lifecycle_com_interface_publish_notification(
-  rcl_lifecycle_com_interface_t * com_interface, unsigned int timestamp,
+  rcl_lifecycle_com_interface_t * com_interface,
   const char * transition_label, uint8_t transition_id,
   const rcl_lifecycle_state_t * start, const rcl_lifecycle_state_t * goal);
 

--- a/rcl_lifecycle/src/rcl_lifecycle.c
+++ b/rcl_lifecycle/src/rcl_lifecycle.c
@@ -361,7 +361,8 @@ _trigger_transition(
 
   if (publish_notification) {
     rcl_ret_t fcn_ret = rcl_lifecycle_com_interface_publish_notification(
-      &state_machine->com_interface, transition->start, state_machine->current_state);
+      &state_machine->com_interface, 250, transition->label, transition->id,
+      transition->start, state_machine->current_state);
     if (fcn_ret != RCL_RET_OK) {
       rcl_error_string_t error_string = rcl_get_error_string();
       rcutils_reset_error();

--- a/rcl_lifecycle/src/rcl_lifecycle.c
+++ b/rcl_lifecycle/src/rcl_lifecycle.c
@@ -361,7 +361,7 @@ _trigger_transition(
 
   if (publish_notification) {
     rcl_ret_t fcn_ret = rcl_lifecycle_com_interface_publish_notification(
-      &state_machine->com_interface, 250, transition->label, transition->id,
+      &state_machine->com_interface, transition->label, transition->id,
       transition->start, state_machine->current_state);
     if (fcn_ret != RCL_RET_OK) {
       rcl_error_string_t error_string = rcl_get_error_string();


### PR DESCRIPTION
Meant to resolve #1019 this PR adds the timestamp and transition portion of a `TransitionEvent` to the [`rcl_lifecycle_com_interface_publish_notification`](https://github.com/ros2/rcl/blob/rolling/rcl_lifecycle/src/com_interface.h#L80) function

Unfortunately, it looks like in order to do this we will have to break the ABI with either changes or additions to that function's parameters.