### PR TITLE
add rcl_action_goal_handle_is_abortable().

### DIFF
--- a/rcl_action/include/rcl_action/goal_handle.h
+++ b/rcl_action/include/rcl_action/goal_handle.h
@@ -264,6 +264,28 @@ RCL_WARN_UNUSED
 bool
 rcl_action_goal_handle_is_cancelable(const rcl_action_goal_handle_t * goal_handle);
 
+/// Check if a goal can be transitioned to ABORTED in its current state.
+/**
+ * This is a non-blocking call.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[in] goal_handle struct containing the goal and metadata
+ * \return `true` if the goal can be transitioned to ABORTED from its current state, or
+ * \return `false` if the goal handle pointer is invalid, or
+ * \return `false` otherwise
+*/
+RCL_ACTION_PUBLIC
+RCL_WARN_UNUSED
+bool
+rcl_action_goal_handle_is_abortable(const rcl_action_goal_handle_t * goal_handle);
+
 /// Check if a rcl_action_goal_handle_t is valid.
 /**
  * This is a non-blocking call.

--- a/rcl_action/src/rcl_action/goal_handle.c
+++ b/rcl_action/src/rcl_action/goal_handle.c
@@ -170,6 +170,18 @@ rcl_action_goal_handle_is_cancelable(const rcl_action_goal_handle_t * goal_handl
 }
 
 bool
+rcl_action_goal_handle_is_abortable(const rcl_action_goal_handle_t * goal_handle)
+{
+  if (!rcl_action_goal_handle_is_valid(goal_handle)) {
+    return false;  // error message is set
+  }
+  // Check if the state machine reports an abort goal event is valid
+  rcl_action_goal_state_t state = rcl_action_transition_goal_state(
+    goal_handle->impl->state, GOAL_EVENT_ABORT);
+  return GOAL_STATE_ABORTED == state;
+}
+
+bool
 rcl_action_goal_handle_is_valid(const rcl_action_goal_handle_t * goal_handle)
 {
   RCL_CHECK_FOR_NULL_WITH_MSG(goal_handle, "goal handle pointer is invalid", return false);

--- a/rcl_action/test/rcl_action/test_goal_handle.cpp
+++ b/rcl_action/test/rcl_action/test_goal_handle.cpp
@@ -202,7 +202,7 @@ TEST(TestGoalHandle, rcl_action_goal_handle_get_goal_terminal_timestamp)
 }
 
 using EventStateActiveCancelableTuple =
-  std::tuple<rcl_action_goal_event_t, rcl_action_goal_state_t, bool, bool>;
+  std::tuple<rcl_action_goal_event_t, rcl_action_goal_state_t, bool, bool, bool>;
 using StateTransitionSequence = std::vector<EventStateActiveCancelableTuple>;
 const std::vector<std::string> event_strs = {
   "EXECUTE", "CANCEL_GOAL", "SUCCEED", "ABORT", "CANCELED"};
@@ -282,6 +282,10 @@ TEST_P(TestGoalHandleStateTransitionSequence, test_goal_handle_state_transitions
   EXPECT_TRUE(rcl_error_is_set());
   rcl_reset_error();
 
+  EXPECT_FALSE(rcl_action_goal_handle_is_abortable(nullptr));
+  EXPECT_TRUE(rcl_error_is_set());
+  rcl_reset_error();
+
   // Walk through state transitions
   rcl_ret_t ret;
   for (const EventStateActiveCancelableTuple & event_state : this->test_sequence) {
@@ -289,8 +293,9 @@ TEST_P(TestGoalHandleStateTransitionSequence, test_goal_handle_state_transitions
     rcl_action_goal_state_t expected_goal_state;
     bool expected_is_active;
     bool expected_is_cancelable;
-    std::tie(goal_event, expected_goal_state, expected_is_active, expected_is_cancelable) =
-      event_state;
+    bool expected_is_abortable;
+    std::tie(goal_event, expected_goal_state, expected_is_active, expected_is_cancelable,
+      expected_is_abortable) = event_state;
     ret = rcl_action_update_goal_state(&this->goal_handle, goal_event);
     if (GOAL_STATE_UNKNOWN == expected_goal_state) {
       EXPECT_EQ(ret, RCL_RET_ACTION_GOAL_EVENT_INVALID);
@@ -302,47 +307,48 @@ TEST_P(TestGoalHandleStateTransitionSequence, test_goal_handle_state_transitions
     expect_state_eq(expected_goal_state);
     EXPECT_EQ(expected_is_active, rcl_action_goal_handle_is_active(&this->goal_handle));
     EXPECT_EQ(expected_is_cancelable, rcl_action_goal_handle_is_cancelable(&this->goal_handle));
+    EXPECT_EQ(expected_is_abortable, rcl_action_goal_handle_is_abortable(&this->goal_handle));
   }
-}
+};
 
 // Test sequence parameters
 // Note, each sequence starts in the ACCEPTED state
 const StateTransitionSequence valid_state_transition_sequences[] = {
   {
-    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_EXECUTING, true, true),
-    std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_CANCELING, true, false),
-    std::make_tuple(GOAL_EVENT_CANCELED, GOAL_STATE_CANCELED, false, false),
+    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_EXECUTING, true, true, true),
+    std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_CANCELING, true, false, true),
+    std::make_tuple(GOAL_EVENT_CANCELED, GOAL_STATE_CANCELED, false, false, false),
   },
   {
-    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_EXECUTING, true, true),
-    std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_CANCELING, true, false),
-    std::make_tuple(GOAL_EVENT_SUCCEED, GOAL_STATE_SUCCEEDED, false, false),
+    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_EXECUTING, true, true, true),
+    std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_CANCELING, true, false, true),
+    std::make_tuple(GOAL_EVENT_SUCCEED, GOAL_STATE_SUCCEEDED, false, false, false),
   },
   {
-    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_EXECUTING, true, true),
-    std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_CANCELING, true, false),
-    std::make_tuple(GOAL_EVENT_ABORT, GOAL_STATE_ABORTED, false, false),
+    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_EXECUTING, true, true, true),
+    std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_CANCELING, true, false, true),
+    std::make_tuple(GOAL_EVENT_ABORT, GOAL_STATE_ABORTED, false, false, false),
   },
   {
-    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_EXECUTING, true, true),
-    std::make_tuple(GOAL_EVENT_SUCCEED, GOAL_STATE_SUCCEEDED, false, false),
+    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_EXECUTING, true, true, true),
+    std::make_tuple(GOAL_EVENT_SUCCEED, GOAL_STATE_SUCCEEDED, false, false, false),
   },
   {
-    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_EXECUTING, true, true),
-    std::make_tuple(GOAL_EVENT_ABORT, GOAL_STATE_ABORTED, false, false),
+    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_EXECUTING, true, true, true),
+    std::make_tuple(GOAL_EVENT_ABORT, GOAL_STATE_ABORTED, false, false, false),
   },
   {
-    std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_CANCELING, true, false),
-    std::make_tuple(GOAL_EVENT_CANCELED, GOAL_STATE_CANCELED, false, false),
+    std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_CANCELING, true, false, true),
+    std::make_tuple(GOAL_EVENT_CANCELED, GOAL_STATE_CANCELED, false, false, false),
   },
   {
-    std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_CANCELING, true, false),
-    std::make_tuple(GOAL_EVENT_ABORT, GOAL_STATE_ABORTED, false, false),
+    std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_CANCELING, true, false, true),
+    std::make_tuple(GOAL_EVENT_ABORT, GOAL_STATE_ABORTED, false, false, false),
   },
   // This is an odd case, but valid nonetheless
   {
-    std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_CANCELING, true, false),
-    std::make_tuple(GOAL_EVENT_SUCCEED, GOAL_STATE_SUCCEEDED, false, false),
+    std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_CANCELING, true, false, true),
+    std::make_tuple(GOAL_EVENT_SUCCEED, GOAL_STATE_SUCCEEDED, false, false, false),
   },
 };
 
@@ -354,27 +360,27 @@ INSTANTIATE_TEST_SUITE_P(
 
 const StateTransitionSequence invalid_state_transition_sequences[] = {
   {
-    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_EXECUTING, true, true),
-    std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_CANCELING, true, false),
-    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_UNKNOWN, false, false),
+    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_EXECUTING, true, true, true),
+    std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_CANCELING, true, false, true),
+    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_UNKNOWN, false, false, false),
   },
   {
-    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_EXECUTING, true, true),
-    std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_CANCELING, true, false),
-    std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_UNKNOWN, false, false),
+    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_EXECUTING, true, true, true),
+    std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_CANCELING, true, false, true),
+    std::make_tuple(GOAL_EVENT_CANCEL_GOAL, GOAL_STATE_UNKNOWN, false, false, false),
   },
   {
-    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_EXECUTING, true, true),
-    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_UNKNOWN, false, false),
+    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_EXECUTING, true, true, true),
+    std::make_tuple(GOAL_EVENT_EXECUTE, GOAL_STATE_UNKNOWN, false, false, false),
   },
   {
-    std::make_tuple(GOAL_EVENT_CANCELED, GOAL_STATE_UNKNOWN, false, false),
+    std::make_tuple(GOAL_EVENT_CANCELED, GOAL_STATE_UNKNOWN, false, false, false),
   },
   {
-    std::make_tuple(GOAL_EVENT_SUCCEED, GOAL_STATE_UNKNOWN, false, false),
+    std::make_tuple(GOAL_EVENT_SUCCEED, GOAL_STATE_UNKNOWN, false, false, false),
   },
   {
-    std::make_tuple(GOAL_EVENT_ABORT, GOAL_STATE_UNKNOWN, false, false),
+    std::make_tuple(GOAL_EVENT_ABORT, GOAL_STATE_UNKNOWN, false, false, false),
   },
 };
 


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Part of https://github.com/ros2/rclcpp/issues/2948 and https://github.com/ros2/rclcpp/issues/2757

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

No

This PR adds `rcl_action_goal_handle_is_abortable` function to check if it can be transitioned to ABORTED state in the current state.

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
