### PR TITLE
Removed deprecated rcl_init_timer()

### DIFF
--- a/rcl/include/rcl/timer.h
+++ b/rcl/include/rcl/timer.h
@@ -178,21 +178,6 @@ rcl_timer_init2(
   rcl_allocator_t allocator,
   bool autostart);
 
-/**
- * \deprecated `rcl_timer_init` implementation was removed.
- *   Refer to `rcl_timer_init2`.
- */
-RCL_PUBLIC
-RCUTILS_DEPRECATED_WITH_MSG("Call rcl_timer_init2 instead")
-rcl_ret_t
-rcl_timer_init(
-  rcl_timer_t * timer,
-  rcl_clock_t * clock,
-  rcl_context_t * context,
-  int64_t period,
-  const rcl_timer_callback_t callback,
-  rcl_allocator_t allocator);
-
 /// Finalize a timer.
 /**
  * This function will deallocate any memory and make the timer invalid.

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -127,20 +127,6 @@ void _rcl_timer_time_jump(
 }
 
 rcl_ret_t
-rcl_timer_init(
-  rcl_timer_t * timer,
-  rcl_clock_t * clock,
-  rcl_context_t * context,
-  int64_t period,
-  const rcl_timer_callback_t callback,
-  rcl_allocator_t allocator)
-{
-  return rcl_timer_init2(
-    timer, clock, context, period, callback,
-    allocator, true);
-}
-
-rcl_ret_t
 rcl_timer_init2(
   rcl_timer_t * timer,
   rcl_clock_t * clock,


### PR DESCRIPTION
Removed deprecated rcl_init_timer() deprecated since `jazzy`