### PR TITLE
parse_key() should use yaml_map_lvl_t instead of uint_32.

### DIFF
--- a/rcl_yaml_param_parser/src/impl/parse.h
+++ b/rcl_yaml_param_parser/src/impl/parse.h
@@ -53,7 +53,7 @@ RCL_YAML_PARAM_PARSER_PUBLIC
 RCUTILS_WARN_UNUSED
 rcutils_ret_t parse_key(
   const yaml_event_t event,
-  uint32_t * map_level,
+  yaml_map_lvl_t * map_level,
   bool * is_new_map,
   size_t * node_idx,
   size_t * parameter_idx,

--- a/rcl_yaml_param_parser/src/parse.c
+++ b/rcl_yaml_param_parser/src/parse.c
@@ -747,7 +747,7 @@ _get_float_value(
 ///
 rcutils_ret_t parse_key(
   const yaml_event_t event,
-  uint32_t * map_level,
+  yaml_map_lvl_t * map_level,
   bool * is_new_map,
   size_t * node_idx,
   size_t * parameter_idx,
@@ -901,7 +901,7 @@ rcutils_ret_t parse_file_events(
   bool is_seq = false;
   uint32_t line_num = 0;
   data_types_t seq_data_type = DATA_TYPE_UNKNOWN;
-  uint32_t map_level = 1U;
+  yaml_map_lvl_t map_level = MAP_NODE_NAME_LVL;
   uint32_t map_depth = 0U;
   bool is_new_map = false;
 
@@ -945,7 +945,7 @@ rcutils_ret_t parse_file_events(
             is_key = false;
           } else {
             /// It is a value
-            if (map_level < (uint32_t)(MAP_PARAMS_LVL)) {
+            if (map_level < MAP_PARAMS_LVL) {
               RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
                 "Cannot have a value before %s at line %d", PARAMS_KEY, line_num);
               ret = RCUTILS_RET_ERROR;
@@ -980,7 +980,7 @@ rcutils_ret_t parse_file_events(
           ret = RCUTILS_RET_ERROR;
           break;
         }
-        if (map_level < (uint32_t)(MAP_PARAMS_LVL)) {
+        if (map_level < MAP_PARAMS_LVL) {
           RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
             "Sequences can only be values and not keys in params. Error at line %d\n", line_num);
           ret = RCUTILS_RET_ERROR;

--- a/rcl_yaml_param_parser/test/test_parse.cpp
+++ b/rcl_yaml_param_parser/test/test_parse.cpp
@@ -368,7 +368,7 @@ TEST(TestParse, parse_key_bad_args)
   event.end_mark = {0u, 0u, 0u};
 
   rcutils_allocator_t allocator = rcutils_get_default_allocator();
-  uint32_t map_level = MAP_NODE_NAME_LVL;
+  yaml_map_lvl_t map_level = MAP_NODE_NAME_LVL;
   bool is_new_map = false;
   size_t node_idx = 0;
   size_t parameter_idx = 0;
@@ -428,16 +428,6 @@ TEST(TestParse, parse_key_bad_args)
 
   // map_level is MAP_UNINIT_LVL
   map_level = MAP_UNINIT_LVL;
-  EXPECT_EQ(
-    RCUTILS_RET_ERROR,
-    parse_key(
-      event, &map_level, &is_new_map, &node_idx, &parameter_idx, &ns_tracker, params_st)) <<
-    rcutils_get_error_string().str;
-  EXPECT_TRUE(rcutils_error_is_set());
-  rcutils_reset_error();
-
-  // map_level is not a valid value
-  map_level = 42;
   EXPECT_EQ(
     RCUTILS_RET_ERROR,
     parse_key(


### PR DESCRIPTION
## Description

Follow up of https://github.com/ros2/rcl/pull/1278

https://github.com/ros2/rcl/pull/1278 exposes https://github.com/ros2/rmw_zenoh/pull/871#pullrequestreview-3588307809 failure but we missed to test there. the proper fix is that, it should use enum data type for the switch statement, so that the compiler can always give us warning during build time.

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

Technically yes, because this changes the parse_key function argument signature.

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->

> [!NOTE]
> DO NOT BACKPORT THIS.