### PR TITLE
rcl_yaml_param_parser: add support for binary tag to load byte array parameter

### DIFF
--- a/rcl_yaml_param_parser/src/impl/add_to_arrays.h
+++ b/rcl_yaml_param_parser/src/impl/add_to_arrays.h
@@ -69,10 +69,6 @@ rcutils_ret_t add_val_to_string_arr(
   char * value,
   const rcutils_allocator_t allocator);
 
-///
-/// TODO (anup.pemmaiah): Support byte array
-///
-
 #ifdef __cplusplus
 }
 #endif

--- a/rcl_yaml_param_parser/src/impl/types.h
+++ b/rcl_yaml_param_parser/src/impl/types.h
@@ -45,7 +45,8 @@ typedef enum data_types_e
   DATA_TYPE_BOOL = 1U,
   DATA_TYPE_INT64 = 2U,
   DATA_TYPE_DOUBLE = 3U,
-  DATA_TYPE_STRING = 4U
+  DATA_TYPE_STRING = 4U,
+  DATA_TYPE_BYTE = 5U
 } data_types_t;
 
 typedef enum namespace_type_e

--- a/rcl_yaml_param_parser/src/parse.c
+++ b/rcl_yaml_param_parser/src/parse.c
@@ -20,11 +20,13 @@
 #include <yaml.h>
 
 #include "rcutils/allocator.h"
+#include "rcutils/base64.h"
 #include "rcutils/error_handling.h"
 #include "rcutils/format_string.h"
 #include "rcutils/strdup.h"
 #include "rcutils/types/rcutils_ret.h"
 #include "rcutils/types/string_array.h"
+#include "rcutils/types/uint8_array.h"
 
 #include "rmw/error_handling.h"
 #include "rmw/validate_namespace.h"
@@ -36,6 +38,9 @@
 #include "./impl/node_params.h"
 #include "rcl_yaml_param_parser/parser.h"
 #include "rcl_yaml_param_parser/visibility_control.h"
+
+/// The tag @c !!binary for binary values. Not defined in libyaml
+#define BINARY_TAG          "tag:yaml.org,2002:binary"
 
 ///
 /// Check a name space whether it is valid
@@ -138,6 +143,24 @@ _get_float_value(
   const rcutils_allocator_t allocator);
 
 ///
+/// Get a binary array when it is valid
+///
+/// \param[in] value a base64 encoded string
+/// \param[out] val_type the value type
+/// \param[out] ret_val the converted rcl_byte_array_t when value is valid
+/// \param[in] allocator the allocator to use
+/// \return RCUTILS_RET_OK if value is valid, or
+/// \return RCUTILS_RET_ERROR if value is not valid
+/// \return RCUTILS_RET_BAD_ALLOC if memory allocation fails
+RCL_YAML_PARAM_PARSER_LOCAL
+rcutils_ret_t
+_get_binary_array(
+  const char * const value,
+  data_types_t * val_type,
+  void ** ret_val,
+  const rcutils_allocator_t allocator);
+
+///
 /// Determine the type of the value and return the converted value
 /// NOTE: Only canonical forms supported as of now
 ///
@@ -190,7 +213,16 @@ void * get_value(
       }
     }
 
-    /// YAML_NULL_TAG, YAML_TIMESTAMP_TAG and "tag:yaml.org,2002:binary" are not supported
+    /// Check for binary tag
+    if (strcmp(BINARY_TAG, (char *)tag) == 0) {
+      if (_get_binary_array(value, val_type, &ret_val, allocator) == RCUTILS_RET_OK) {
+        return ret_val;
+      } else {
+        return NULL;
+      }
+    }
+
+    /// YAML_NULL_TAG and YAML_TIMESTAMP_TAG are not supported
     return NULL;
   }
 
@@ -456,6 +488,32 @@ rcutils_ret_t parse_value(
         }
       }
       break;
+    case DATA_TYPE_BYTE:
+      if (is_seq) {
+        RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
+        "Byte array must be encoded as a base64 string, not a sequence, "
+        "cannot parse value %s at line %d\n",
+        value, line_num);
+        ret = RCUTILS_RET_ERROR;
+        allocator.deallocate(ret_val, allocator.state);
+      } else {
+        // Overwriting, deallocate original
+        if (NULL != param_value->byte_array_value) {
+          if (NULL != param_value->byte_array_value->values) {
+            allocator.deallocate(param_value->byte_array_value->values, allocator.state);
+          }
+          allocator.deallocate(param_value->byte_array_value, allocator.state);
+          param_value->byte_array_value = NULL;
+        }
+        param_value->byte_array_value = (rcl_byte_array_t *)ret_val;
+      }
+      break;
+    default:
+      RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
+        "Unknown data type of value %s at line %d", value, line_num);
+      ret = RCUTILS_RET_ERROR;
+      allocator.deallocate(ret_val, allocator.state);
+      break;
   }
   return ret;
 }
@@ -659,6 +717,37 @@ _get_bool_value(
   }
 
   return RCUTILS_RET_ERROR;
+}
+
+rcutils_ret_t
+_get_binary_array(
+  const char * const value,
+  data_types_t * val_type,
+  void ** ret_val,
+  const rcutils_allocator_t allocator)
+{
+  rcutils_uint8_array_t byte_array = rcutils_get_zero_initialized_uint8_array();
+
+  if (RCUTILS_RET_OK != rcutils_decode_base64(value, &byte_array, &allocator)) {
+    return RCUTILS_RET_ERROR;
+  }
+
+  // ret_val will be a rcl_byte_array_t*
+  rcl_byte_array_t * dst = allocator.zero_allocate(1U, sizeof(rcl_byte_array_t), allocator.state);
+  if (NULL == dst) {
+    if (NULL != byte_array.buffer) {
+      allocator.deallocate(byte_array.buffer, allocator.state);
+    }
+    return RCUTILS_RET_BAD_ALLOC;
+  }
+
+  // Transfer ownership of the decoded buffer to dst without extra allocation.
+  dst->values = byte_array.buffer;
+  dst->size = byte_array.buffer_length;
+
+  *val_type = DATA_TYPE_BYTE;
+  *ret_val = dst;
+  return RCUTILS_RET_OK;
 }
 
 rcutils_ret_t

--- a/rcl_yaml_param_parser/src/parser.c
+++ b/rcl_yaml_param_parser/src/parser.c
@@ -407,6 +407,16 @@ void rcl_yaml_node_struct_print(
               printf(": %lf\n", *(param_var->double_value));
             } else if (NULL != param_var->string_value) {
               printf(": %s\n", param_var->string_value);
+            } else if (NULL != param_var->byte_array_value) {
+              printf(": ");
+              for (size_t i = 0; i < param_var->byte_array_value->size; i++) {
+                if (param_var->byte_array_value->values) {
+                  printf(
+                    "0x%02x, ",
+                    param_var->byte_array_value->values[i]);
+                }
+              }
+              printf("\n");
             } else if (NULL != param_var->bool_array_value) {
               printf(": ");
               for (size_t i = 0; i < param_var->bool_array_value->size; i++) {

--- a/rcl_yaml_param_parser/src/yaml_variant.c
+++ b/rcl_yaml_param_parser/src/yaml_variant.c
@@ -80,6 +80,12 @@ void rcl_yaml_variant_fini(
   } else if (NULL != param_var->string_value) {
     allocator.deallocate(param_var->string_value, allocator.state);
     param_var->string_value = NULL;
+  } else if (NULL != param_var->byte_array_value) {
+    if (NULL != param_var->byte_array_value->values) {
+      allocator.deallocate(param_var->byte_array_value->values, allocator.state);
+    }
+    allocator.deallocate(param_var->byte_array_value, allocator.state);
+    param_var->byte_array_value = NULL;
   } else if (NULL != param_var->bool_array_value) {
     if (NULL != param_var->bool_array_value->values) {
       allocator.deallocate(param_var->bool_array_value->values, allocator.state);
@@ -132,6 +138,10 @@ bool rcl_yaml_variant_copy(
       RCUTILS_SAFE_FWRITE_TO_STDERR("Error allocating variant mem when copying string_value\n");
       return false;
     }
+  } else if (NULL != param_var->byte_array_value) {
+    RCL_YAML_VARIANT_COPY_ARRAY_VALUE(
+      out_param_var->byte_array_value, param_var->byte_array_value, allocator,
+      rcl_byte_array_t, uint8_t);
   } else if (NULL != param_var->bool_array_value) {
     RCL_YAML_VARIANT_COPY_ARRAY_VALUE(
       out_param_var->bool_array_value, param_var->bool_array_value, allocator,

--- a/rcl_yaml_param_parser/test/benchmark/benchmark_variant.cpp
+++ b/rcl_yaml_param_parser/test/benchmark/benchmark_variant.cpp
@@ -121,6 +121,45 @@ BENCHMARK_F(PerformanceTest, string_copy_variant)(benchmark::State & st)
   }
 }
 
+BENCHMARK_F(PerformanceTest, array_byte_copy_variant)(benchmark::State & st)
+{
+  rcl_variant_t src_variant{};
+  rcl_variant_t dest_variant{};
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  using ArrayT = std::remove_pointer<decltype(src_variant.byte_array_value)>::type;
+  src_variant.byte_array_value =
+    static_cast<ArrayT *>(allocator.allocate(sizeof(ArrayT), allocator.state));
+  if (src_variant.byte_array_value == nullptr) {
+    st.SkipWithError("Failed to allocate byte_array_value");
+    return;
+  }
+  using ValueT = std::remove_pointer<decltype(src_variant.byte_array_value->values)>::type;
+  src_variant.byte_array_value->values =
+    static_cast<ValueT *>(
+    allocator.zero_allocate(kSize, sizeof(ValueT), allocator.state));
+  if (src_variant.byte_array_value->values == nullptr) {
+    allocator.deallocate(src_variant.byte_array_value, allocator.state);
+    st.SkipWithError("Failed to allocate byte_array_value->values");
+    return;
+  }
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    rcl_yaml_variant_fini(&src_variant, allocator);
+    rcl_yaml_variant_fini(&dest_variant, allocator);
+  });
+  src_variant.byte_array_value->size = kSize;
+
+  reset_heap_counters();
+
+  for (auto _ : st) {
+    RCUTILS_UNUSED(_);
+    if (!rcl_yaml_variant_copy(&dest_variant, &src_variant, allocator)) {
+      st.SkipWithError(rcutils_get_error_string().str);
+    }
+    rcl_yaml_variant_fini(&dest_variant, allocator);
+  }
+}
+
 BENCHMARK_F(PerformanceTest, array_bool_copy_variant)(benchmark::State & st)
 {
   rcl_variant_t src_variant{};

--- a/rcl_yaml_param_parser/test/correct_config.yaml
+++ b/rcl_yaml_param_parser/test/correct_config.yaml
@@ -85,3 +85,6 @@ seq_tag:
 map_tag:
   ros__parameters:
     map_test: !!map {str: string, bool: true, int: 10, float: 1.1}
+binary_tag:
+  ros__parameters:
+    byte_array: !!binary AQID

--- a/rcl_yaml_param_parser/test/test_parse.cpp
+++ b/rcl_yaml_param_parser/test/test_parse.cpp
@@ -16,6 +16,8 @@
 
 #include <yaml.h>
 
+#include <cstring>
+
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcl_yaml_param_parser/parser.h"
 #include "../src/impl/parse.h"
@@ -116,6 +118,39 @@ TEST(TestParse, parse_value) {
   allocator.deallocate(
     params_st->params[node_idx].parameter_values[parameter_idx].string_value, allocator.state);
   params_st->params[node_idx].parameter_values[parameter_idx].string_value = nullptr;
+
+  // byte value
+  yaml_char_t byte_value[] = "AQID";  // [0x01, 0x02, 0x03]
+  const size_t byte_value_length = strlen((const char *)byte_value);
+  event.data.scalar.value = byte_value;
+  event.data.scalar.length = byte_value_length;
+  // Set tag, needed to parse base64 encoded binary
+  yaml_char_t tag_value[] = "tag:yaml.org,2002:binary";
+  event.data.scalar.tag = tag_value;
+
+  seq_data_type = DATA_TYPE_UNKNOWN;
+  EXPECT_EQ(
+    RCUTILS_RET_OK,
+    parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
+    rcutils_get_error_string().str;
+  ASSERT_NE(
+    nullptr, params_st->params[node_idx].parameter_values[parameter_idx].byte_array_value);
+  EXPECT_EQ(
+    params_st->params[node_idx].parameter_values[parameter_idx].byte_array_value->size, 3);
+  EXPECT_EQ(
+    params_st->params[node_idx].parameter_values[parameter_idx].byte_array_value->values[0], 1);
+  EXPECT_EQ(
+    params_st->params[node_idx].parameter_values[parameter_idx].byte_array_value->values[1], 2);
+  EXPECT_EQ(
+    params_st->params[node_idx].parameter_values[parameter_idx].byte_array_value->values[2], 3);
+  allocator.deallocate(
+    params_st->params[node_idx].parameter_values[parameter_idx].byte_array_value->values,
+    allocator.state);
+  allocator.deallocate(
+    params_st->params[node_idx].parameter_values[parameter_idx].byte_array_value, allocator.state);
+  params_st->params[node_idx].parameter_values[parameter_idx].byte_array_value = nullptr;
+  // reset tag
+  event.data.scalar.tag = NULL;
 }
 
 TEST(TestParse, parse_value_sequence) {
@@ -154,7 +189,7 @@ TEST(TestParse, parse_value_sequence) {
     rcutils_get_error_string().str;
   EXPECT_EQ(
     nullptr,
-    params_st->params[node_idx].parameter_values[parameter_idx].integer_array_value);
+    params_st->params[node_idx].parameter_values[parameter_idx].bool_array_value);
   rcutils_reset_error();
 
   // Check proper sequence type
@@ -281,6 +316,21 @@ TEST(TestParse, parse_value_sequence) {
     params_st->params[node_idx].parameter_values[parameter_idx].string_array_value,
     allocator.state);
   params_st->params[node_idx].parameter_values[parameter_idx].string_array_value = nullptr;
+
+  // byte array value cannot be parsed, byte array is encoded as a base64 string, not a sequence
+  yaml_char_t byte_value[] = "AQID";  // [0x01, 0x02, 0x03]
+  const size_t byte_value_length = strlen((const char *)byte_value);
+  event.data.scalar.value = byte_value;
+  event.data.scalar.length = byte_value_length;
+  // Set tag, needed to parse base64 encoded binary
+  yaml_char_t tag_value[] = "tag:yaml.org,2002:binary";
+  event.data.scalar.tag = tag_value;
+  seq_data_type = DATA_TYPE_UNKNOWN;
+  EXPECT_EQ(
+    RCUTILS_RET_ERROR,
+    parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st));
+  rcutils_reset_error();
+  event.data.scalar.tag = NULL;
 }
 
 TEST(TestParse, parse_value_bad_args) {

--- a/rcl_yaml_param_parser/test/test_parse_yaml.cpp
+++ b/rcl_yaml_param_parser/test/test_parse_yaml.cpp
@@ -332,6 +332,15 @@ TEST(test_parser, correct_syntax) {
     ASSERT_TRUE(NULL != param_value->double_value);
     EXPECT_DOUBLE_EQ(1.1, *param_value->double_value);
 
+    param_value = rcl_yaml_node_struct_get("binary_tag", "byte_array", params);
+    ASSERT_TRUE(NULL != param_value) << rcutils_get_error_string().str;
+    ASSERT_TRUE(NULL != param_value->byte_array_value);
+    EXPECT_EQ(3, param_value->byte_array_value->size);
+    size_t i = 0;
+    for (i = 0; i < param_value->byte_array_value->size; i++) {
+      EXPECT_EQ(i + 1, param_value->byte_array_value->values[i]);
+    }
+
     rcl_yaml_node_struct_print(params);
   }
 }

--- a/rcl_yaml_param_parser/test/test_yaml_variant.cpp
+++ b/rcl_yaml_param_parser/test/test_yaml_variant.cpp
@@ -134,6 +134,11 @@ TEST(TestYamlVariant, copy_string_value) {
   EXPECT_STREQ(tmp_string, dest_variant.string_value);
 }
 
+TEST(TestYamlVariant, copy_byte_array_values) {
+  constexpr uint8_t byte_array[] = {0x01, 0x02, 0x03};
+  TEST_VARIANT_ARRAY_COPY(byte_array_value, byte_array);
+}
+
 TEST(TestYamlVariant, copy_bool_array_values) {
   constexpr bool bool_arry[] = {true, false, true};
   TEST_VARIANT_ARRAY_COPY(bool_array_value, bool_arry);


### PR DESCRIPTION
## Description

When a parameter is declared as an array of bytes (`std::vector<uint8_t>`), passing an array of integers in the command line or in a YAML file is interpreted by the YAML parser as an array of integers and produces an error.

To workaround this, I have used a base64 encoded string with the the `!!binary` tag as shown in the [YAML specification](https://yaml.org/spec/1.2.2/#24-tags).

Example:
```
ros2 run pkg_name exe_name --ros-args -p 'my_param:=!!binary AAECAw=='
```

Note that this implementation adds a dependency on OpenSSL which might not be acceptable (and the ugly global variable hack to use the custom allocator).

We might implement the base64 decoding [directly in C](https://github.com/ros2/demos/blob/472a4796bb838906a286c8c00260169873255e59/image_tools/src/burger.cpp#L39) or use another lib like [libb64](https://libb64.sourceforge.net/).

Until this question is resolved, I put this PR as a Draft.

The sequence handling is not very clear in `parse.c` and might need some improvements.

Fixes https://github.com/ros2/ros2/issues/1436

Can be seen as part of https://github.com/ros2/rcl/issues/1026

### Is this user-facing behavior change?

Yes, the byte array parameters are now supported as ros arguments or in yaml parameters files.

Until now, it was not supported at all, has decribed in https://github.com/ros2/ros2/issues/1436.

### Did you use Generative AI?

Yes, the `base64_decode()` function has been written with the help of Mistral Le Chat.