### PR TITLE
Added remapping resolution for action names

### DIFF
--- a/rcl_action/CMakeLists.txt
+++ b/rcl_action/CMakeLists.txt
@@ -220,6 +220,20 @@ if(BUILD_TESTING)
       src
     )
   endif()
+  ament_add_gtest(test_action_name_remapping
+    test/rcl_action/test_action_name_remapping.cpp
+  )
+  if(TARGET test_action_name_remapping)
+    target_link_libraries(test_action_name_remapping
+      ${PROJECT_NAME}
+      osrf_testing_tools_cpp::memory_tools
+      rcl::rcl
+      ${test_msgs_TARGETS}
+    )
+    target_include_directories(test_action_name_remapping PRIVATE
+      src
+    )
+  endif()
 endif()
 
 # Export old-style CMake variables

--- a/rcl_action/src/rcl_action/action_client.c
+++ b/rcl_action/src/rcl_action/action_client.c
@@ -110,7 +110,7 @@ _rcl_action_client_fini_impl(
 // \internal Initializes an action client specific service client.
 #define CLIENT_INIT(Type) \
   char * Type ## _service_name = NULL; \
-  ret = rcl_action_get_ ## Type ## _service_name(action_name, allocator, &Type ## _service_name); \
+  ret = rcl_action_get_ ## Type ## _service_name(resolved_action_name, allocator, &Type ## _service_name); \
   if (RCL_RET_OK != ret) { \
     rcl_reset_error(); \
     RCL_SET_ERROR_MSG("failed to get " #Type " service name"); \
@@ -137,7 +137,7 @@ _rcl_action_client_fini_impl(
 // \internal Initializes an action client specific topic subscription.
 #define SUBSCRIPTION_INIT(Type) \
   char * Type ## _topic_name = NULL; \
-  ret = rcl_action_get_ ## Type ## _topic_name(action_name, allocator, &Type ## _topic_name); \
+  ret = rcl_action_get_ ## Type ## _topic_name(resolved_action_name, allocator, &Type ## _topic_name); \
   if (RCL_RET_OK != ret) { \
     rcl_reset_error(); \
     RCL_SET_ERROR_MSG("failed to get " #Type " topic name"); \
@@ -195,8 +195,19 @@ rcl_action_client_init(
 
   // Avoid uninitialized pointers should initialization fail
   *action_client->impl = _rcl_action_get_zero_initialized_client_impl();
+
+  // Remap/Expand the action name
+  char* resolved_action_name = NULL;
+  ret = rcl_node_resolve_name(node, action_name, allocator, false, false, &resolved_action_name);
+  if (RCL_RET_OK != ret) {
+    if (RCL_RET_TOPIC_NAME_INVALID == ret || RCL_RET_SERVICE_NAME_INVALID == ret) {
+      ret = RCL_RET_ACTION_NAME_INVALID;
+    }
+    goto fail;
+  }
+
   // Copy action client name and options.
-  action_client->impl->action_name = rcutils_strdup(action_name, allocator);
+  action_client->impl->action_name = rcutils_strdup(resolved_action_name, allocator);
   if (NULL == action_client->impl->action_name) {
     RCL_SET_ERROR_MSG("failed to duplicate action name");
     ret = RCL_RET_BAD_ALLOC;
@@ -213,6 +224,10 @@ rcl_action_client_init(
   SUBSCRIPTION_INIT(feedback);
   SUBSCRIPTION_INIT(status);
 
+  // The resolved action name is no longer needed
+  allocator.deallocate(resolved_action_name, allocator.state);
+  resolved_action_name = NULL;
+
   ret = rcl_node_type_cache_register_type(
       node, type_support->get_type_hash_func(type_support),
       type_support->get_type_description_func(type_support),
@@ -227,6 +242,12 @@ rcl_action_client_init(
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Action client initialized");
   return ret;
 fail:
+  // Deallocate the resolved action name
+  if (NULL != resolved_action_name)
+  {
+    allocator.deallocate(resolved_action_name, allocator.state);
+  }
+
   fini_ret = _rcl_action_client_fini_impl(action_client, node, allocator);
   if (RCL_RET_OK != fini_ret) {
     RCL_SET_ERROR_MSG("failed to cleanup action client");

--- a/rcl_action/src/rcl_action/action_client.c
+++ b/rcl_action/src/rcl_action/action_client.c
@@ -110,7 +110,8 @@ _rcl_action_client_fini_impl(
 // \internal Initializes an action client specific service client.
 #define CLIENT_INIT(Type) \
   char * Type ## _service_name = NULL; \
-  ret = rcl_action_get_ ## Type ## _service_name(resolved_action_name, allocator, &Type ## _service_name); \
+  ret = rcl_action_get_ ## Type ## _service_name( \
+    resolved_action_name, allocator, &Type ## _service_name); \
   if (RCL_RET_OK != ret) { \
     rcl_reset_error(); \
     RCL_SET_ERROR_MSG("failed to get " #Type " service name"); \
@@ -137,7 +138,8 @@ _rcl_action_client_fini_impl(
 // \internal Initializes an action client specific topic subscription.
 #define SUBSCRIPTION_INIT(Type) \
   char * Type ## _topic_name = NULL; \
-  ret = rcl_action_get_ ## Type ## _topic_name(resolved_action_name, allocator, &Type ## _topic_name); \
+  ret = rcl_action_get_ ## Type ## _topic_name( \
+    resolved_action_name, allocator, &Type ## _topic_name); \
   if (RCL_RET_OK != ret) { \
     rcl_reset_error(); \
     RCL_SET_ERROR_MSG("failed to get " #Type " topic name"); \
@@ -197,7 +199,7 @@ rcl_action_client_init(
   *action_client->impl = _rcl_action_get_zero_initialized_client_impl();
 
   // Remap/Expand the action name
-  char* resolved_action_name = NULL;
+  char * resolved_action_name = NULL;
   ret = rcl_node_resolve_name(node, action_name, allocator, false, false, &resolved_action_name);
   if (RCL_RET_OK != ret) {
     if (RCL_RET_TOPIC_NAME_INVALID == ret || RCL_RET_SERVICE_NAME_INVALID == ret) {
@@ -243,8 +245,7 @@ rcl_action_client_init(
   return ret;
 fail:
   // Deallocate the resolved action name
-  if (NULL != resolved_action_name)
-  {
+  if (NULL != resolved_action_name) {
     allocator.deallocate(resolved_action_name, allocator.state);
   }
 

--- a/rcl_action/src/rcl_action/action_client.c
+++ b/rcl_action/src/rcl_action/action_client.c
@@ -100,7 +100,7 @@ _rcl_action_client_fini_impl(
   {
     ret = RCL_RET_ERROR;
   }
-  allocator.deallocate(action_client->impl->action_name, allocator.state);
+  allocator.deallocate(action_client->impl->remapped_action_name, allocator.state);
   allocator.deallocate(action_client->impl, allocator.state);
   action_client->impl = NULL;
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Action client finalized");
@@ -211,8 +211,8 @@ rcl_action_client_init(
   }
 
   // Copy action client name and options.
-  action_client->impl->action_name = rcutils_strdup(resolved_action_name, allocator);
-  if (NULL == action_client->impl->action_name) {
+  action_client->impl->remapped_action_name = rcutils_strdup(resolved_action_name, allocator);
+  if (NULL == action_client->impl->remapped_action_name) {
     RCL_SET_ERROR_MSG("failed to duplicate action name");
     ret = RCL_RET_BAD_ALLOC;
     goto fail;
@@ -478,7 +478,7 @@ rcl_action_client_get_action_name(const rcl_action_client_t * action_client)
   if (!rcl_action_client_is_valid(action_client)) {
     return NULL;
   }
-  return action_client->impl->action_name;
+  return action_client->impl->remapped_action_name;
 }
 
 const rcl_action_client_options_t *

--- a/rcl_action/src/rcl_action/action_client.c
+++ b/rcl_action/src/rcl_action/action_client.c
@@ -111,7 +111,7 @@ _rcl_action_client_fini_impl(
 #define CLIENT_INIT(Type) \
   char * Type ## _service_name = NULL; \
   ret = rcl_action_get_ ## Type ## _service_name( \
-    resolved_action_name, allocator, &Type ## _service_name); \
+    action_client->impl->remapped_action_name, allocator, &Type ## _service_name); \
   if (RCL_RET_OK != ret) { \
     rcl_reset_error(); \
     RCL_SET_ERROR_MSG("failed to get " #Type " service name"); \
@@ -139,7 +139,7 @@ _rcl_action_client_fini_impl(
 #define SUBSCRIPTION_INIT(Type) \
   char * Type ## _topic_name = NULL; \
   ret = rcl_action_get_ ## Type ## _topic_name( \
-    resolved_action_name, allocator, &Type ## _topic_name); \
+    action_client->impl->remapped_action_name, allocator, &Type ## _topic_name); \
   if (RCL_RET_OK != ret) { \
     rcl_reset_error(); \
     RCL_SET_ERROR_MSG("failed to get " #Type " topic name"); \
@@ -199,8 +199,14 @@ rcl_action_client_init(
   *action_client->impl = _rcl_action_get_zero_initialized_client_impl();
 
   // Remap/Expand the action name
-  char * resolved_action_name = NULL;
-  ret = rcl_node_resolve_name(node, action_name, allocator, false, false, &resolved_action_name);
+  ret = rcl_node_resolve_name(
+    node,
+    action_name,
+    allocator,
+    false, false,
+    &action_client->impl->remapped_action_name
+  );
+
   if (RCL_RET_OK != ret) {
     if (RCL_RET_TOPIC_NAME_INVALID == ret || RCL_RET_UNKNOWN_SUBSTITUTION == ret) {
       ret = RCL_RET_ACTION_NAME_INVALID;
@@ -209,14 +215,13 @@ rcl_action_client_init(
     }
     goto fail;
   }
+  RCUTILS_LOG_DEBUG_NAMED(
+    ROS_PACKAGE_NAME,
+    "Remapped and expanded action name '%s'",
+    action_client->impl->remapped_action_name
+  );
 
   // Copy action client name and options.
-  action_client->impl->remapped_action_name = rcutils_strdup(resolved_action_name, allocator);
-  if (NULL == action_client->impl->remapped_action_name) {
-    RCL_SET_ERROR_MSG("failed to duplicate action name");
-    ret = RCL_RET_BAD_ALLOC;
-    goto fail;
-  }
   action_client->impl->options = *options;
 
   // Initialize action service clients.
@@ -227,10 +232,6 @@ rcl_action_client_init(
   // Initialize action topic subscriptions.
   SUBSCRIPTION_INIT(feedback);
   SUBSCRIPTION_INIT(status);
-
-  // The resolved action name is no longer needed
-  allocator.deallocate(resolved_action_name, allocator.state);
-  resolved_action_name = NULL;
 
   ret = rcl_node_type_cache_register_type(
       node, type_support->get_type_hash_func(type_support),
@@ -246,10 +247,6 @@ rcl_action_client_init(
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Action client initialized");
   return ret;
 fail:
-  // Deallocate the resolved action name
-  if (NULL != resolved_action_name) {
-    allocator.deallocate(resolved_action_name, allocator.state);
-  }
 
   fini_ret = _rcl_action_client_fini_impl(action_client, node, allocator);
   if (RCL_RET_OK != fini_ret) {

--- a/rcl_action/src/rcl_action/action_client.c
+++ b/rcl_action/src/rcl_action/action_client.c
@@ -202,8 +202,10 @@ rcl_action_client_init(
   char * resolved_action_name = NULL;
   ret = rcl_node_resolve_name(node, action_name, allocator, false, false, &resolved_action_name);
   if (RCL_RET_OK != ret) {
-    if (RCL_RET_TOPIC_NAME_INVALID == ret || RCL_RET_SERVICE_NAME_INVALID == ret) {
+    if (RCL_RET_TOPIC_NAME_INVALID == ret || RCL_RET_UNKNOWN_SUBSTITUTION == ret) {
       ret = RCL_RET_ACTION_NAME_INVALID;
+    } else if (RCL_RET_BAD_ALLOC != ret) {
+      ret = RCL_RET_ERROR;
     }
     goto fail;
   }

--- a/rcl_action/src/rcl_action/action_client_impl.h
+++ b/rcl_action/src/rcl_action/action_client_impl.h
@@ -26,7 +26,7 @@ typedef struct rcl_action_client_impl_s
   rcl_subscription_t feedback_subscription;
   rcl_subscription_t status_subscription;
   rcl_action_client_options_t options;
-  char * action_name;
+  char * remapped_action_name;
   // Wait set records
   size_t wait_set_goal_client_index;
   size_t wait_set_cancel_client_index;

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -51,7 +51,7 @@ rcl_action_get_zero_initialized_server(void)
 
 #define SERVICE_INIT(Type) \
   char * Type ## _service_name = NULL; \
-  ret = rcl_action_get_ ## Type ## _service_name(action_name, allocator, &Type ## _service_name); \
+  ret = rcl_action_get_ ## Type ## _service_name(resolved_action_name, allocator, &Type ## _service_name); \
   if (RCL_RET_OK != ret) { \
     rcl_reset_error(); \
     RCL_SET_ERROR_MSG("failed to get " #Type " service name"); \
@@ -76,7 +76,7 @@ rcl_action_get_zero_initialized_server(void)
 
 #define PUBLISHER_INIT(Type) \
   char * Type ## _topic_name = NULL; \
-  ret = rcl_action_get_ ## Type ## _topic_name(action_name, allocator, &Type ## _topic_name); \
+  ret = rcl_action_get_ ## Type ## _topic_name(resolved_action_name, allocator, &Type ## _topic_name); \
   if (RCL_RET_OK != ret) { \
     rcl_reset_error(); \
     RCL_SET_ERROR_MSG("failed to get " #Type " topic name"); \
@@ -150,6 +150,16 @@ rcl_action_server_init(
   action_server->impl->type_hash = rosidl_get_zero_initialized_type_hash();
 
   rcl_ret_t ret = RCL_RET_OK;
+  // Resolve action name
+  char* resolved_action_name = NULL;
+  ret = rcl_node_resolve_name(node, action_name, allocator, false, false, &resolved_action_name);
+  if (RCL_RET_OK != ret) {
+    if (RCL_RET_TOPIC_NAME_INVALID == ret || RCL_RET_SERVICE_NAME_INVALID == ret) {
+      ret = RCL_RET_ACTION_NAME_INVALID;
+    }
+    goto fail;
+  }
+
   // Initialize services
   SERVICE_INIT(goal);
   SERVICE_INIT(cancel);
@@ -171,11 +181,15 @@ rcl_action_server_init(
   }
 
   // Copy action name
-  action_server->impl->action_name = rcutils_strdup(action_name, allocator);
+  action_server->impl->action_name = rcutils_strdup(resolved_action_name, allocator);
   if (NULL == action_server->impl->action_name) {
     ret = RCL_RET_BAD_ALLOC;
     goto fail;
   }
+
+  // The resolved_action_name is no longer needed
+  allocator.deallocate(resolved_action_name, allocator.state);
+  resolved_action_name = NULL;
 
   // Store type hash
   ret = rcl_node_type_cache_register_type(
@@ -192,6 +206,11 @@ rcl_action_server_init(
   return ret;
 fail:
   {
+    // Deallocate the resolved action name
+    if (NULL != resolved_action_name)
+    {
+      allocator.deallocate(resolved_action_name, allocator.state);
+    }
     // Finalize any services/publishers that were initialized and deallocate action_server->impl
     rcl_ret_t ret_throwaway = rcl_action_server_fini(action_server, node);
     // Since there is already a failure, it is likely that finalize will error on one or more of

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -156,8 +156,10 @@ rcl_action_server_init(
   char * resolved_action_name = NULL;
   ret = rcl_node_resolve_name(node, action_name, allocator, false, false, &resolved_action_name);
   if (RCL_RET_OK != ret) {
-    if (RCL_RET_TOPIC_NAME_INVALID == ret || RCL_RET_SERVICE_NAME_INVALID == ret) {
+    if (RCL_RET_TOPIC_NAME_INVALID == ret || RCL_RET_UNKNOWN_SUBSTITUTION == ret) {
       ret = RCL_RET_ACTION_NAME_INVALID;
+    } else if (RCL_RET_BAD_ALLOC != ret) {
+      ret = RCL_RET_ERROR;
     }
     goto fail;
   }

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -52,7 +52,7 @@ rcl_action_get_zero_initialized_server(void)
 #define SERVICE_INIT(Type) \
   char * Type ## _service_name = NULL; \
   ret = rcl_action_get_ ## Type ## _service_name( \
-    resolved_action_name, allocator, &Type ## _service_name); \
+    action_server->impl->remapped_action_name, allocator, &Type ## _service_name); \
   if (RCL_RET_OK != ret) { \
     rcl_reset_error(); \
     RCL_SET_ERROR_MSG("failed to get " #Type " service name"); \
@@ -78,7 +78,7 @@ rcl_action_get_zero_initialized_server(void)
 #define PUBLISHER_INIT(Type) \
   char * Type ## _topic_name = NULL; \
   ret = rcl_action_get_ ## Type ## _topic_name( \
-    resolved_action_name, allocator, &Type ## _topic_name); \
+    action_server->impl->remapped_action_name, allocator, &Type ## _topic_name); \
   if (RCL_RET_OK != ret) { \
     rcl_reset_error(); \
     RCL_SET_ERROR_MSG("failed to get " #Type " topic name"); \
@@ -153,8 +153,14 @@ rcl_action_server_init(
 
   rcl_ret_t ret = RCL_RET_OK;
   // Resolve action name
-  char * resolved_action_name = NULL;
-  ret = rcl_node_resolve_name(node, action_name, allocator, false, false, &resolved_action_name);
+  ret = rcl_node_resolve_name(
+    node,
+    action_name,
+    allocator,
+    false, false,
+    &action_server->impl->remapped_action_name
+  );
+
   if (RCL_RET_OK != ret) {
     if (RCL_RET_TOPIC_NAME_INVALID == ret || RCL_RET_UNKNOWN_SUBSTITUTION == ret) {
       ret = RCL_RET_ACTION_NAME_INVALID;
@@ -163,6 +169,11 @@ rcl_action_server_init(
     }
     goto fail;
   }
+  RCUTILS_LOG_DEBUG_NAMED(
+    ROS_PACKAGE_NAME,
+    "Remapped and expanded action name '%s'",
+    action_server->impl->remapped_action_name
+  );
 
   // Initialize services
   SERVICE_INIT(goal);
@@ -184,17 +195,6 @@ rcl_action_server_init(
     goto fail;
   }
 
-  // Copy action name
-  action_server->impl->remapped_action_name = rcutils_strdup(resolved_action_name, allocator);
-  if (NULL == action_server->impl->remapped_action_name) {
-    ret = RCL_RET_BAD_ALLOC;
-    goto fail;
-  }
-
-  // The resolved_action_name is no longer needed
-  allocator.deallocate(resolved_action_name, allocator.state);
-  resolved_action_name = NULL;
-
   // Store type hash
   ret = rcl_node_type_cache_register_type(
       node, type_support->get_type_hash_func(type_support),
@@ -210,10 +210,6 @@ rcl_action_server_init(
   return ret;
 fail:
   {
-    // Deallocate the resolved action name
-    if (NULL != resolved_action_name) {
-      allocator.deallocate(resolved_action_name, allocator.state);
-    }
     // Finalize any services/publishers that were initialized and deallocate action_server->impl
     rcl_ret_t ret_throwaway = rcl_action_server_fini(action_server, node);
     // Since there is already a failure, it is likely that finalize will error on one or more of

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -144,7 +144,7 @@ rcl_action_server_init(
   action_server->impl->expire_timer = rcl_get_zero_initialized_timer();
   action_server->impl->feedback_publisher = rcl_get_zero_initialized_publisher();
   action_server->impl->status_publisher = rcl_get_zero_initialized_publisher();
-  action_server->impl->action_name = NULL;
+  action_server->impl->remapped_action_name = NULL;
   action_server->impl->options = *options;  // copy options
   action_server->impl->goal_handles = NULL;
   action_server->impl->num_goal_handles = 0u;
@@ -185,8 +185,8 @@ rcl_action_server_init(
   }
 
   // Copy action name
-  action_server->impl->action_name = rcutils_strdup(resolved_action_name, allocator);
-  if (NULL == action_server->impl->action_name) {
+  action_server->impl->remapped_action_name = rcutils_strdup(resolved_action_name, allocator);
+  if (NULL == action_server->impl->remapped_action_name) {
     ret = RCL_RET_BAD_ALLOC;
     goto fail;
   }
@@ -258,9 +258,9 @@ rcl_action_server_fini(rcl_action_server_t * action_server, rcl_node_t * node)
     action_server->impl->clock = NULL;
     // Deallocate action name
     rcl_allocator_t allocator = action_server->impl->options.allocator;
-    if (action_server->impl->action_name) {
-      allocator.deallocate(action_server->impl->action_name, allocator.state);
-      action_server->impl->action_name = NULL;
+    if (action_server->impl->remapped_action_name) {
+      allocator.deallocate(action_server->impl->remapped_action_name, allocator.state);
+      action_server->impl->remapped_action_name = NULL;
     }
     // Deallocate goal handles storage, but don't fini them.
     for (size_t i = 0; i < action_server->impl->num_goal_handles; ++i) {
@@ -904,7 +904,7 @@ rcl_action_server_get_action_name(const rcl_action_server_t * action_server)
   if (!rcl_action_server_is_valid(action_server)) {
     return NULL;  // error already set
   }
-  return action_server->impl->action_name;
+  return action_server->impl->remapped_action_name;
 }
 
 const rcl_action_server_options_t *

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -51,7 +51,8 @@ rcl_action_get_zero_initialized_server(void)
 
 #define SERVICE_INIT(Type) \
   char * Type ## _service_name = NULL; \
-  ret = rcl_action_get_ ## Type ## _service_name(resolved_action_name, allocator, &Type ## _service_name); \
+  ret = rcl_action_get_ ## Type ## _service_name( \
+    resolved_action_name, allocator, &Type ## _service_name); \
   if (RCL_RET_OK != ret) { \
     rcl_reset_error(); \
     RCL_SET_ERROR_MSG("failed to get " #Type " service name"); \
@@ -76,7 +77,8 @@ rcl_action_get_zero_initialized_server(void)
 
 #define PUBLISHER_INIT(Type) \
   char * Type ## _topic_name = NULL; \
-  ret = rcl_action_get_ ## Type ## _topic_name(resolved_action_name, allocator, &Type ## _topic_name); \
+  ret = rcl_action_get_ ## Type ## _topic_name( \
+    resolved_action_name, allocator, &Type ## _topic_name); \
   if (RCL_RET_OK != ret) { \
     rcl_reset_error(); \
     RCL_SET_ERROR_MSG("failed to get " #Type " topic name"); \
@@ -151,7 +153,7 @@ rcl_action_server_init(
 
   rcl_ret_t ret = RCL_RET_OK;
   // Resolve action name
-  char* resolved_action_name = NULL;
+  char * resolved_action_name = NULL;
   ret = rcl_node_resolve_name(node, action_name, allocator, false, false, &resolved_action_name);
   if (RCL_RET_OK != ret) {
     if (RCL_RET_TOPIC_NAME_INVALID == ret || RCL_RET_SERVICE_NAME_INVALID == ret) {
@@ -207,8 +209,7 @@ rcl_action_server_init(
 fail:
   {
     // Deallocate the resolved action name
-    if (NULL != resolved_action_name)
-    {
+    if (NULL != resolved_action_name) {
       allocator.deallocate(resolved_action_name, allocator.state);
     }
     // Finalize any services/publishers that were initialized and deallocate action_server->impl

--- a/rcl_action/src/rcl_action/action_server_impl.h
+++ b/rcl_action/src/rcl_action/action_server_impl.h
@@ -27,7 +27,7 @@ typedef struct rcl_action_server_impl_s
   rcl_publisher_t feedback_publisher;
   rcl_publisher_t status_publisher;
   rcl_timer_t expire_timer;
-  char * action_name;
+  char * remapped_action_name;
   rcl_action_server_options_t options;
   // Array of goal handles
   rcl_action_goal_handle_t ** goal_handles;

--- a/rcl_action/test/rcl_action/arg_macros.hpp
+++ b/rcl_action/test/rcl_action/arg_macros.hpp
@@ -1,0 +1,81 @@
+// Copyright 2018 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef RCL_ACTION__ARG_MACROS_HPP_
+#define RCL_ACTION__ARG_MACROS_HPP_
+
+#include "osrf_testing_tools_cpp/scope_exit.hpp"
+
+#include "rcl/error_handling.h"
+#include "rcl/rcl.h"
+#include "rcutils/strdup.h"
+
+/// Helper to get around non-const args passed to rcl_init().
+char **
+copy_args(int argc, const char ** args)
+{
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  char ** copy = static_cast<char **>(allocator.allocate(sizeof(char *) * argc, allocator.state));
+  for (int i = 0; i < argc; ++i) {
+    copy[i] = rcutils_strdup(args[i], allocator);
+  }
+  return copy;
+}
+
+/// Destroy args allocated by copy_args.
+void
+destroy_args(int argc, char ** args)
+{
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  for (int i = 0; i < argc; ++i) {
+    allocator.deallocate(args[i], allocator.state);
+  }
+  allocator.deallocate(args, allocator.state);
+}
+
+#define SCOPE_GLOBAL_ARGS(argc, argv, ...) \
+  rcl_init_options_t init_options = rcl_get_zero_initialized_init_options(); \
+  ASSERT_EQ(RCL_RET_OK, rcl_init_options_init(&init_options, rcl_get_default_allocator())) \
+    << rcl_get_error_string().str; \
+  rcl_context_t context = rcl_get_zero_initialized_context(); \
+  { \
+    const char * const_argv[] = {__VA_ARGS__}; \
+    argc = (sizeof(const_argv) / sizeof(const char *)); \
+    argv = copy_args(argc, const_argv); \
+    rcl_ret_t ret = rcl_init(argc, argv, &init_options, &context); \
+    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str; \
+  } \
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT( \
+  { \
+    EXPECT_EQ(RCL_RET_OK, rcl_init_options_fini(&init_options)) << rcl_get_error_string().str; \
+    destroy_args(argc, argv); \
+    ASSERT_EQ(RCL_RET_OK, rcl_shutdown(&context)) << rcl_get_error_string().str; \
+    ASSERT_EQ(RCL_RET_OK, rcl_context_fini(&context)) << rcl_get_error_string().str; \
+  })
+
+#define SCOPE_ARGS(local_arguments, ...) \
+  { \
+    local_arguments = rcl_get_zero_initialized_arguments(); \
+    const char * local_argv[] = {__VA_ARGS__}; \
+    unsigned int local_argc = (sizeof(local_argv) / sizeof(const char *)); \
+    rcl_ret_t ret = rcl_parse_arguments( \
+      local_argc, local_argv, rcl_get_default_allocator(), &local_arguments); \
+    ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str; \
+  } \
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT( \
+  { \
+    ASSERT_EQ(RCL_RET_OK, rcl_arguments_fini(&local_arguments)); \
+  })
+
+#endif  // RCL_ACTION__ARG_MACROS_HPP_

--- a/rcl_action/test/rcl_action/test_action_client.cpp
+++ b/rcl_action/test/rcl_action/test_action_client.cpp
@@ -240,7 +240,7 @@ protected:
     TestActionClientBaseFixture::TearDown();
   }
 
-  const char * const action_name = "test_action_client_name";
+  const char * const action_name = "/test_action_client_name";
   rcl_action_client_options_t action_client_options;
   rcl_action_client_t invalid_action_client;
   rcl_action_client_t action_client;

--- a/rcl_action/test/rcl_action/test_action_name_remapping.cpp
+++ b/rcl_action/test/rcl_action/test_action_name_remapping.cpp
@@ -1,0 +1,175 @@
+// Copyright 2024 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+#include <rcl/error_handling.h>
+#include <rcl_action/rcl_action.h>
+#include "test_msgs/action/fibonacci.h"
+#include "arg_macros.hpp"
+
+class TestActionNameRemappingFixture : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+  }
+
+  void TearDown() override
+  {
+  }
+};
+
+TEST_F(TestActionNameRemappingFixture, test_action_client_name_remapping) {
+  // Check that remapping works with global args passed to rcl_init
+  int argc;
+  char ** argv;
+
+  SCOPE_GLOBAL_ARGS(
+    argc, argv,
+    "process_name",
+    "--ros-args",
+    "-r", "__node:=new_name",
+    "-r", "__ns:=/new_ns",
+    "-r", "/foo/bar:=/bar/foo");
+
+  rcl_node_t node = rcl_get_zero_initialized_node();
+  rcl_node_options_t default_options = rcl_node_get_default_options();
+  ASSERT_EQ(
+    RCL_RET_OK,
+    rcl_node_init(&node, "original_name", "/original_ns", &context, &default_options));
+
+  // Absolute names should be unchanged
+  {
+    const rcl_action_client_options_t action_client_options =
+      rcl_action_client_get_default_options();
+    const rosidl_action_type_support_t * action_typesupport =
+      ROSIDL_GET_ACTION_TYPE_SUPPORT(test_msgs, Fibonacci);
+    rcl_action_client_t client = rcl_action_get_zero_initialized_client();
+    rcl_ret_t ret = rcl_action_client_init(
+      &client, &node, action_typesupport, "/absolute_name", &action_client_options);
+    ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+    EXPECT_STREQ("/absolute_name",
+      rcl_action_client_get_action_name(&client)) << rcl_get_error_string().str;
+    EXPECT_EQ(RCL_RET_OK, rcl_action_client_fini(&client, &node)) << rcl_get_error_string().str;
+  }
+
+  // Namespace relative names should work
+  {
+    const rcl_action_client_options_t action_client_options =
+      rcl_action_client_get_default_options();
+    const rosidl_action_type_support_t * action_typesupport =
+      ROSIDL_GET_ACTION_TYPE_SUPPORT(test_msgs, Fibonacci);
+    rcl_action_client_t client = rcl_action_get_zero_initialized_client();
+    rcl_ret_t ret = rcl_action_client_init(
+      &client, &node, action_typesupport, "ns_relative_name", &action_client_options);
+    ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+    EXPECT_STREQ("/new_ns/ns_relative_name",
+      rcl_action_client_get_action_name(&client)) << rcl_get_error_string().str;
+    EXPECT_EQ(RCL_RET_OK, rcl_action_client_fini(&client, &node)) << rcl_get_error_string().str;
+  }
+
+  // Node relative names should work
+  {
+    const rcl_action_client_options_t action_client_options =
+      rcl_action_client_get_default_options();
+    const rosidl_action_type_support_t * action_typesupport =
+      ROSIDL_GET_ACTION_TYPE_SUPPORT(test_msgs, Fibonacci);
+    rcl_action_client_t client = rcl_action_get_zero_initialized_client();
+    rcl_ret_t ret = rcl_action_client_init(
+      &client, &node, action_typesupport, "~/node_relative_name", &action_client_options);
+    ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+    EXPECT_STREQ("/new_ns/new_name/node_relative_name",
+      rcl_action_client_get_action_name(&client)) << rcl_get_error_string().str;
+    EXPECT_EQ(RCL_RET_OK, rcl_action_client_fini(&client, &node)) << rcl_get_error_string().str;
+  }
+
+  EXPECT_EQ(RCL_RET_OK, rcl_node_fini(&node)) << rcl_get_error_string().str;
+}
+
+TEST_F(TestActionNameRemappingFixture, test_action_server_name_remapping) {
+  // Check that remapping works with global args passed to rcl_init
+  int argc;
+  char ** argv;
+
+  SCOPE_GLOBAL_ARGS(
+    argc, argv,
+    "process_name",
+    "--ros-args",
+    "-r", "__node:=new_name",
+    "-r", "__ns:=/new_ns",
+    "-r", "/foo/bar:=/bar/foo");
+
+  rcl_node_t node = rcl_get_zero_initialized_node();
+  rcl_node_options_t default_options = rcl_node_get_default_options();
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  rcl_clock_t clock;
+  rcl_ret_t ret = rcl_clock_init(RCL_STEADY_TIME, &clock, &allocator);
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ASSERT_EQ(
+    RCL_RET_OK,
+    rcl_node_init(&node, "original_name", "/original_ns", &context, &default_options)
+  );
+
+  // Absolute names should be unchanged
+  {
+    const rcl_action_server_options_t action_server_options =
+      rcl_action_server_get_default_options();
+    const rosidl_action_type_support_t * action_typesupport =
+      ROSIDL_GET_ACTION_TYPE_SUPPORT(test_msgs, Fibonacci);
+    rcl_action_server_t server = rcl_action_get_zero_initialized_server();
+    ret = rcl_action_server_init(
+      &server, &node, &clock, action_typesupport, "/absolute_name", &action_server_options);
+    ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+    EXPECT_STREQ(
+      "/absolute_name",
+      rcl_action_server_get_action_name(&server)
+    ) << rcl_get_error_string().str;
+    EXPECT_EQ(RCL_RET_OK, rcl_action_server_fini(&server, &node)) << rcl_get_error_string().str;
+  }
+
+  // Namespace relative names should work
+  {
+    const rcl_action_server_options_t action_server_options =
+      rcl_action_server_get_default_options();
+    const rosidl_action_type_support_t * action_typesupport =
+      ROSIDL_GET_ACTION_TYPE_SUPPORT(test_msgs, Fibonacci);
+    rcl_action_server_t server = rcl_action_get_zero_initialized_server();
+    ret = rcl_action_server_init(
+      &server, &node, &clock, action_typesupport, "ns_relative_name", &action_server_options);
+    ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+    EXPECT_STREQ(
+      "/new_ns/ns_relative_name",
+      rcl_action_server_get_action_name(&server)
+    ) << rcl_get_error_string().str;
+    EXPECT_EQ(RCL_RET_OK, rcl_action_server_fini(&server, &node)) << rcl_get_error_string().str;
+  }
+
+  // Node relative names should work
+  {
+    const rcl_action_server_options_t action_server_options =
+      rcl_action_server_get_default_options();
+    const rosidl_action_type_support_t * action_typesupport =
+      ROSIDL_GET_ACTION_TYPE_SUPPORT(test_msgs, Fibonacci);
+    rcl_action_server_t server = rcl_action_get_zero_initialized_server();
+    ret = rcl_action_server_init(
+      &server, &node, &clock, action_typesupport, "~/node_relative_name", &action_server_options);
+    ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+    EXPECT_STREQ(
+      "/new_ns/new_name/node_relative_name",
+      rcl_action_server_get_action_name(&server)
+    ) << rcl_get_error_string().str;
+    EXPECT_EQ(RCL_RET_OK, rcl_action_server_fini(&server, &node)) << rcl_get_error_string().str;
+    EXPECT_EQ(RCL_RET_OK, rcl_node_fini(&node)) << rcl_get_error_string().str;
+  }
+}

--- a/rcl_action/test/rcl_action/test_action_name_remapping.cpp
+++ b/rcl_action/test/rcl_action/test_action_name_remapping.cpp
@@ -49,7 +49,7 @@ TEST_F(TestActionNameRemappingFixture, test_action_client_name_remapping) {
     RCL_RET_OK,
     rcl_node_init(&node, "original_name", "/original_ns", &context, &default_options));
 
-  // Absolute names should be unchanged
+  // Absolute name that should be unchanged
   {
     const rcl_action_client_options_t action_client_options =
       rcl_action_client_get_default_options();
@@ -60,6 +60,21 @@ TEST_F(TestActionNameRemappingFixture, test_action_client_name_remapping) {
       &client, &node, action_typesupport, "/absolute_name", &action_client_options);
     ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
     EXPECT_STREQ("/absolute_name",
+      rcl_action_client_get_action_name(&client)) << rcl_get_error_string().str;
+    EXPECT_EQ(RCL_RET_OK, rcl_action_client_fini(&client, &node)) << rcl_get_error_string().str;
+  }
+
+  // Absolute name that should change
+  {
+    const rcl_action_client_options_t action_client_options =
+      rcl_action_client_get_default_options();
+    const rosidl_action_type_support_t * action_typesupport =
+      ROSIDL_GET_ACTION_TYPE_SUPPORT(test_msgs, Fibonacci);
+    rcl_action_client_t client = rcl_action_get_zero_initialized_client();
+    rcl_ret_t ret = rcl_action_client_init(
+      &client, &node, action_typesupport, "/foo/bar", &action_client_options);
+    ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+    EXPECT_STREQ("/bar/foo",
       rcl_action_client_get_action_name(&client)) << rcl_get_error_string().str;
     EXPECT_EQ(RCL_RET_OK, rcl_action_client_fini(&client, &node)) << rcl_get_error_string().str;
   }
@@ -97,6 +112,98 @@ TEST_F(TestActionNameRemappingFixture, test_action_client_name_remapping) {
   EXPECT_EQ(RCL_RET_OK, rcl_node_fini(&node)) << rcl_get_error_string().str;
 }
 
+TEST_F(TestActionNameRemappingFixture, test_action_client_name_remapping_local_rules) {
+  // Check that remapping works with local args passed to rcl_node_init
+  int argc;
+  char ** argv;
+
+  SCOPE_GLOBAL_ARGS(
+    argc, argv,
+    "process_name",
+    "--ros-args",
+    "-r", "__node:=global_name",
+    "-r", "__ns:=/global_ns",
+    "-r", "/foo/bar:=/bar/foo");
+
+  rcl_arguments_t local_arguments;
+  SCOPE_ARGS(
+    local_arguments,
+    "process_name",
+    "--ros-args",
+    "-r", "__node:=local_name",
+    "-r", "__ns:=/local_ns",
+    "-r", "/foo/bar:=/bar/local");
+
+  rcl_node_t node = rcl_get_zero_initialized_node();
+  rcl_node_options_t options = rcl_node_get_default_options();
+  options.arguments = local_arguments;
+  ASSERT_EQ(
+    RCL_RET_OK,
+    rcl_node_init(&node, "original_name", "/original_ns", &context, &options));
+
+  // Absolute name that should be unchanged
+  {
+    const rcl_action_client_options_t action_client_options =
+      rcl_action_client_get_default_options();
+    const rosidl_action_type_support_t * action_typesupport =
+      ROSIDL_GET_ACTION_TYPE_SUPPORT(test_msgs, Fibonacci);
+    rcl_action_client_t client = rcl_action_get_zero_initialized_client();
+    rcl_ret_t ret = rcl_action_client_init(
+      &client, &node, action_typesupport, "/absolute_name", &action_client_options);
+    ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+    EXPECT_STREQ("/absolute_name",
+      rcl_action_client_get_action_name(&client)) << rcl_get_error_string().str;
+    EXPECT_EQ(RCL_RET_OK, rcl_action_client_fini(&client, &node)) << rcl_get_error_string().str;
+  }
+
+  // Absolute name that should change
+  {
+    const rcl_action_client_options_t action_client_options =
+      rcl_action_client_get_default_options();
+    const rosidl_action_type_support_t * action_typesupport =
+      ROSIDL_GET_ACTION_TYPE_SUPPORT(test_msgs, Fibonacci);
+    rcl_action_client_t client = rcl_action_get_zero_initialized_client();
+    rcl_ret_t ret = rcl_action_client_init(
+      &client, &node, action_typesupport, "/foo/bar", &action_client_options);
+    ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+    EXPECT_STREQ("/bar/local",
+      rcl_action_client_get_action_name(&client)) << rcl_get_error_string().str;
+    EXPECT_EQ(RCL_RET_OK, rcl_action_client_fini(&client, &node)) << rcl_get_error_string().str;
+  }
+
+  // Namespace relative names should work
+  {
+    const rcl_action_client_options_t action_client_options =
+      rcl_action_client_get_default_options();
+    const rosidl_action_type_support_t * action_typesupport =
+      ROSIDL_GET_ACTION_TYPE_SUPPORT(test_msgs, Fibonacci);
+    rcl_action_client_t client = rcl_action_get_zero_initialized_client();
+    rcl_ret_t ret = rcl_action_client_init(
+      &client, &node, action_typesupport, "ns_relative_name", &action_client_options);
+    ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+    EXPECT_STREQ("/local_ns/ns_relative_name",
+      rcl_action_client_get_action_name(&client)) << rcl_get_error_string().str;
+    EXPECT_EQ(RCL_RET_OK, rcl_action_client_fini(&client, &node)) << rcl_get_error_string().str;
+  }
+
+  // Node relative names should work
+  {
+    const rcl_action_client_options_t action_client_options =
+      rcl_action_client_get_default_options();
+    const rosidl_action_type_support_t * action_typesupport =
+      ROSIDL_GET_ACTION_TYPE_SUPPORT(test_msgs, Fibonacci);
+    rcl_action_client_t client = rcl_action_get_zero_initialized_client();
+    rcl_ret_t ret = rcl_action_client_init(
+      &client, &node, action_typesupport, "~/node_relative_name", &action_client_options);
+    ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+    EXPECT_STREQ("/local_ns/local_name/node_relative_name",
+      rcl_action_client_get_action_name(&client)) << rcl_get_error_string().str;
+    EXPECT_EQ(RCL_RET_OK, rcl_action_client_fini(&client, &node)) << rcl_get_error_string().str;
+  }
+
+  EXPECT_EQ(RCL_RET_OK, rcl_node_fini(&node)) << rcl_get_error_string().str;
+}
+
 TEST_F(TestActionNameRemappingFixture, test_action_server_name_remapping) {
   // Check that remapping works with global args passed to rcl_init
   int argc;
@@ -121,7 +228,7 @@ TEST_F(TestActionNameRemappingFixture, test_action_server_name_remapping) {
     rcl_node_init(&node, "original_name", "/original_ns", &context, &default_options)
   );
 
-  // Absolute names should be unchanged
+  // Absolute name that should be unchanged
   {
     const rcl_action_server_options_t action_server_options =
       rcl_action_server_get_default_options();
@@ -133,6 +240,23 @@ TEST_F(TestActionNameRemappingFixture, test_action_server_name_remapping) {
     ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
     EXPECT_STREQ(
       "/absolute_name",
+      rcl_action_server_get_action_name(&server)
+    ) << rcl_get_error_string().str;
+    EXPECT_EQ(RCL_RET_OK, rcl_action_server_fini(&server, &node)) << rcl_get_error_string().str;
+  }
+
+  // Absolute name that should change
+  {
+    const rcl_action_server_options_t action_server_options =
+      rcl_action_server_get_default_options();
+    const rosidl_action_type_support_t * action_typesupport =
+      ROSIDL_GET_ACTION_TYPE_SUPPORT(test_msgs, Fibonacci);
+    rcl_action_server_t server = rcl_action_get_zero_initialized_server();
+    ret = rcl_action_server_init(
+      &server, &node, &clock, action_typesupport, "/foo/bar", &action_server_options);
+    ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+    EXPECT_STREQ(
+      "/bar/foo",
       rcl_action_server_get_action_name(&server)
     ) << rcl_get_error_string().str;
     EXPECT_EQ(RCL_RET_OK, rcl_action_server_fini(&server, &node)) << rcl_get_error_string().str;
@@ -170,6 +294,111 @@ TEST_F(TestActionNameRemappingFixture, test_action_server_name_remapping) {
       rcl_action_server_get_action_name(&server)
     ) << rcl_get_error_string().str;
     EXPECT_EQ(RCL_RET_OK, rcl_action_server_fini(&server, &node)) << rcl_get_error_string().str;
-    EXPECT_EQ(RCL_RET_OK, rcl_node_fini(&node)) << rcl_get_error_string().str;
   }
+  EXPECT_EQ(RCL_RET_OK, rcl_node_fini(&node)) << rcl_get_error_string().str;
+}
+
+TEST_F(TestActionNameRemappingFixture, test_action_server_name_remapping_local_rules) {
+  // Check that remapping works with local args passed to rcl_init
+  int argc;
+  char ** argv;
+
+  SCOPE_GLOBAL_ARGS(
+    argc, argv,
+    "process_name",
+    "--ros-args",
+    "-r", "__node:=global_name",
+    "-r", "__ns:=/global_ns",
+    "-r", "/foo/bar:=/bar/global");
+
+  rcl_arguments_t local_arguments;
+  SCOPE_ARGS(
+    local_arguments,
+    "process_name",
+    "--ros-args",
+    "-r", "__node:=local_name",
+    "-r", "__ns:=/local_ns",
+    "-r", "/foo/bar:=/bar/local");
+
+  rcl_node_t node = rcl_get_zero_initialized_node();
+  rcl_node_options_t options = rcl_node_get_default_options();
+  options.arguments = local_arguments;
+
+  rcl_allocator_t allocator = rcl_get_default_allocator();
+  rcl_clock_t clock;
+  rcl_ret_t ret = rcl_clock_init(RCL_STEADY_TIME, &clock, &allocator);
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  ASSERT_EQ(
+    RCL_RET_OK,
+    rcl_node_init(&node, "original_name", "/original_ns", &context, &options)
+  );
+
+  // Absolute name that should be unchanged
+  {
+    const rcl_action_server_options_t action_server_options =
+      rcl_action_server_get_default_options();
+    const rosidl_action_type_support_t * action_typesupport =
+      ROSIDL_GET_ACTION_TYPE_SUPPORT(test_msgs, Fibonacci);
+    rcl_action_server_t server = rcl_action_get_zero_initialized_server();
+    ret = rcl_action_server_init(
+      &server, &node, &clock, action_typesupport, "/absolute_name", &action_server_options);
+    ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+    EXPECT_STREQ(
+      "/absolute_name",
+      rcl_action_server_get_action_name(&server)
+    ) << rcl_get_error_string().str;
+    EXPECT_EQ(RCL_RET_OK, rcl_action_server_fini(&server, &node)) << rcl_get_error_string().str;
+  }
+
+  // Absolute name that should change
+  {
+    const rcl_action_server_options_t action_server_options =
+      rcl_action_server_get_default_options();
+    const rosidl_action_type_support_t * action_typesupport =
+      ROSIDL_GET_ACTION_TYPE_SUPPORT(test_msgs, Fibonacci);
+    rcl_action_server_t server = rcl_action_get_zero_initialized_server();
+    ret = rcl_action_server_init(
+      &server, &node, &clock, action_typesupport, "/foo/bar", &action_server_options);
+    ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+    EXPECT_STREQ(
+      "/bar/local",
+      rcl_action_server_get_action_name(&server)
+    ) << rcl_get_error_string().str;
+    EXPECT_EQ(RCL_RET_OK, rcl_action_server_fini(&server, &node)) << rcl_get_error_string().str;
+  }
+
+  // Namespace relative names should work
+  {
+    const rcl_action_server_options_t action_server_options =
+      rcl_action_server_get_default_options();
+    const rosidl_action_type_support_t * action_typesupport =
+      ROSIDL_GET_ACTION_TYPE_SUPPORT(test_msgs, Fibonacci);
+    rcl_action_server_t server = rcl_action_get_zero_initialized_server();
+    ret = rcl_action_server_init(
+      &server, &node, &clock, action_typesupport, "ns_relative_name", &action_server_options);
+    ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+    EXPECT_STREQ(
+      "/local_ns/ns_relative_name",
+      rcl_action_server_get_action_name(&server)
+    ) << rcl_get_error_string().str;
+    EXPECT_EQ(RCL_RET_OK, rcl_action_server_fini(&server, &node)) << rcl_get_error_string().str;
+  }
+
+  // Node relative names should work
+  {
+    const rcl_action_server_options_t action_server_options =
+      rcl_action_server_get_default_options();
+    const rosidl_action_type_support_t * action_typesupport =
+      ROSIDL_GET_ACTION_TYPE_SUPPORT(test_msgs, Fibonacci);
+    rcl_action_server_t server = rcl_action_get_zero_initialized_server();
+    ret = rcl_action_server_init(
+      &server, &node, &clock, action_typesupport, "~/node_relative_name", &action_server_options);
+    ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+    EXPECT_STREQ(
+      "/local_ns/local_name/node_relative_name",
+      rcl_action_server_get_action_name(&server)
+    ) << rcl_get_error_string().str;
+    EXPECT_EQ(RCL_RET_OK, rcl_action_server_fini(&server, &node)) << rcl_get_error_string().str;
+  }
+  EXPECT_EQ(RCL_RET_OK, rcl_node_fini(&node)) << rcl_get_error_string().str;
 }

--- a/rcl_action/test/rcl_action/test_action_server.cpp
+++ b/rcl_action/test/rcl_action/test_action_server.cpp
@@ -783,7 +783,7 @@ TEST_F(TestActionServer, test_action_server_get_action_name)
   // Get action_name for a valid action server
   action_name = rcl_action_server_get_action_name(&this->action_server);
   ASSERT_NE(action_name, nullptr) << rcl_get_error_string().str;
-  EXPECT_STREQ(action_name, "test_action_server_name");
+  EXPECT_STREQ(action_name, "/test_action_server_name");
 }
 
 TEST_F(TestActionServer, test_action_server_get_options)


### PR DESCRIPTION
Currently remapping of action names is not possible see  https://github.com/ros2/ros2/issues/1312 .
I have now stumbled over this multiple times and I think it is a useful feature, so i took a shot at implementing the remapping of action names. Please let me know if you have any comments or if I overlooked something.
Fixes https://github.com/ros2/ros2/issues/1312.