### PR TITLE
Remove default from switch with enum, so that compiler warns.

### DIFF
--- a/rcl/src/rcl/discovery_options.c
+++ b/rcl/src/rcl/discovery_options.c
@@ -100,9 +100,8 @@ rcl_automatic_discovery_range_to_string(rmw_automatic_discovery_range_t automati
       return "RMW_AUTOMATIC_DISCOVERY_RANGE_SUBNET";
     case RMW_AUTOMATIC_DISCOVERY_RANGE_SYSTEM_DEFAULT:
       return "RMW_AUTOMATIC_DISCOVERY_RANGE_SYSTEM_DEFAULT";
-    default:
-      return NULL;
   }
+  return NULL;
 }
 
 rcl_ret_t

--- a/rcl/src/rcl/event.c
+++ b/rcl/src/rcl/event.c
@@ -71,9 +71,10 @@ rcl_publisher_event_init(
     case RCL_PUBLISHER_MATCHED:
       rmw_event_type = RMW_EVENT_PUBLICATION_MATCHED;
       break;
-    default:
-      RCL_SET_ERROR_MSG("Event type for publisher not supported");
-      return RCL_RET_INVALID_ARGUMENT;
+  }
+  if (rmw_event_type == RMW_EVENT_INVALID) {
+    RCL_SET_ERROR_MSG("Event type for publisher not supported");
+    return RCL_RET_INVALID_ARGUMENT;
   }
 
   // Allocate space for the implementation struct.
@@ -131,9 +132,10 @@ rcl_subscription_event_init(
     case RCL_SUBSCRIPTION_MATCHED:
       rmw_event_type = RMW_EVENT_SUBSCRIPTION_MATCHED;
       break;
-    default:
-      RCL_SET_ERROR_MSG("Event type for subscription not supported");
-      return RCL_RET_INVALID_ARGUMENT;
+  }
+  if (rmw_event_type == RMW_EVENT_INVALID) {
+    RCL_SET_ERROR_MSG("Event type for subscription not supported");
+    return RCL_RET_INVALID_ARGUMENT;
   }
 
   // Allocate space for the implementation struct.

--- a/rcl/src/rcl/time.c
+++ b/rcl/src/rcl/time.c
@@ -111,9 +111,8 @@ rcl_clock_init(
       return rcl_system_clock_init(clock, allocator);
     case RCL_STEADY_TIME:
       return rcl_steady_clock_init(clock, allocator);
-    default:
-      return RCL_RET_INVALID_ARGUMENT;
   }
+  return RCL_RET_INVALID_ARGUMENT;
 }
 
 static void
@@ -143,10 +142,9 @@ rcl_clock_fini(
     case RCL_STEADY_TIME:
       return rcl_steady_clock_fini(clock);
     case RCL_CLOCK_UNINITIALIZED:
-    // fall through
-    default:
       return RCL_RET_INVALID_ARGUMENT;
   }
+  return RCL_RET_INVALID_ARGUMENT;
 }
 
 rcl_ret_t

--- a/rcl_yaml_param_parser/src/parse.c
+++ b/rcl_yaml_param_parser/src/parse.c
@@ -1098,6 +1098,18 @@ rcutils_ret_t parse_value_events(
         RCUTILS_SET_ERROR_MSG("Received an empty event");
         ret = RCUTILS_RET_ERROR;
         break;
+      case YAML_ALIAS_EVENT:
+        RCUTILS_SET_ERROR_MSG("Aliasing not supported");
+        ret = RCUTILS_RET_ERROR;
+        break;
+      case YAML_MAPPING_START_EVENT:
+        RCUTILS_SET_ERROR_MSG("Mapping not supported in value parsing");
+        ret = RCUTILS_RET_ERROR;
+        break;
+      case YAML_MAPPING_END_EVENT:
+        RCUTILS_SET_ERROR_MSG("Mapping not supported in value parsing");
+        ret = RCUTILS_RET_ERROR;
+        break;
     }
     yaml_event_delete(&event);
   }

--- a/rcl_yaml_param_parser/src/parse.c
+++ b/rcl_yaml_param_parser/src/parse.c
@@ -456,12 +456,6 @@ rcutils_ret_t parse_value(
         }
       }
       break;
-    default:
-      RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
-        "Unknown data type of value %s at line %d", value, line_num);
-      ret = RCUTILS_RET_ERROR;
-      allocator.deallocate(ret_val, allocator.state);
-      break;
   }
   return ret;
 }
@@ -890,10 +884,6 @@ rcutils_ret_t parse_key(
         }
       }
       break;
-    default:
-      RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("Unknown map level at line %d", line_num);
-      ret = RCUTILS_RET_ERROR;
-      break;
   }
   return ret;
 }
@@ -1056,10 +1046,6 @@ rcutils_ret_t parse_file_events(
           "Received an empty event at line %d", line_num);
         ret = RCUTILS_RET_ERROR;
         break;
-      default:
-        RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING("Unknown YAML event at line %d", line_num);
-        ret = RCUTILS_RET_ERROR;
-        break;
     }
     yaml_event_delete(&event);
   }
@@ -1110,10 +1096,6 @@ rcutils_ret_t parse_value_events(
         break;
       case YAML_NO_EVENT:
         RCUTILS_SET_ERROR_MSG("Received an empty event");
-        ret = RCUTILS_RET_ERROR;
-        break;
-      default:
-        RCUTILS_SET_ERROR_MSG("Unknown YAML event");
         ret = RCUTILS_RET_ERROR;
         break;
     }


### PR DESCRIPTION
## Description

Now the compiler will warn us if new enum values are added to it but aren't handled in this function.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

No

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

> [!NOTE]
> No backports requested, this is just a minor enhancement for maintainability.