### PR TITLE
Make transition event topic reliable to avoid topic lost

### DIFF
--- a/rcl_lifecycle/src/com_interface.c
+++ b/rcl_lifecycle/src/com_interface.c
@@ -108,6 +108,9 @@ rcl_lifecycle_com_interface_publisher_init(
 
   // initialize publisher
   rcl_publisher_options_t publisher_options = rcl_publisher_get_default_options();
+  publisher_options.qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  publisher_options.qos.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+  publisher_options.qos.depth = 1;
   rcl_ret_t ret = rcl_publisher_init(
     &com_interface->pub_transition_event, node_handle,
     ts_pub_notify, pub_transition_event_topic, &publisher_options);

--- a/rcl_lifecycle/src/com_interface.c
+++ b/rcl_lifecycle/src/com_interface.c
@@ -108,7 +108,6 @@ rcl_lifecycle_com_interface_publisher_init(
 
   // initialize publisher
   rcl_publisher_options_t publisher_options = rcl_publisher_get_default_options();
-  publisher_options.qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   // transition event topic needs to be latched for the subscription joins later.
   publisher_options.qos.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
   publisher_options.qos.depth = 1;

--- a/rcl_lifecycle/src/com_interface.c
+++ b/rcl_lifecycle/src/com_interface.c
@@ -109,6 +109,7 @@ rcl_lifecycle_com_interface_publisher_init(
   // initialize publisher
   rcl_publisher_options_t publisher_options = rcl_publisher_get_default_options();
   publisher_options.qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  // transition event topic needs to be latched for the subscription joins later.
   publisher_options.qos.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
   publisher_options.qos.depth = 1;
   rcl_ret_t ret = rcl_publisher_init(

--- a/rcl_lifecycle/src/com_interface.c
+++ b/rcl_lifecycle/src/com_interface.c
@@ -113,7 +113,6 @@ rcl_lifecycle_com_interface_publisher_init(
 
   // initialize publisher
   rcl_publisher_options_t publisher_options = rcl_publisher_get_default_options();
-  publisher_options.qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
   // transition event topic needs to be latched for the subscription joins later.
   publisher_options.qos.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
   publisher_options.qos.depth = 1;

--- a/rcl_lifecycle/src/com_interface.c
+++ b/rcl_lifecycle/src/com_interface.c
@@ -114,6 +114,7 @@ rcl_lifecycle_com_interface_publisher_init(
   // initialize publisher
   rcl_publisher_options_t publisher_options = rcl_publisher_get_default_options();
   publisher_options.qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  // transition event topic needs to be latched for the subscription joins later.
   publisher_options.qos.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
   publisher_options.qos.depth = 1;
   rcl_ret_t ret = rcl_publisher_init(

--- a/rcl_lifecycle/src/com_interface.c
+++ b/rcl_lifecycle/src/com_interface.c
@@ -113,6 +113,9 @@ rcl_lifecycle_com_interface_publisher_init(
 
   // initialize publisher
   rcl_publisher_options_t publisher_options = rcl_publisher_get_default_options();
+  publisher_options.qos.reliability = RMW_QOS_POLICY_RELIABILITY_RELIABLE;
+  publisher_options.qos.durability = RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL;
+  publisher_options.qos.depth = 1;
   rcl_ret_t ret = rcl_publisher_init(
     &com_interface->pub_transition_event, node_handle,
     ts_pub_notify, pub_transition_event_topic, &publisher_options);


### PR DESCRIPTION
This PR is related to #1166.
Lifecycle action of launch_ros occasionally fails to transit because of topic event lost.
This PR make transition event topic reliable.
After the marge of this PR, I will make a PR for launch_ros.