### PR TITLE
Set envars to run tests with rmw_zenoh_cpp with multicast discovery

### DIFF
--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -182,11 +182,10 @@ function(test_target)
   set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
 
   # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+  # Note: This is a temporary change that will be reverted before we branch into Kilted.
   if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
     list(APPEND rmw_implementation_env_var
-      ZENOH_ROUTER_CHECK_ATTEMPTS=-1
       ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-      RUST_LOG=z=error
     )
   endif()
 

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -181,14 +181,14 @@ function(test_target)
   message(STATUS "Creating tests for '${rmw_implementation}'")
   set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
 
-# If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
-if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
-  list(APPEND rmw_implementation_env_var
-    ZENOH_ROUTER_CHECK_ATTEMPTS=-1
-    ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-    RUST_LOG=z=error
-  )
-endif()
+  # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+  if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
+    list(APPEND rmw_implementation_env_var
+      ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+      ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
+      RUST_LOG=z=error
+    )
+  endif()
 
   # Gtests
   ament_add_gtest_test(test_client

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -181,6 +181,15 @@ function(test_target)
   message(STATUS "Creating tests for '${rmw_implementation}'")
   set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
 
+# If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
+  list(APPEND rmw_implementation_env_var
+    ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+    ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
+    RUST_LOG=z=error
+  )
+endif()
+
   # Gtests
   ament_add_gtest_test(test_client
     TEST_NAME test_client${target_suffix}

--- a/rcl_action/CMakeLists.txt
+++ b/rcl_action/CMakeLists.txt
@@ -137,11 +137,10 @@ if(BUILD_TESTING)
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
 
     # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    # Note: This is a temporary change that will be reverted before we branch into Kilted.
     if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
       list(APPEND rmw_implementation_env_var
-        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
         ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-        RUST_LOG=z=error
       )
     endif()
 

--- a/rcl_action/CMakeLists.txt
+++ b/rcl_action/CMakeLists.txt
@@ -136,6 +136,15 @@ if(BUILD_TESTING)
     message(STATUS "Creating tests for '${rmw_implementation}'")
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
 
+    # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
+    if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
+      list(APPEND rmw_implementation_env_var
+        ZENOH_ROUTER_CHECK_ATTEMPTS=-1
+        ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
+        RUST_LOG=z=error
+      )
+    endif()
+
     ament_add_gtest_test(test_action_communication
       TEST_NAME test_action_communication${target_suffix}
       ENV ${rmw_implementation_env_var}


### PR DESCRIPTION
 See https://github.com/ros2/rmw_zenoh/issues/567

To test this PR, we can run the usual CI jobs to show there are no regressions and additionally run a CI job with a copy of the ros2.repos file from https://github.com/ros2/ros2/pull/1649 with CI Scripts branch set to yadu/cargo