### PR TITLE
Fix typos: occurrs->occurs, successfull->successful

### DIFF
--- a/rcl/include/rcl/lexer_lookahead.h
+++ b/rcl/include/rcl/lexer_lookahead.h
@@ -80,7 +80,7 @@ rcl_get_zero_initialized_lexer_lookahead2(void);
  * \return #RCL_RET_OK if the buffer is successfully initialized, or
  * \return #RCL_RET_INVALID_ARGUMENT if any function arguments are invalid, or
  * \return #RCL_RET_BAD_ALLOC if allocating memory failed, or
- * \return #RCL_RET_ERROR if an unspecified error occurrs.
+ * \return #RCL_RET_ERROR if an unspecified error occurs.
  */
 RCL_PUBLIC
 RCL_WARN_UNUSED
@@ -131,7 +131,7 @@ rcl_lexer_lookahead2_fini(
  *
  * \param[in] buffer the lookahead2 buffer being used to analyze a string.
  * \param[out] next_type an output variable for the next lexeme in the string.
- * \return #RCL_RET_OK if peeking was successfull, or
+ * \return #RCL_RET_OK if peeking was successful, or
  * \return #RCL_RET_INVALID_ARGUMENT if any function arguments are invalid, or
  * \return #RCL_RET_ERROR if an unspecified error occurs.
  */
@@ -160,7 +160,7 @@ rcl_lexer_lookahead2_peek(
  * \param[in] buffer the lookahead2 buffer being used to analyze a string.
  * \param[out] next_type1 an output variable for the next lexeme in the string.
  * \param[out] next_type2 an output variable for the lexeme after the next lexeme in the string.
- * \return #RCL_RET_OK if peeking was successfull, or
+ * \return #RCL_RET_OK if peeking was successful, or
  * \return #RCL_RET_INVALID_ARGUMENT if any function arguments are invalid, or
  * \return #RCL_RET_ERROR if an unspecified error occurs.
  */
@@ -190,7 +190,7 @@ rcl_lexer_lookahead2_peek2(
  * \param[in] buffer the lookahead2 buffer being used to analyze a string.
  * \param[out] lexeme_text pointer to where lexeme begins in string.
  * \param[out] lexeme_text_length length of lexeme_text.
- * \return #RCL_RET_OK if peeking was successfull, or
+ * \return #RCL_RET_OK if peeking was successful, or
  * \return #RCL_RET_INVALID_ARGUMENT if any function arguments are invalid, or
  * \return #RCL_RET_ERROR if an unspecified error occurs.
  */

--- a/rcl/src/rcl/lexer_lookahead.c
+++ b/rcl/src/rcl/lexer_lookahead.c
@@ -29,7 +29,7 @@ struct rcl_lexer_lookahead2_impl_s
   // Type of lexeme
   rcl_lexeme_t type[2];
 
-  // Allocator to use if an error occurrs
+  // Allocator to use if an error occurs
   rcl_allocator_t allocator;
 };
 


### PR DESCRIPTION
## Description

:nerd_face: 

- "something occurred" with 2 Rs, but "something occurs" with 1 R
- "successfully achieved" with 2 Ls, but "something was successful" with 1 L

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
