### PR TITLE
No need to add public symbol visibility macros in implementation.

### DIFF
--- a/rcl/src/rcl/discovery_options.c
+++ b/rcl/src/rcl/discovery_options.c
@@ -86,7 +86,6 @@ rcl_get_automatic_discovery_range(rmw_discovery_options_t * discovery_options)
   return RCL_RET_OK;
 }
 
-RCL_PUBLIC
 const char *
 rcl_automatic_discovery_range_to_string(rmw_automatic_discovery_range_t automatic_discovery_range)
 {

--- a/rcl/src/rcl/dynamic_message_type_support.c
+++ b/rcl/src/rcl/dynamic_message_type_support.c
@@ -32,8 +32,6 @@ extern "C"
 
 
 /// Initialize a rosidl_message_type_support_t from a TypeDescription message
-RCL_PUBLIC
-RCL_WARN_UNUSED
 rcl_ret_t
 rcl_dynamic_message_type_support_handle_init(
   const char * serialization_lib_name,
@@ -113,8 +111,6 @@ rcl_dynamic_message_type_support_handle_init(
   return RCL_RET_OK;
 }
 
-RCL_PUBLIC
-RCL_WARN_UNUSED
 rcl_ret_t
 rcl_dynamic_message_type_support_handle_fini(rosidl_message_type_support_t * ts)
 {

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -248,8 +248,6 @@ rcl_timer_fini(rcl_timer_t * timer)
   return result;
 }
 
-RCL_PUBLIC
-RCL_WARN_UNUSED
 rcl_ret_t
 rcl_timer_clock(const rcl_timer_t * timer, rcl_clock_t ** clock)
 {

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -101,8 +101,6 @@ rcl_action_get_zero_initialized_server(void)
     goto fail; \
   }
 
-RCL_ACTION_PUBLIC
-RCL_WARN_UNUSED
 rcl_ret_t
 rcl_action_server_init(
   rcl_action_server_t * action_server,
@@ -1186,8 +1184,6 @@ rcl_action_server_wait_set_get_entities_ready(
   return RCL_RET_OK;
 }
 
-RCL_ACTION_PUBLIC
-RCL_WARN_UNUSED
 rcl_ret_t
 rcl_action_server_set_goal_service_callback(
   const rcl_action_server_t * action_server,
@@ -1204,8 +1200,6 @@ rcl_action_server_set_goal_service_callback(
     user_data);
 }
 
-RCL_ACTION_PUBLIC
-RCL_WARN_UNUSED
 rcl_ret_t
 rcl_action_server_set_result_service_callback(
   const rcl_action_server_t * action_server,
@@ -1222,8 +1216,6 @@ rcl_action_server_set_result_service_callback(
     user_data);
 }
 
-RCL_ACTION_PUBLIC
-RCL_WARN_UNUSED
 rcl_ret_t
 rcl_action_server_set_cancel_service_callback(
   const rcl_action_server_t * action_server,


### PR DESCRIPTION
cosmetic fix to remove unnecessary symbol visibility macros from the implementation.