### PR TITLE
Populate Transitions in Transition Events (continuation)

### DIFF
--- a/rcl_lifecycle/include/rcl_lifecycle/data_types.h
+++ b/rcl_lifecycle/include/rcl_lifecycle/data_types.h
@@ -74,6 +74,8 @@ typedef struct rcl_lifecycle_com_interface_s
 {
   /// Handle to the node used to create the publisher and the services
   rcl_node_t * node_handle;
+  /// Node clock for timestamping transition event messages
+  rcl_clock_t * clock;
   /// Event used to publish the transitions
   rcl_publisher_t pub_transition_event;
   /// Service that allows to trigger changes on the state

--- a/rcl_lifecycle/include/rcl_lifecycle/rcl_lifecycle.h
+++ b/rcl_lifecycle/include/rcl_lifecycle/rcl_lifecycle.h
@@ -225,6 +225,7 @@ rcl_lifecycle_get_zero_initialized_state_machine(void);
  * \param[inout] state_machine struct to be initialized
  * \param[in] node_handle a valid (not finalized) handle to the node used to create the publisher
  *    and the services
+ * \param[in] clock the clock associated with the node used for time stamping transition events
  * \param[in] ts_pub_notify pointer to transition publisher, it used to publish the transitions
  * \param[in] ts_srv_change_state pointer to the service that allows to trigger changes on the state
  * \param[in] ts_srv_get_state pointer to the service that allows to get the current state
@@ -244,6 +245,7 @@ rcl_ret_t
 rcl_lifecycle_state_machine_init(
   rcl_lifecycle_state_machine_t * state_machine,
   rcl_node_t * node_handle,
+  rcl_clock_t * clock,
   const rosidl_message_type_support_t * ts_pub_notify,
   const rosidl_service_type_support_t * ts_srv_change_state,
   const rosidl_service_type_support_t * ts_srv_get_state,

--- a/rcl_lifecycle/src/com_interface.c
+++ b/rcl_lifecycle/src/com_interface.c
@@ -328,7 +328,18 @@ rcl_lifecycle_com_interface_publish_notification(
   const char * transition_label, uint8_t transition_id,
   const rcl_lifecycle_state_t * start, const rcl_lifecycle_state_t * goal)
 {
-  com_interface->msg.timestamp = 0u;
+  // Get the current system time based on the rcl_clock
+  rcutils_time_point_value_t current_time;
+  rcutils_ret_t time_ret = rcutils_system_time_now(&current_time);
+  if (time_ret != RCUTILS_RET_OK) {
+    rcutils_error_string_t error = rcutils_get_error_string();
+    rcutils_reset_error();
+    RCL_SET_ERROR_MSG(error.str);
+    time_ret = RCL_RET_ERROR;
+    return time_ret;
+  }
+
+  com_interface->msg.timestamp = current_time;
   com_interface->msg.transition.id = transition_id;
   rosidl_runtime_c__String__assign(&com_interface->msg.transition.label, transition_label);
   com_interface->msg.start_state.id = start->id;

--- a/rcl_lifecycle/src/com_interface.c
+++ b/rcl_lifecycle/src/com_interface.c
@@ -324,9 +324,13 @@ rcl_lifecycle_com_interface_fini(
 
 rcl_ret_t
 rcl_lifecycle_com_interface_publish_notification(
-  rcl_lifecycle_com_interface_t * com_interface,
+  rcl_lifecycle_com_interface_t * com_interface, unsigned int timestamp,
+  const char * transition_label, uint8_t transition_id,
   const rcl_lifecycle_state_t * start, const rcl_lifecycle_state_t * goal)
 {
+  com_interface->msg.timestamp = timestamp;
+  com_interface->msg.transition.id = transition_id;
+  rosidl_runtime_c__String__assign(&com_interface->msg.transition.label, transition_label);
   com_interface->msg.start_state.id = start->id;
   rosidl_runtime_c__String__assign(&com_interface->msg.start_state.label, start->label);
   com_interface->msg.goal_state.id = goal->id;

--- a/rcl_lifecycle/src/com_interface.c
+++ b/rcl_lifecycle/src/com_interface.c
@@ -324,11 +324,11 @@ rcl_lifecycle_com_interface_fini(
 
 rcl_ret_t
 rcl_lifecycle_com_interface_publish_notification(
-  rcl_lifecycle_com_interface_t * com_interface, unsigned int timestamp,
+  rcl_lifecycle_com_interface_t * com_interface,
   const char * transition_label, uint8_t transition_id,
   const rcl_lifecycle_state_t * start, const rcl_lifecycle_state_t * goal)
 {
-  com_interface->msg.timestamp = timestamp;
+  com_interface->msg.timestamp = 0u;
   com_interface->msg.transition.id = transition_id;
   rosidl_runtime_c__String__assign(&com_interface->msg.transition.label, transition_label);
   com_interface->msg.start_state.id = start->id;

--- a/rcl_lifecycle/src/com_interface.c
+++ b/rcl_lifecycle/src/com_interface.c
@@ -344,8 +344,8 @@ rcl_lifecycle_com_interface_publish_notification(
   }
 
   com_interface->msg.stamp.sec = (int32_t) RCL_NS_TO_S(timestamp);
-  com_interface->msg.stamp.nanosec = (timestamp % RCL_S_TO_NS(1));
-  com_interface->msg.transition.id = transition->id;
+  com_interface->msg.stamp.nanosec = (uint32_t) (timestamp % RCL_S_TO_NS(1));
+  com_interface->msg.transition.id = (uint8_t) transition->id;
   rosidl_runtime_c__String__assign(&com_interface->msg.transition.label, transition->label);
   com_interface->msg.start_state.id = transition->start->id;
   rosidl_runtime_c__String__assign(&com_interface->msg.start_state.label, transition->start->label);

--- a/rcl_lifecycle/src/com_interface.c
+++ b/rcl_lifecycle/src/com_interface.c
@@ -325,8 +325,7 @@ rcl_lifecycle_com_interface_fini(
 rcl_ret_t
 rcl_lifecycle_com_interface_publish_notification(
   rcl_lifecycle_com_interface_t * com_interface,
-  const char * transition_label, uint8_t transition_id,
-  const rcl_lifecycle_state_t * start, const rcl_lifecycle_state_t * goal)
+  const rcl_lifecycle_transition_t * transition)
 {
   // Get the current system time based on the rcl_clock
   rcutils_time_point_value_t current_time;
@@ -340,12 +339,12 @@ rcl_lifecycle_com_interface_publish_notification(
   }
 
   com_interface->msg.timestamp = current_time;
-  com_interface->msg.transition.id = transition_id;
-  rosidl_runtime_c__String__assign(&com_interface->msg.transition.label, transition_label);
-  com_interface->msg.start_state.id = start->id;
-  rosidl_runtime_c__String__assign(&com_interface->msg.start_state.label, start->label);
-  com_interface->msg.goal_state.id = goal->id;
-  rosidl_runtime_c__String__assign(&com_interface->msg.goal_state.label, goal->label);
+  com_interface->msg.transition.id = transition->id;
+  rosidl_runtime_c__String__assign(&com_interface->msg.transition.label, transition->label);
+  com_interface->msg.start_state.id = transition->start->id;
+  rosidl_runtime_c__String__assign(&com_interface->msg.start_state.label, transition->start->label);
+  com_interface->msg.goal_state.id = transition->goal->id;
+  rosidl_runtime_c__String__assign(&com_interface->msg.goal_state.label, transition->goal->label);
 
   return rcl_publish(&com_interface->pub_transition_event, &com_interface->msg, NULL);
 }

--- a/rcl_lifecycle/src/com_interface.c
+++ b/rcl_lifecycle/src/com_interface.c
@@ -49,6 +49,7 @@ rcl_lifecycle_get_zero_initialized_com_interface(void)
 {
   rcl_lifecycle_com_interface_t com_interface;
   com_interface.node_handle = NULL;
+  com_interface.clock = NULL;
   com_interface.pub_transition_event = rcl_get_zero_initialized_publisher();
   com_interface.srv_change_state = rcl_get_zero_initialized_service();
   com_interface.srv_get_state = rcl_get_zero_initialized_service();
@@ -64,6 +65,7 @@ rcl_ret_t
 rcl_lifecycle_com_interface_init(
   rcl_lifecycle_com_interface_t * com_interface,
   rcl_node_t * node_handle,
+  rcl_clock_t * clock,
   const rosidl_message_type_support_t * ts_pub_notify,
   const rosidl_service_type_support_t * ts_srv_change_state,
   const rosidl_service_type_support_t * ts_srv_get_state,
@@ -72,7 +74,7 @@ rcl_lifecycle_com_interface_init(
   const rosidl_service_type_support_t * ts_srv_get_transition_graph)
 {
   rcl_ret_t ret = rcl_lifecycle_com_interface_publisher_init(
-    com_interface, node_handle, ts_pub_notify);
+    com_interface, node_handle, clock, ts_pub_notify);
   if (ret != RCL_RET_OK) {
     return ret;
   }
@@ -100,11 +102,17 @@ rcl_ret_t
 rcl_lifecycle_com_interface_publisher_init(
   rcl_lifecycle_com_interface_t * com_interface,
   rcl_node_t * node_handle,
+  rcl_clock_t * clock,
   const rosidl_message_type_support_t * ts_pub_notify)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(com_interface, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(node_handle, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_ARGUMENT_FOR_NULL(ts_pub_notify, RCL_RET_INVALID_ARGUMENT);
+
+  if (!rcl_clock_valid(clock)) {
+    RCL_SET_ERROR_MSG("invalid clock");
+    return RCL_RET_INVALID_ARGUMENT;
+  }
 
   // initialize publisher
   rcl_publisher_options_t publisher_options = rcl_publisher_get_default_options();
@@ -118,6 +126,7 @@ rcl_lifecycle_com_interface_publisher_init(
 
   // initialize static message for notification
   lifecycle_msgs__msg__TransitionEvent__init(&com_interface->msg);
+  com_interface->clock = clock;
 
   return RCL_RET_OK;
 
@@ -327,18 +336,14 @@ rcl_lifecycle_com_interface_publish_notification(
   rcl_lifecycle_com_interface_t * com_interface,
   const rcl_lifecycle_transition_t * transition)
 {
-  // Get the current system time based on the rcl_clock
-  rcutils_time_point_value_t current_time;
-  rcutils_ret_t time_ret = rcutils_system_time_now(&current_time);
-  if (time_ret != RCUTILS_RET_OK) {
-    rcutils_error_string_t error = rcutils_get_error_string();
-    rcutils_reset_error();
-    RCL_SET_ERROR_MSG(error.str);
-    time_ret = RCL_RET_ERROR;
-    return time_ret;
+  // Get the current time based on the rcl_clock
+  rcl_time_point_value_t timestamp;
+  rcl_ret_t time_ret = rcl_clock_get_now(com_interface->clock, &timestamp);
+  if (time_ret != RCL_RET_OK) {
+    return time_ret;  // rcl error state should already be set.
   }
 
-  com_interface->msg.timestamp = current_time;
+  com_interface->msg.timestamp = timestamp;
   com_interface->msg.transition.id = transition->id;
   rosidl_runtime_c__String__assign(&com_interface->msg.transition.label, transition->label);
   com_interface->msg.start_state.id = transition->start->id;

--- a/rcl_lifecycle/src/com_interface.c
+++ b/rcl_lifecycle/src/com_interface.c
@@ -343,7 +343,8 @@ rcl_lifecycle_com_interface_publish_notification(
     return time_ret;  // rcl error state should already be set.
   }
 
-  com_interface->msg.timestamp = timestamp;
+  com_interface->msg.stamp.sec = (int32_t) RCL_NS_TO_S(timestamp);
+  com_interface->msg.stamp.nanosec = (timestamp % RCL_S_TO_NS(1));
   com_interface->msg.transition.id = transition->id;
   rosidl_runtime_c__String__assign(&com_interface->msg.transition.label, transition->label);
   com_interface->msg.start_state.id = transition->start->id;

--- a/rcl_lifecycle/src/com_interface.h
+++ b/rcl_lifecycle/src/com_interface.h
@@ -21,6 +21,7 @@ extern "C"
 #endif
 
 #include "rcl/macros.h"
+#include <cstdint>
 
 #include "rcl_lifecycle/data_types.h"
 
@@ -78,7 +79,8 @@ rcl_lifecycle_com_interface_fini(
 rcl_ret_t
 RCL_WARN_UNUSED
 rcl_lifecycle_com_interface_publish_notification(
-  rcl_lifecycle_com_interface_t * com_interface,
+  rcl_lifecycle_com_interface_t * com_interface, unsigned int timestamp,
+  const char * transition_label, uint8_t transition_id,
   const rcl_lifecycle_state_t * start, const rcl_lifecycle_state_t * goal);
 
 #ifdef __cplusplus

--- a/rcl_lifecycle/src/com_interface.h
+++ b/rcl_lifecycle/src/com_interface.h
@@ -21,7 +21,6 @@ extern "C"
 #endif
 
 #include "rcl/macros.h"
-#include <cstdint>
 
 #include "rcl_lifecycle/data_types.h"
 
@@ -79,7 +78,7 @@ rcl_lifecycle_com_interface_fini(
 rcl_ret_t
 RCL_WARN_UNUSED
 rcl_lifecycle_com_interface_publish_notification(
-  rcl_lifecycle_com_interface_t * com_interface, unsigned int timestamp,
+  rcl_lifecycle_com_interface_t * com_interface,
   const char * transition_label, uint8_t transition_id,
   const rcl_lifecycle_state_t * start, const rcl_lifecycle_state_t * goal);
 

--- a/rcl_lifecycle/src/com_interface.h
+++ b/rcl_lifecycle/src/com_interface.h
@@ -32,6 +32,7 @@ RCL_WARN_UNUSED
 rcl_lifecycle_com_interface_init(
   rcl_lifecycle_com_interface_t * com_interface,
   rcl_node_t * node_handle,
+  rcl_clock_t * clock,
   const rosidl_message_type_support_t * ts_pub_notify,
   const rosidl_service_type_support_t * ts_srv_change_state,
   const rosidl_service_type_support_t * ts_srv_get_state,
@@ -44,6 +45,7 @@ RCL_WARN_UNUSED
 rcl_lifecycle_com_interface_publisher_init(
   rcl_lifecycle_com_interface_t * com_interface,
   rcl_node_t * node_handle,
+  rcl_clock_t * clock,
   const rosidl_message_type_support_t * ts_pub_notify);
 
 rcl_ret_t

--- a/rcl_lifecycle/src/com_interface.h
+++ b/rcl_lifecycle/src/com_interface.h
@@ -79,8 +79,7 @@ rcl_ret_t
 RCL_WARN_UNUSED
 rcl_lifecycle_com_interface_publish_notification(
   rcl_lifecycle_com_interface_t * com_interface,
-  const char * transition_label, uint8_t transition_id,
-  const rcl_lifecycle_state_t * start, const rcl_lifecycle_state_t * goal);
+  const rcl_lifecycle_transition_t * transition);
 
 #ifdef __cplusplus
 }

--- a/rcl_lifecycle/src/rcl_lifecycle.c
+++ b/rcl_lifecycle/src/rcl_lifecycle.c
@@ -379,7 +379,8 @@ _trigger_transition(
 
   if (publish_notification) {
     rcl_ret_t fcn_ret = rcl_lifecycle_com_interface_publish_notification(
-      &state_machine->com_interface, transition->start, state_machine->current_state);
+      &state_machine->com_interface, 250, transition->label, transition->id,
+      transition->start, state_machine->current_state);
     if (fcn_ret != RCL_RET_OK) {
       rcl_error_string_t error_string = rcl_get_error_string();
       rcutils_reset_error();

--- a/rcl_lifecycle/src/rcl_lifecycle.c
+++ b/rcl_lifecycle/src/rcl_lifecycle.c
@@ -379,7 +379,7 @@ _trigger_transition(
 
   if (publish_notification) {
     rcl_ret_t fcn_ret = rcl_lifecycle_com_interface_publish_notification(
-      &state_machine->com_interface, 250, transition->label, transition->id,
+      &state_machine->com_interface, transition->label, transition->id,
       transition->start, state_machine->current_state);
     if (fcn_ret != RCL_RET_OK) {
       rcl_error_string_t error_string = rcl_get_error_string();

--- a/rcl_lifecycle/src/rcl_lifecycle.c
+++ b/rcl_lifecycle/src/rcl_lifecycle.c
@@ -194,6 +194,7 @@ rcl_ret_t
 rcl_lifecycle_state_machine_init(
   rcl_lifecycle_state_machine_t * state_machine,
   rcl_node_t * node_handle,
+  rcl_clock_t * clock,
   const rosidl_message_type_support_t * ts_pub_notify,
   const rosidl_service_type_support_t * ts_srv_change_state,
   const rosidl_service_type_support_t * ts_srv_get_state,
@@ -208,6 +209,9 @@ rcl_lifecycle_state_machine_init(
   RCL_CHECK_FOR_NULL_WITH_MSG(
     node_handle, "Node handle is null\n", return RCL_RET_INVALID_ARGUMENT);
 
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    clock, "Clock is null\n", return RCL_RET_INVALID_ARGUMENT);
+
   RCL_CHECK_ALLOCATOR_WITH_MSG(
     &state_machine_options->allocator, "can't initialize state machine, no allocator given\n",
     return RCL_RET_INVALID_ARGUMENT);
@@ -218,7 +222,7 @@ rcl_lifecycle_state_machine_init(
   if (state_machine->options.enable_com_interface) {
     rcl_ret_t ret = rcl_lifecycle_com_interface_init(
       &state_machine->com_interface, node_handle,
-      ts_pub_notify,
+      clock, ts_pub_notify,
       ts_srv_change_state, ts_srv_get_state,
       ts_srv_get_available_states, ts_srv_get_available_transitions, ts_srv_get_transition_graph);
     if (ret != RCL_RET_OK) {
@@ -226,7 +230,7 @@ rcl_lifecycle_state_machine_init(
     }
   } else {
     rcl_ret_t ret = rcl_lifecycle_com_interface_publisher_init(
-      &state_machine->com_interface, node_handle, ts_pub_notify);
+      &state_machine->com_interface, node_handle, clock, ts_pub_notify);
     if (ret != RCL_RET_OK) {
       return RCL_RET_ERROR;
     }

--- a/rcl_lifecycle/src/rcl_lifecycle.c
+++ b/rcl_lifecycle/src/rcl_lifecycle.c
@@ -379,8 +379,7 @@ _trigger_transition(
 
   if (publish_notification) {
     rcl_ret_t fcn_ret = rcl_lifecycle_com_interface_publish_notification(
-      &state_machine->com_interface, transition->label, transition->id,
-      transition->start, state_machine->current_state);
+      &state_machine->com_interface, transition);
     if (fcn_ret != RCL_RET_OK) {
       rcl_error_string_t error_string = rcl_get_error_string();
       rcutils_reset_error();

--- a/rcl_lifecycle/test/test_rcl_lifecycle.cpp
+++ b/rcl_lifecycle/test/test_rcl_lifecycle.cpp
@@ -193,6 +193,7 @@ TEST(TestRclLifecycle, state_machine) {
   EXPECT_EQ(0u, state_machine.transition_map.transitions_size);
 
   rcl_node_t node = rcl_get_zero_initialized_node();
+  rcl_clock_t clock;
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_context_t context = rcl_get_zero_initialized_context();
   rcl_node_options_t options = rcl_node_get_default_options();
@@ -223,6 +224,13 @@ TEST(TestRclLifecycle, state_machine) {
     EXPECT_EQ(RCL_RET_OK, rcl_node_fini(&node)) << rcl_get_error_string().str;
   });
 
+  ret = rcl_clock_init(RCL_SYSTEM_TIME, &clock, &allocator);
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    EXPECT_EQ(RCL_RET_OK, rcl_clock_fini(&clock)) << rcl_get_error_string().str;
+  });
+
   const rosidl_message_type_support_t * pn =
     ROSIDL_GET_MSG_TYPE_SUPPORT(lifecycle_msgs, msg, TransitionEvent);
   const rosidl_service_type_support_t * cs =
@@ -242,56 +250,63 @@ TEST(TestRclLifecycle, state_machine) {
 
   // Check various arguments are null
   ret = rcl_lifecycle_state_machine_init(
-    nullptr, &node, pn, cs, gs, gas, gat, gtg, &state_machine_options);
+    nullptr, &node, &clock, pn, cs, gs, gas, gat, gtg, &state_machine_options);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
   rcutils_reset_error();
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_lifecycle_state_machine_is_initialized(&state_machine));
   rcutils_reset_error();
 
   ret = rcl_lifecycle_state_machine_init(
-    &state_machine, nullptr, pn, cs, gs, gas, gat, gtg, &state_machine_options);
+    &state_machine, nullptr, &clock, pn, cs, gs, gas, gat, gtg, &state_machine_options);
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
   rcutils_reset_error();
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_lifecycle_state_machine_is_initialized(&state_machine));
   rcutils_reset_error();
 
   ret = rcl_lifecycle_state_machine_init(
-    &state_machine, &node, nullptr, cs, gs, gas, gat, gtg, &state_machine_options);
+    &state_machine, &node, nullptr, pn, cs, gs, gas, gat, gtg, &state_machine_options);
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret);
+  rcutils_reset_error();
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_lifecycle_state_machine_is_initialized(&state_machine));
+  rcutils_reset_error();
+
+  ret = rcl_lifecycle_state_machine_init(
+    &state_machine, &node, &clock, nullptr, cs, gs, gas, gat, gtg, &state_machine_options);
   EXPECT_EQ(RCL_RET_ERROR, ret);
   rcutils_reset_error();
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_lifecycle_state_machine_is_initialized(&state_machine));
   rcutils_reset_error();
 
   ret = rcl_lifecycle_state_machine_init(
-    &state_machine, &node, pn, nullptr, gs, gas, gat, gtg, &state_machine_options);
+    &state_machine, &node, &clock, pn, nullptr, gs, gas, gat, gtg, &state_machine_options);
   EXPECT_EQ(RCL_RET_ERROR, ret);
   rcutils_reset_error();
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_lifecycle_state_machine_is_initialized(&state_machine));
   rcutils_reset_error();
 
   ret = rcl_lifecycle_state_machine_init(
-    &state_machine, &node, pn, cs, nullptr, gas, gat, gtg, &state_machine_options);
+    &state_machine, &node, &clock, pn, cs, nullptr, gas, gat, gtg, &state_machine_options);
   EXPECT_EQ(RCL_RET_ERROR, ret);
   rcutils_reset_error();
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_lifecycle_state_machine_is_initialized(&state_machine));
   rcutils_reset_error();
 
   ret = rcl_lifecycle_state_machine_init(
-    &state_machine, &node, pn, cs, gs, nullptr, gat, gtg, &state_machine_options);
+    &state_machine, &node, &clock, pn, cs, gs, nullptr, gat, gtg, &state_machine_options);
   EXPECT_EQ(RCL_RET_ERROR, ret);
   rcutils_reset_error();
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_lifecycle_state_machine_is_initialized(&state_machine));
   rcutils_reset_error();
 
   ret = rcl_lifecycle_state_machine_init(
-    &state_machine, &node, pn, cs, gs, gas, nullptr, gtg, &state_machine_options);
+    &state_machine, &node, &clock, pn, cs, gs, gas, nullptr, gtg, &state_machine_options);
   EXPECT_EQ(RCL_RET_ERROR, ret);
   rcutils_reset_error();
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_lifecycle_state_machine_is_initialized(&state_machine));
   rcutils_reset_error();
 
   ret = rcl_lifecycle_state_machine_init(
-    &state_machine, &node, pn, cs, gs, gas, gat, nullptr, &state_machine_options);
+    &state_machine, &node, &clock, pn, cs, gs, gas, gat, nullptr, &state_machine_options);
   EXPECT_EQ(RCL_RET_ERROR, ret);
   rcutils_reset_error();
   EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, rcl_lifecycle_state_machine_is_initialized(&state_machine));
@@ -304,7 +319,7 @@ TEST(TestRclLifecycle, state_machine) {
   state_machine_options.enable_com_interface = false;
 
   ret = rcl_lifecycle_state_machine_init(
-    &state_machine, &node, pn, cs, gs, gas, gat, gtg, &state_machine_options);
+    &state_machine, &node, &clock, pn, cs, gs, gas, gat, gtg, &state_machine_options);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   EXPECT_NE(nullptr, &state_machine.com_interface);
   EXPECT_NE(nullptr, &state_machine.com_interface.pub_transition_event.impl);
@@ -325,7 +340,7 @@ TEST(TestRclLifecycle, state_machine) {
   state_machine_options.initialize_default_states = false;
 
   ret = rcl_lifecycle_state_machine_init(
-    &state_machine, &node, pn, cs, gs, gas, gat, gtg, &state_machine_options);
+    &state_machine, &node, &clock, pn, cs, gs, gas, gat, gtg, &state_machine_options);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
   // Transition_map is not initialized
@@ -385,6 +400,7 @@ TEST(TestRclLifecycle, state_transitions) {
   EXPECT_EQ(0u, state_machine.transition_map.transitions_size);
 
   rcl_node_t node = rcl_get_zero_initialized_node();
+  rcl_clock_t clock;
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_lifecycle_state_machine_options_t state_machine_options =
     rcl_lifecycle_get_default_state_machine_options();
@@ -419,6 +435,13 @@ TEST(TestRclLifecycle, state_transitions) {
     EXPECT_EQ(RCL_RET_OK, rcl_node_fini(&node));
   });
 
+  ret = rcl_clock_init(RCL_SYSTEM_TIME, &clock, &allocator);
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    EXPECT_EQ(RCL_RET_OK, rcl_clock_fini(&clock));
+  });
+
   const rosidl_message_type_support_t * pn =
     ROSIDL_GET_MSG_TYPE_SUPPORT(lifecycle_msgs, msg, TransitionEvent);
   const rosidl_service_type_support_t * cs =
@@ -433,7 +456,7 @@ TEST(TestRclLifecycle, state_transitions) {
     ROSIDL_GET_SRV_TYPE_SUPPORT(lifecycle_msgs, srv, GetAvailableTransitions);
 
   ret = rcl_lifecycle_state_machine_init(
-    &state_machine, &node, pn, cs, gs, gas, gat, gtg, &state_machine_options);
+    &state_machine, &node, &clock, pn, cs, gs, gas, gat, gtg, &state_machine_options);
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
 
   ret = rcl_lifecycle_state_machine_is_initialized(&state_machine);
@@ -491,6 +514,7 @@ TEST(TestRclLifecycle, state_transitions) {
 
 TEST(TestRclLifecycle, init_fini_maybe_fail) {
   rcl_node_t node = rcl_get_zero_initialized_node();
+  rcl_clock_t clock;
   rcl_allocator_t allocator = rcl_get_default_allocator();
   rcl_context_t context = rcl_get_zero_initialized_context();
   rcl_node_options_t options = rcl_node_get_default_options();
@@ -522,6 +546,13 @@ TEST(TestRclLifecycle, init_fini_maybe_fail) {
     EXPECT_EQ(RCL_RET_OK, rcl_node_fini(&node));
   });
 
+  ret = rcl_clock_init(RCL_SYSTEM_TIME, &clock, &allocator);
+  ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    EXPECT_EQ(RCL_RET_OK, rcl_clock_fini(&clock));
+  });
+
   const rosidl_message_type_support_t * pn =
     ROSIDL_GET_MSG_TYPE_SUPPORT(lifecycle_msgs, msg, TransitionEvent);
   const rosidl_service_type_support_t * cs =
@@ -544,7 +575,7 @@ TEST(TestRclLifecycle, init_fini_maybe_fail) {
     rcl_lifecycle_get_default_state_machine_options();
 
     ret = rcl_lifecycle_state_machine_init(
-      &sm, &node, pn, cs, gs, gas, gat, gtg, &state_machine_options);
+      &sm, &node, &clock, pn, cs, gs, gas, gat, gtg, &state_machine_options);
     if (RCL_RET_OK == ret) {
       ret = rcl_lifecycle_state_machine_fini(&sm, &node);
       if (RCL_RET_OK != ret) {


### PR DESCRIPTION
## Description

Original author: @CursedRock17
Original reviewers: @fujitatomoya @audrow @ivanpauno @wjwwood 

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->
Continuation of #1140.
Implemented most feedback.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #1019 

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

Yes, Lifecycle transition events are now filled.
This comes with a small change in function signatures to support timestamping.


### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

No.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

I would also recommend merging ros2/rcl_interfaces#185 to limit the amount of breaking changes.

I noticed that the `node_handle` field of `rcl_lifecycle_com_interface_t` is never filled or used as far as I can see.