### PR TITLE
Fixed warnings - strict-prototypes

### DIFF
--- a/rcl/include/rcl/lexer_lookahead.h
+++ b/rcl/include/rcl/lexer_lookahead.h
@@ -56,7 +56,7 @@ typedef struct rcl_lexer_lookahead2_s
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_lexer_lookahead2_t
-rcl_get_zero_initialized_lexer_lookahead2();
+rcl_get_zero_initialized_lexer_lookahead2(void);
 
 /// Initialize an rcl_lexer_lookahead2_t instance.
 /**

--- a/rcl/include/rcl/log_level.h
+++ b/rcl/include/rcl/log_level.h
@@ -69,7 +69,7 @@ typedef struct rcl_log_levels_s
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_log_levels_t
-rcl_get_zero_initialized_log_levels();
+rcl_get_zero_initialized_log_levels(void);
 
 /// Initialize a log levels structure.
 /**

--- a/rcl/include/rcl/logging_rosout.h
+++ b/rcl/include/rcl/logging_rosout.h
@@ -91,7 +91,7 @@ rcl_logging_rosout_init(
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
-rcl_logging_rosout_fini();
+rcl_logging_rosout_fini(void);
 
 /// Creates a rosout publisher for a node and registers it to be used by the logging system
 /**

--- a/rcl/src/rcl/client.c
+++ b/rcl/src/rcl/client.c
@@ -53,7 +53,7 @@ struct rcl_client_impl_s
 };
 
 rcl_client_t
-rcl_get_zero_initialized_client()
+rcl_get_zero_initialized_client(void)
 {
   static rcl_client_t null_client = {0};
   return null_client;
@@ -276,7 +276,7 @@ rcl_client_fini(rcl_client_t * client, rcl_node_t * node)
 }
 
 rcl_client_options_t
-rcl_client_get_default_options()
+rcl_client_get_default_options(void)
 {
   // !!! MAKE SURE THAT CHANGES TO THESE DEFAULTS ARE REFLECTED IN THE HEADER DOC STRING
   static rcl_client_options_t default_options;

--- a/rcl/src/rcl/event.c
+++ b/rcl/src/rcl/event.c
@@ -36,7 +36,7 @@ extern "C"
 #include "./subscription_impl.h"
 
 rcl_event_t
-rcl_get_zero_initialized_event()
+rcl_get_zero_initialized_event(void)
 {
   static rcl_event_t null_event = {0};
   return null_event;

--- a/rcl/src/rcl/guard_condition.c
+++ b/rcl/src/rcl/guard_condition.c
@@ -34,7 +34,7 @@ struct rcl_guard_condition_impl_s
 };
 
 rcl_guard_condition_t
-rcl_get_zero_initialized_guard_condition()
+rcl_get_zero_initialized_guard_condition(void)
 {
   static rcl_guard_condition_t null_guard_condition = {
     .context = 0,
@@ -141,7 +141,7 @@ rcl_guard_condition_fini(rcl_guard_condition_t * guard_condition)
 }
 
 rcl_guard_condition_options_t
-rcl_guard_condition_get_default_options()
+rcl_guard_condition_get_default_options(void)
 {
   // !!! MAKE SURE THAT CHANGES TO THESE DEFAULTS ARE REFLECTED IN THE HEADER DOC STRING
   static rcl_guard_condition_options_t default_options;

--- a/rcl/src/rcl/lexer_lookahead.c
+++ b/rcl/src/rcl/lexer_lookahead.c
@@ -34,7 +34,7 @@ struct rcl_lexer_lookahead2_impl_s
 };
 
 rcl_lexer_lookahead2_t
-rcl_get_zero_initialized_lexer_lookahead2()
+rcl_get_zero_initialized_lexer_lookahead2(void)
 {
   static rcl_lexer_lookahead2_t zero_initialized = {
     .impl = NULL,

--- a/rcl/src/rcl/log_level.c
+++ b/rcl/src/rcl/log_level.c
@@ -20,7 +20,7 @@
 #include "rcutils/strdup.h"
 
 rcl_log_levels_t
-rcl_get_zero_initialized_log_levels()
+rcl_get_zero_initialized_log_levels(void)
 {
   const rcl_log_levels_t log_levels = {
     .default_logger_level = RCUTILS_LOG_SEVERITY_UNSET,

--- a/rcl/src/rcl/logging_rosout.c
+++ b/rcl/src/rcl/logging_rosout.c
@@ -173,7 +173,7 @@ _rcl_logging_rosout_clear_hashmap(
   return status;
 }
 
-rcl_ret_t rcl_logging_rosout_fini()
+rcl_ret_t rcl_logging_rosout_fini(void)
 {
   if (!__is_initialized) {
     return RCL_RET_OK;

--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -96,7 +96,7 @@ const char * rcl_create_node_logger_name(
 }
 
 rcl_node_t
-rcl_get_zero_initialized_node()
+rcl_get_zero_initialized_node(void)
 {
   static rcl_node_t null_node = {
     .context = 0,

--- a/rcl/src/rcl/node_options.c
+++ b/rcl/src/rcl/node_options.c
@@ -27,7 +27,7 @@ extern "C"
 #include "rcl/logging_rosout.h"
 
 rcl_node_options_t
-rcl_node_get_default_options()
+rcl_node_get_default_options(void)
 {
   // !!! MAKE SURE THAT CHANGES TO THESE DEFAULTS ARE REFLECTED IN THE HEADER DOC STRING
   rcl_node_options_t default_options = {

--- a/rcl/src/rcl/publisher.c
+++ b/rcl/src/rcl/publisher.c
@@ -37,7 +37,7 @@ extern "C"
 #include "./publisher_impl.h"
 
 rcl_publisher_t
-rcl_get_zero_initialized_publisher()
+rcl_get_zero_initialized_publisher(void)
 {
   static rcl_publisher_t null_publisher = {0};
   return null_publisher;
@@ -216,7 +216,7 @@ rcl_publisher_fini(rcl_publisher_t * publisher, rcl_node_t * node)
 }
 
 rcl_publisher_options_t
-rcl_publisher_get_default_options()
+rcl_publisher_get_default_options(void)
 {
   // !!! MAKE SURE THAT CHANGES TO THESE DEFAULTS ARE REFLECTED IN THE HEADER DOC STRING
   static rcl_publisher_options_t default_options;

--- a/rcl/src/rcl/service.c
+++ b/rcl/src/rcl/service.c
@@ -52,7 +52,7 @@ struct rcl_service_impl_s
 };
 
 rcl_service_t
-rcl_get_zero_initialized_service()
+rcl_get_zero_initialized_service(void)
 {
   static rcl_service_t null_service = {0};
   return null_service;
@@ -282,7 +282,7 @@ rcl_service_fini(rcl_service_t * service, rcl_node_t * node)
 }
 
 rcl_service_options_t
-rcl_service_get_default_options()
+rcl_service_get_default_options(void)
 {
   // !!! MAKE SURE THAT CHANGES TO THESE DEFAULTS ARE REFLECTED IN THE HEADER DOC STRING
   static rcl_service_options_t default_options;

--- a/rcl/src/rcl/service_event_publisher.c
+++ b/rcl/src/rcl/service_event_publisher.c
@@ -29,7 +29,7 @@
 #include "rmw/error_handling.h"
 #include "service_msgs/msg/service_event_info.h"
 
-rcl_service_event_publisher_t rcl_get_zero_initialized_service_event_publisher()
+rcl_service_event_publisher_t rcl_get_zero_initialized_service_event_publisher(void)
 {
   static rcl_service_event_publisher_t zero_service_event_publisher = {0};
   return zero_service_event_publisher;

--- a/rcl/src/rcl/service_event_publisher.h
+++ b/rcl/src/rcl/service_event_publisher.h
@@ -54,7 +54,7 @@ typedef struct rcl_service_event_publisher_s
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_service_event_publisher_t
-rcl_get_zero_initialized_service_event_publisher();
+rcl_get_zero_initialized_service_event_publisher(void);
 
 /// Initialize a service event publisher.
 /**

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -40,7 +40,7 @@ extern "C"
 
 
 rcl_subscription_t
-rcl_get_zero_initialized_subscription()
+rcl_get_zero_initialized_subscription(void)
 {
   static rcl_subscription_t null_subscription = {0};
   return null_subscription;
@@ -224,7 +224,7 @@ rcl_subscription_fini(rcl_subscription_t * subscription, rcl_node_t * node)
 }
 
 rcl_subscription_options_t
-rcl_subscription_get_default_options()
+rcl_subscription_get_default_options(void)
 {
   // !!! MAKE SURE THAT CHANGES TO THESE DEFAULTS ARE REFLECTED IN THE HEADER DOC STRING
   static rcl_subscription_options_t default_options;
@@ -382,7 +382,7 @@ failed:
 }
 
 rcl_subscription_content_filter_options_t
-rcl_get_zero_initialized_subscription_content_filter_options()
+rcl_get_zero_initialized_subscription_content_filter_options(void)
 {
   return (const rcl_subscription_content_filter_options_t) {
            .rmw_subscription_content_filter_options =

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -56,7 +56,7 @@ struct rcl_timer_impl_s
 };
 
 rcl_timer_t
-rcl_get_zero_initialized_timer()
+rcl_get_zero_initialized_timer(void)
 {
   static rcl_timer_t null_timer = {0};
   return null_timer;

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -61,7 +61,7 @@ struct rcl_wait_set_impl_s
 };
 
 rcl_wait_set_t
-rcl_get_zero_initialized_wait_set()
+rcl_get_zero_initialized_wait_set(void)
 {
   static rcl_wait_set_t null_wait_set = {
     .subscriptions = NULL,

--- a/rcl/test/rcl/test_wait.cpp
+++ b/rcl/test/rcl/test_wait.cpp
@@ -654,9 +654,7 @@ TEST_F(WaitSetTestFixture, multi_wait_set_threaded) {
       return false;
     };
   // *INDENT-ON*
-  size_t loop_count = 0;
   while (loop_test()) {
-    loop_count++;
     for (auto & test_set : test_sets) {
       ret = rcl_trigger_guard_condition(&test_set.guard_condition);
       ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;

--- a/rcl_lifecycle/include/rcl_lifecycle/rcl_lifecycle.h
+++ b/rcl_lifecycle/include/rcl_lifecycle/rcl_lifecycle.h
@@ -53,7 +53,7 @@ extern "C"
  */
 RCL_LIFECYCLE_PUBLIC
 rcl_lifecycle_state_t
-rcl_lifecycle_get_zero_initialized_state();
+rcl_lifecycle_get_zero_initialized_state(void);
 
 /// Initialize a rcl_lifecycle_state_init.
 /**
@@ -123,7 +123,7 @@ rcl_lifecycle_state_fini(
  */
 RCL_LIFECYCLE_PUBLIC
 rcl_lifecycle_transition_t
-rcl_lifecycle_get_zero_initialized_transition();
+rcl_lifecycle_get_zero_initialized_transition(void);
 
 /// Initialize a transition from a start state to the goal state.
 /**
@@ -197,7 +197,7 @@ rcl_lifecycle_transition_fini(
 /// Return a default initialized state machine options struct.
 RCL_LIFECYCLE_PUBLIC
 rcl_lifecycle_state_machine_options_t
-rcl_lifecycle_get_default_state_machine_options();
+rcl_lifecycle_get_default_state_machine_options(void);
 
 /// Return a rcl_lifecycle_state_machine_t struct with members set to `NULL` or 0.
 /**
@@ -206,7 +206,7 @@ rcl_lifecycle_get_default_state_machine_options();
  */
 RCL_LIFECYCLE_PUBLIC
 rcl_lifecycle_state_machine_t
-rcl_lifecycle_get_zero_initialized_state_machine();
+rcl_lifecycle_get_zero_initialized_state_machine(void);
 
 /// Initialize state machine
 /**

--- a/rcl_lifecycle/include/rcl_lifecycle/transition_map.h
+++ b/rcl_lifecycle/include/rcl_lifecycle/transition_map.h
@@ -35,7 +35,7 @@ extern "C"
 RCL_LIFECYCLE_PUBLIC
 RCL_WARN_UNUSED
 rcl_lifecycle_transition_map_t
-rcl_lifecycle_get_zero_initialized_transition_map();
+rcl_lifecycle_get_zero_initialized_transition_map(void);
 
 /// Check if a transition map is active using a rcl_lifecycle_state_machine_t.
 /*

--- a/rcl_lifecycle/src/com_interface.c
+++ b/rcl_lifecycle/src/com_interface.c
@@ -45,7 +45,7 @@ static const char * srv_get_available_transitions_service = "~/get_available_tra
 static const char * srv_get_transition_graph = "~/get_transition_graph";
 
 rcl_lifecycle_com_interface_t
-rcl_lifecycle_get_zero_initialized_com_interface()
+rcl_lifecycle_get_zero_initialized_com_interface(void)
 {
   rcl_lifecycle_com_interface_t com_interface;
   com_interface.node_handle = NULL;

--- a/rcl_lifecycle/src/com_interface.h
+++ b/rcl_lifecycle/src/com_interface.h
@@ -25,7 +25,7 @@ extern "C"
 #include "rcl_lifecycle/data_types.h"
 
 rcl_lifecycle_com_interface_t
-rcl_lifecycle_get_zero_initialized_com_interface();
+rcl_lifecycle_get_zero_initialized_com_interface(void);
 
 rcl_ret_t
 RCL_WARN_UNUSED

--- a/rcl_lifecycle/src/rcl_lifecycle.c
+++ b/rcl_lifecycle/src/rcl_lifecycle.c
@@ -37,7 +37,7 @@ extern "C"
 #include "./com_interface.h"
 
 rcl_lifecycle_state_t
-rcl_lifecycle_get_zero_initialized_state()
+rcl_lifecycle_get_zero_initialized_state(void)
 {
   rcl_lifecycle_state_t state;
   state.id = 0;
@@ -94,7 +94,7 @@ rcl_lifecycle_state_fini(
 }
 
 rcl_lifecycle_transition_t
-rcl_lifecycle_get_zero_initialized_transition()
+rcl_lifecycle_get_zero_initialized_transition(void)
 {
   rcl_lifecycle_transition_t transition;
   transition.id = 0;
@@ -168,7 +168,7 @@ rcl_lifecycle_transition_fini(
 }
 
 rcl_lifecycle_state_machine_options_t
-rcl_lifecycle_get_default_state_machine_options()
+rcl_lifecycle_get_default_state_machine_options(void)
 {
   rcl_lifecycle_state_machine_options_t options;
   options.enable_com_interface = true;
@@ -180,7 +180,7 @@ rcl_lifecycle_get_default_state_machine_options()
 
 // get zero initialized state machine here
 rcl_lifecycle_state_machine_t
-rcl_lifecycle_get_zero_initialized_state_machine()
+rcl_lifecycle_get_zero_initialized_state_machine(void)
 {
   rcl_lifecycle_state_machine_t state_machine;
   state_machine.current_state = NULL;

--- a/rcl_lifecycle/src/transition_map.c
+++ b/rcl_lifecycle/src/transition_map.c
@@ -28,7 +28,7 @@ extern "C"
 #include "rcl_lifecycle/transition_map.h"
 
 rcl_lifecycle_transition_map_t
-rcl_lifecycle_get_zero_initialized_transition_map()
+rcl_lifecycle_get_zero_initialized_transition_map(void)
 {
   static rcl_lifecycle_transition_map_t transition_map;
   transition_map.states = NULL;


### PR DESCRIPTION
There are new warnings on CI related with this compiler option `strict-prototypes`

https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/1860/gcc/new/