### PR TITLE
Added rcl_timer_get_next_call_time (#1146)

### DIFF
--- a/rcl/include/rcl/timer.h
+++ b/rcl/include/rcl/timer.h
@@ -325,6 +325,30 @@ RCL_WARN_UNUSED
 rcl_ret_t
 rcl_timer_get_time_until_next_call(const rcl_timer_t * timer, int64_t * time_until_next_call);
 
+/// Retrieve the time when the next call to rcl_timer_call() shall occur.
+/**
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | Yes
+ * Uses Atomics       | Yes
+ * Lock-Free          | Yes [1]
+ * <i>[1] if `atomic_is_lock_free()` returns true for `atomic_int_least64_t`</i>
+ *
+ * \param[in] timer the handle to the timer that is being queried
+ * \param[out] next_call_time the output variable for the result
+ * \return #RCL_RET_OK if the timer until next call was successfully calculated, or
+ * \return #RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or
+ * \return #RCL_RET_TIMER_INVALID if the timer->impl is invalid, or
+ * \return #RCL_RET_TIMER_CANCELED if the timer is canceled, or
+ * \return #RCL_RET_ERROR an unspecified error occur.
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_timer_get_next_call_time(const rcl_timer_t * timer, int64_t * next_call_time);
+
 /// Retrieve the time since the previous call to rcl_timer_call() occurred.
 /**
  * This function calculates the time since the last call and copies it into

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -310,6 +310,22 @@ rcl_timer_is_ready(const rcl_timer_t * timer, bool * is_ready)
 }
 
 rcl_ret_t
+rcl_timer_get_next_call_time(const rcl_timer_t * timer, int64_t * next_call_time)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(timer, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_ARGUMENT_FOR_NULL(timer->impl, RCL_RET_TIMER_INVALID);
+  RCL_CHECK_ARGUMENT_FOR_NULL(next_call_time, RCL_RET_INVALID_ARGUMENT);
+
+  if (rcutils_atomic_load_bool(&timer->impl->canceled)) {
+    return RCL_RET_TIMER_CANCELED;
+  }
+
+  *next_call_time =
+    rcutils_atomic_load_int64_t(&timer->impl->next_call_time);
+  return RCL_RET_OK;
+}
+
+rcl_ret_t
 rcl_timer_get_time_until_next_call(const rcl_timer_t * timer, int64_t * time_until_next_call)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(timer, RCL_RET_INVALID_ARGUMENT);

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -497,6 +497,10 @@ TEST_F(TestTimerFixture, test_canceled_timer) {
   ret = rcl_timer_cancel(&timer);
   ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
+  int64_t next_call_time = 0;
+  ret = rcl_timer_get_next_call_time(&timer, &next_call_time);
+  EXPECT_EQ(RCL_RET_TIMER_CANCELED, ret) << rcl_get_error_string().str;
+
   int64_t time_until_next_call = 0;
   ret = rcl_timer_get_time_until_next_call(&timer, &time_until_next_call);
   EXPECT_EQ(RCL_RET_TIMER_CANCELED, ret) << rcl_get_error_string().str;
@@ -903,4 +907,26 @@ TEST_F(TestPreInitTimer, test_time_since_last_call) {
   std::this_thread::sleep_for(std::chrono::milliseconds(1));
   ASSERT_EQ(RCL_RET_OK, rcl_timer_get_time_since_last_call(&timer, &time_sice_next_call_end));
   EXPECT_GT(time_sice_next_call_end, time_sice_next_call_start);
+}
+
+TEST_F(TestPreInitTimer, test_next_call_time) {
+  int64_t next_call_time_start = 0;
+  int64_t next_call_time_end = 0;
+  times_called = 0;
+
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_timer_get_next_call_time(nullptr, &next_call_time_start));
+  rcl_reset_error();
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_timer_get_next_call_time(&timer, nullptr));
+  rcl_reset_error();
+
+  ASSERT_EQ(RCL_RET_OK, rcl_timer_get_next_call_time(&timer, &next_call_time_start)) <<
+    rcl_get_error_string().str;
+
+  // move the next call time one period forward
+  ASSERT_EQ(RCL_RET_OK, rcl_timer_call(&timer)) << rcl_get_error_string().str;
+  EXPECT_EQ(times_called, 1);
+
+  ASSERT_EQ(RCL_RET_OK, rcl_timer_get_next_call_time(&timer, &next_call_time_end)) <<
+    rcl_get_error_string().str;
+  EXPECT_EQ(RCL_S_TO_NS(1), next_call_time_end - next_call_time_start);
 }


### PR DESCRIPTION
Add function `rcl_timer_get_next_call_time` to support humble backport of rclpy EventsExecutor (ros2/rclpy#1454).

Cherry-picked from commit 2e9549c0301a0d390eea7f3d2b9251626e03b376 (#1146)