### PR TITLE
Validate name input in add_name_to_ns()

### DIFF
--- a/rcl_yaml_param_parser/src/namespace.c
+++ b/rcl_yaml_param_parser/src/namespace.c
@@ -52,7 +52,7 @@ rcutils_ret_t add_name_to_ns(
   }
 
   /// Add a name to ns
-  if (NULL == name) {
+  if (NULL == name || strlen(name) == 0) {
     return RCUTILS_RET_INVALID_ARGUMENT;
   }
   if (0U == *cur_count) {

--- a/rcl_yaml_param_parser/test/test_namespace.cpp
+++ b/rcl_yaml_param_parser/test/test_namespace.cpp
@@ -35,6 +35,10 @@ TEST(TestNamespace, add_name_to_ns) {
   EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
   EXPECT_EQ(nullptr, ns_tracker.node_ns);
 
+  ret = add_name_to_ns(&ns_tracker, "", NS_TYPE_NODE, allocator);
+  EXPECT_EQ(RCUTILS_RET_INVALID_ARGUMENT, ret) << rcutils_get_error_string().str;
+  EXPECT_EQ(nullptr, ns_tracker.node_ns);
+
   ret = add_name_to_ns(&ns_tracker, "node1", NS_TYPE_NODE, allocator);
   EXPECT_EQ(RCUTILS_RET_OK, ret) << rcutils_get_error_string().str;
   EXPECT_STREQ("node1", ns_tracker.node_ns);


### PR DESCRIPTION
## Description

Fixes https://github.com/ros2/ros2/issues/1777

When add_name_to_ns() is called for the first time and the input `name` is an empty string ("" as a key in YAML), it will be directly added to "ns_tracker->node_ns".  While add_name_to_ns() is called for the second time, `cur_ns` is from ns_tracker->node_ns (it is an empty string). So `ns_len` is 0.  `sep_len` is 1 (fixed value). `cur_ns + ns_len - sep_len` caused a pointer out-of-bounds error. 
So if `name` is an empty string, it is an invalid parameter.

https://github.com/ros2/rcl/blob/defdcffedd26f6178b362c9577978e52323b7470/rcl_yaml_param_parser/src/namespace.c#L64-L68

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

No