### PR TITLE
add rcl_print_transition_map.

### DIFF
--- a/rcl_lifecycle/include/rcl_lifecycle/rcl_lifecycle.h
+++ b/rcl_lifecycle/include/rcl_lifecycle/rcl_lifecycle.h
@@ -443,7 +443,7 @@ rcl_print_state_machine(const rcl_lifecycle_state_machine_t * state_machine);
  * Uses Atomics       | No
  * Lock-Free          | Yes
  *
- * \param[in] state_machine pointer to the state machine struct to print the transition map
+ * \param[in] transition_map pointer to the transition map to print
  */
 RCL_LIFECYCLE_PUBLIC
 void

--- a/rcl_lifecycle/include/rcl_lifecycle/rcl_lifecycle.h
+++ b/rcl_lifecycle/include/rcl_lifecycle/rcl_lifecycle.h
@@ -411,39 +411,27 @@ rcl_lifecycle_trigger_transition_by_label(
   const char * label,
   bool publish_notification);
 
-/// Print the state machine data
+/// Log the state machine data
 /**
- * This function will print in the standard output the data in the
+ * This function will log the all data in the state machine
  * rcl_lifecycle_state_machine_t struct.
  *
- * <hr>
- * Attribute          | Adherence
- * ------------------ | -------------
- * Allocates Memory   | No
- * Thread-Safe        | No
- * Uses Atomics       | No
- * Lock-Free          | Yes
+ * the logging level must be INFO or a more verbose level (e.g., DEBUG).
  *
- * \param[in] state_machine pointer to the state machine struct to print
+ * \param[in] state_machine pointer to the state machine struct to log
  */
 RCL_LIFECYCLE_PUBLIC
 void
 rcl_print_state_machine(const rcl_lifecycle_state_machine_t * state_machine);
 
-/// Print the transition map
+/// Log the transition map
 /**
- * This function will print in the standard output the transition map
- * of the rcl_lifecycle_state_machine_t struct.
+ * This function will log the all data in the transition map
+ * rcl_lifecycle_state_machine_t struct.
  *
- * <hr>
- * Attribute          | Adherence
- * ------------------ | -------------
- * Allocates Memory   | No
- * Thread-Safe        | No
- * Uses Atomics       | No
- * Lock-Free          | Yes
+ * the logging level must be INFO or a more verbose level (e.g., DEBUG).
  *
- * \param[in] transition_map pointer to the transition map to print
+ * \param[in] transition_map pointer to the transition map to log
  */
 RCL_LIFECYCLE_PUBLIC
 void

--- a/rcl_lifecycle/include/rcl_lifecycle/rcl_lifecycle.h
+++ b/rcl_lifecycle/include/rcl_lifecycle/rcl_lifecycle.h
@@ -430,6 +430,25 @@ RCL_LIFECYCLE_PUBLIC
 void
 rcl_print_state_machine(const rcl_lifecycle_state_machine_t * state_machine);
 
+/// Print the transition map
+/**
+ * This function will print in the standard output the transition map
+ * of the rcl_lifecycle_state_machine_t struct.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] state_machine pointer to the state machine struct to print the transition map
+ */
+RCL_LIFECYCLE_PUBLIC
+void
+rcl_print_transition_map(const rcl_lifecycle_transition_map_t * transition_map);
+
 #ifdef __cplusplus
 }
 #endif  // extern "C"

--- a/rcl_lifecycle/src/rcl_lifecycle.c
+++ b/rcl_lifecycle/src/rcl_lifecycle.c
@@ -428,6 +428,26 @@ rcl_print_state_machine(const rcl_lifecycle_state_machine_t * state_machine)
     }
   }
 }
+
+void
+rcl_print_transition_map(const rcl_lifecycle_transition_map_t * transition_map)
+{
+  RCL_CHECK_FOR_NULL_WITH_MSG(transition_map, "transition map is null.", return);
+
+  RCUTILS_LOG_INFO_NAMED(
+    ROS_PACKAGE_NAME,
+    "Transition Map contains %u transitions: ", transition_map->transitions_size);
+
+  for (size_t i = 0; i < transition_map->transitions_size; ++i) {
+    const rcl_lifecycle_transition_t * transition = &transition_map->transitions[i];
+    RCUTILS_LOG_INFO_NAMED(
+      ROS_PACKAGE_NAME,
+      "\tTransition: %s (ID: %u) -> Start State: %s -> Goal State: %s",
+      transition->label, transition->id,
+      transition->start ? transition->start->label : "NULL",
+      transition->goal ? transition->goal->label : "NULL");
+  }
+}
 #ifdef __cplusplus
 }
 #endif  // extern "C"

--- a/rcl_lifecycle/test/test_rcl_lifecycle.cpp
+++ b/rcl_lifecycle/test/test_rcl_lifecycle.cpp
@@ -482,6 +482,8 @@ TEST(TestRclLifecycle, state_transitions) {
 
   rcl_print_state_machine(&state_machine);
   EXPECT_FALSE(rcutils_error_is_set());
+  rcl_print_transition_map(&state_machine.transition_map);
+  EXPECT_FALSE(rcutils_error_is_set());
 
   ret = rcl_lifecycle_state_machine_fini(&state_machine, &node);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;


### PR DESCRIPTION
i was doing some debug related to rcl_lifecycle state control, and this was useful to see the all registered transition table.