### PR TITLE
Add 2 interfaces for configuring action client feedback subscription contents filter

### DIFF
--- a/rcl_action/include/rcl_action/action_client.h
+++ b/rcl_action/include/rcl_action/action_client.h
@@ -818,7 +818,7 @@ rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
 /**
  * If goal ID doesn't exist in feedback subscription content filter, return RCL_RET_OK.
  *
- * If rmw middleware doesn't support content filtering feature, return RCL_RET_OK.
+ * If rmw middleware doesn't support content filtering feature, return RCL_RET_UNSUPPORTED.
  *
  * <hr>
  * Attribute          | Adherence
@@ -837,7 +837,8 @@ rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
  * \return #RCL_RET_ACTION_CLIENT_INVALID if the action client is invalid, or
  * \return #RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or
  * \return #RCL_RET_BAD_ALLOC if allocating memory failed, or
- * \return #RCL_RET_ERROR if calling other rcl functions internally does not return RCL_RET_OK
+ * \return #RCL_RET_ERROR if calling other rcl functions internally does not return RCL_RET_OK, or
+ * \return #RCL_RET_UNSUPPORTED if the middleware doesn't support content filtering
  */
 RCL_ACTION_PUBLIC
 RCL_WARN_UNUSED

--- a/rcl_action/include/rcl_action/action_client.h
+++ b/rcl_action/include/rcl_action/action_client.h
@@ -800,6 +800,7 @@ rcl_action_client_configure_action_introspection(
  * \param[in] goal_id goal id represented as a uint8_t array
  * \param[in] array_size size of the goal_id array
  * \return #RCL_RET_OK if the call was successful, or
+ * \return #RCL_RET_ACTION_CLIENT_INVALID if the action client is invalid, or
  * \return #RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or
  * \return #RCL_RET_BAD_ALLOC if allocating memory failed, or
  * \return #RCL_RET_ERROR if calling other rcl functions internally does not return RCL_RET_OK, or
@@ -833,6 +834,7 @@ rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
  * \param[in] goal_id goal id represented as a uint8_t array
  * \param[in] array_size size of the goal_id array
  * \return #RCL_RET_OK if the call was successful, or
+ * \return #RCL_RET_ACTION_CLIENT_INVALID if the action client is invalid, or
  * \return #RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or
  * \return #RCL_RET_BAD_ALLOC if allocating memory failed, or
  * \return #RCL_RET_ERROR if calling other rcl functions internally does not return RCL_RET_OK

--- a/rcl_action/include/rcl_action/action_client.h
+++ b/rcl_action/include/rcl_action/action_client.h
@@ -786,6 +786,15 @@ rcl_action_client_configure_action_introspection(
  *
  * If rmw middleware doesn't support content filtering feature, return RCL_RET_UNSUPPORTED.
  *
+ * According to the DDS spec, the content filter can have up to 100 parameters. Each goal ID uses
+ * 16 parameters, so if more than 6 goal IDs are configured at the same time, an RCL_RET_ERROR
+ * will be returned.
+ *
+ * Different RMW implementations may also have restrictions on the length of content filter
+ * expressions. If this default limit is exceeded, an RCL_RET_ERROR will be returned. For example,
+ * in ConnextDDS, the `contentfilter_property_max_length` setting affects the available length of
+ * content filter expressions.
+ *
  * <hr>
  * Attribute          | Adherence
  * ------------------ | -------------

--- a/rcl_action/include/rcl_action/action_client.h
+++ b/rcl_action/include/rcl_action/action_client.h
@@ -56,6 +56,14 @@ typedef struct rcl_action_client_options_s
   /// Custom allocator for the action client, used for incidental allocations.
   /** For default behavior (malloc/free), see: rcl_get_default_allocator() */
   rcl_allocator_t allocator;
+  /// Disable the content filter feature for feedback subscription.
+  /**
+   * The default value is false.
+   * Set to true to disable the content filter feature of the feedback subscription
+   * - When the parameter limit of the content filter is exceeded (>100)
+   * - When configuring (adding/removing goal ID) the feedback subscription return error
+   */
+  bool disable_feedback_sub_cft;
 } rcl_action_client_options_t;
 
 /// Return a rcl_action_client_t struct with members set to `NULL`.

--- a/rcl_action/include/rcl_action/action_client.h
+++ b/rcl_action/include/rcl_action/action_client.h
@@ -56,14 +56,6 @@ typedef struct rcl_action_client_options_s
   /// Custom allocator for the action client, used for incidental allocations.
   /** For default behavior (malloc/free), see: rcl_get_default_allocator() */
   rcl_allocator_t allocator;
-  /// Disable the content filter feature for feedback subscription.
-  /**
-   * The default value is false.
-   * Set to true to disable the content filter feature of the feedback subscription
-   * - When the parameter limit of the content filter is exceeded (>100)
-   * - When configuring (adding/removing goal ID) the feedback subscription return error
-   */
-  bool disable_feedback_sub_cft;
 } rcl_action_client_options_t;
 
 /// Return a rcl_action_client_t struct with members set to `NULL`.

--- a/rcl_action/include/rcl_action/action_client.h
+++ b/rcl_action/include/rcl_action/action_client.h
@@ -781,6 +781,70 @@ rcl_action_client_configure_action_introspection(
   const rcl_publisher_options_t publisher_options,
   rcl_service_introspection_state_t introspection_state);
 
+/// Configure feedback subscription content filter to add one goal ID
+/**
+ *
+ * If rmw middleware doesn't support content filtering feature, return RCL_RET_UNSUPPORTED.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | Maybe [1]
+ * Lock-Free          | Maybe [1]
+ * <i>[1] rmw implementation defined</i>
+ *
+ * \param[in] action_client action client whose feedback subscription content filter will be
+ *            configured
+ * \param[in] goal_id goal id represented as a uint8_t array
+ * \param[in] array_size size of the goal_id array
+ * \return #RCL_RET_OK if the call was successful, or
+ * \return #RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or
+ * \return #RCL_RET_BAD_ALLOC if allocating memory failed, or
+ * \return #RCL_RET_ERROR if calling other rcl functions internally does not return RCL_RET_OK, or
+ * \return #RCL_RET_UNSUPPORTED if the middleware doesn't support content filtering
+ */
+RCL_ACTION_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
+  rcl_action_client_t * action_client,
+  uint8_t * goal_id_array,
+  size_t array_size);
+
+/// Configure feedback subscription content filter to remove one goal ID
+/**
+ * If goal ID doesn't exist in feedback subscription content filter, return RCL_RET_OK.
+ *
+ * If rmw middleware doesn't support content filtering feature, return RCL_RET_OK.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | Maybe [1]
+ * Lock-Free          | Maybe [1]
+ * <i>[1] rmw implementation defined</i>
+ *
+ * \param[in] action_client action client whose feedback subscription content filter will be
+ *            configured
+ * \param[in] goal_id goal id represented as a uint8_t array
+ * \param[in] array_size size of the goal_id array
+ * \return #RCL_RET_OK if the call was successful, or
+ * \return #RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or
+ * \return #RCL_RET_BAD_ALLOC if allocating memory failed, or
+ * \return #RCL_RET_ERROR if calling other rcl functions internally does not return RCL_RET_OK
+ */
+RCL_ACTION_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
+  rcl_action_client_t * action_client,
+  uint8_t * goal_id_array,
+  size_t array_size);
+
 RCL_ACTION_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t

--- a/rcl_action/include/rcl_action/action_client.h
+++ b/rcl_action/include/rcl_action/action_client.h
@@ -810,8 +810,8 @@ RCL_ACTION_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
 rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
-  rcl_action_client_t * action_client,
-  uint8_t * goal_id_array,
+  const rcl_action_client_t * action_client,
+  const uint8_t * goal_id_array,
   size_t array_size);
 
 /// Configure feedback subscription content filter to remove one goal ID
@@ -843,8 +843,8 @@ RCL_ACTION_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
 rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
-  rcl_action_client_t * action_client,
-  uint8_t * goal_id_array,
+  const rcl_action_client_t * action_client,
+  const uint8_t * goal_id_array,
   size_t array_size);
 
 RCL_ACTION_PUBLIC

--- a/rcl_action/src/rcl_action/action_client.c
+++ b/rcl_action/src/rcl_action/action_client.c
@@ -66,7 +66,8 @@ _rcl_action_get_zero_initialized_client_impl(void)
     0,
     0,
     0,
-    rosidl_get_zero_initialized_type_hash()
+    rosidl_get_zero_initialized_type_hash(),
+    false
   };
   return null_action_client;
 }
@@ -280,7 +281,6 @@ rcl_action_client_get_default_options(void)
   default_options.feedback_topic_qos = rmw_qos_profile_default;
   default_options.status_topic_qos = rcl_action_qos_profile_status_default;
   default_options.allocator = rcl_get_default_allocator();
-  default_options.disable_feedback_sub_cft = false;
   return default_options;
 }
 
@@ -951,7 +951,7 @@ rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
     return RCL_RET_ACTION_CLIENT_INVALID;
   }
 
-  if (action_client->impl->options.disable_feedback_sub_cft) {
+  if (action_client->impl->disable_feedback_sub_cft) {
     RCL_SET_ERROR_MSG("Content filter has been disabled for feedback subscription.");
     return RCL_RET_ERROR;
   }
@@ -1074,7 +1074,7 @@ rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
 err:
   if (RCL_RET_OK != ret && RCL_RET_UNSUPPORTED != ret) {
     // Clear existing content filter
-    action_client->impl->options.disable_feedback_sub_cft = true;
+    action_client->impl->disable_feedback_sub_cft = true;
     _clear_setting_content_filter_on_error(&action_client->impl->feedback_subscription);
   }
 
@@ -1112,7 +1112,7 @@ rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
     return RCL_RET_ACTION_CLIENT_INVALID;
   }
 
-  if (action_client->impl->options.disable_feedback_sub_cft) {
+  if (action_client->impl->disable_feedback_sub_cft) {
     RCL_SET_ERROR_MSG("Content filter has been disabled for feedback subscription.");
     return RCL_RET_ERROR;
   }
@@ -1258,7 +1258,7 @@ rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
 err:
   if (RCL_RET_OK != ret) {
     // Clear existing content filter
-    action_client->impl->options.disable_feedback_sub_cft = true;
+    action_client->impl->disable_feedback_sub_cft = true;
     _clear_setting_content_filter_on_error(&action_client->impl->feedback_subscription);
   }
 

--- a/rcl_action/src/rcl_action/action_client.c
+++ b/rcl_action/src/rcl_action/action_client.c
@@ -787,6 +787,407 @@ rcl_action_client_configure_action_introspection(
   return RCL_RET_OK;
 }
 
+/// \internal
+/// Converts a goal ID array (uint8_t) to an array of strings.
+static
+rcl_ret_t
+_goal_id_to_string_array(
+  const rcl_allocator_t * allocator,
+  uint8_t * goal_id_array,
+  size_t array_size,
+  char ** goal_id_string_memory_block,
+  char ** goal_id_str_array)
+{
+  // A uint8_t converted to a string occupies at most 4 bytes.
+  char * goal_id_array_str = (char *)allocator->allocate(4 * array_size, allocator->state);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    goal_id_array_str, "allocating memory failed", return RCL_RET_BAD_ALLOC);
+  for (size_t i = 0; i < array_size; ++i) {
+    int n = snprintf(
+      &goal_id_array_str[i * 4], 4, "%u", goal_id_array[i]); // NOLINT
+    if (n < 0 || n >= 4) {
+      goto err;
+    }
+    goal_id_str_array[i] = &goal_id_array_str[i * 4];
+  }
+
+  *goal_id_string_memory_block = goal_id_array_str;
+  return RCL_RET_OK;
+
+err:
+  if (goal_id_array_str != NULL) {
+    allocator->deallocate(goal_id_array_str, allocator->state);
+  }
+
+  return RCL_RET_ERROR;
+}
+
+/// \internal
+/// Generates a filter expression string for goal ID array.
+/// \param[in] goal_id_array_size The size of goal ID array.
+/// \param[out] filter_expression The generated filter expression string. The caller is responsible
+///             for releasing this string.
+/// \param[in] allocator The allocator to use for memory allocation.
+/// \return `RCL_RET_OK` if successful, or an error code otherwise.
+static
+rcl_ret_t
+_generate_goal_id_filter_expression(
+  size_t goal_id_array_size,
+  char ** filter_expression,
+  rcl_allocator_t * allocator)
+{
+  if (goal_id_array_size == 0 || goal_id_array_size % UUID_SIZE != 0 || allocator == NULL) {
+    return RCL_RET_INVALID_ARGUMENT;
+  }
+
+  // Each clause looks like: "goal_id.uuid[XX] = %XX"
+  // Breakdown of maximum length:
+  //   - "goal_id.uuid["            : 13 chars
+  //   - index "XX" (0-15)          :  2 chars max
+  //   - "] = "                     :  4 chars
+  //   - parameter "%XX" (0-99)     :  4 chars max
+  //   => "goal_id.uuid[XX] = %XX"  : 23 chars max
+  // When multiple UUID elements are combined, we also add " AND " (5 chars) between clauses.
+  // So per element we need up to 23 + 5 = 28 chars. We round this up to 30 bytes to include
+  // a small safety margin and help cover separators such as ") OR (" between goal ID arrays.
+  int expression_capacity = goal_id_array_size * 30;
+  char * expression_goal_id_arrays = (char *)allocator->allocate(
+    expression_capacity, allocator->state);
+  RCL_CHECK_FOR_NULL_WITH_MSG(
+    expression_goal_id_arrays, "allocating memory failed", return RCL_RET_BAD_ALLOC);
+
+  int pos = 0;
+  size_t num_arrays = goal_id_array_size / UUID_SIZE;
+
+  // Traverse each goal ID array
+  for (size_t i = 0; i < num_arrays; i++) {
+    if (i > 0) {
+      // Not the first goal ID array, add a separator
+      pos += snprintf(expression_goal_id_arrays + pos, expression_capacity - pos, ") OR (");
+    } else if (num_arrays > 1) {
+      // First array: if there are multiple arrays, add an opening parenthesis
+      pos += snprintf(expression_goal_id_arrays + pos, expression_capacity - pos, "(");
+    }
+
+    // Generate expression for one goal ID array
+    for (int j = 0; j < UUID_SIZE; j++) {
+      if (j > 0) {
+        pos += snprintf(expression_goal_id_arrays + pos, expression_capacity - pos, " AND ");
+      }
+      // goal_id.uuid[XX]: the index range of the UUID array is 0-15
+      // The parameter index is global and the index range of the UUID array is 0-99
+      int param_index = i * UUID_SIZE + j;
+      pos += snprintf(
+        expression_goal_id_arrays + pos,
+        expression_capacity - pos,
+        "goal_id.uuid[%d] = %%%d", j, param_index);
+    }
+  }
+
+  // Add the closing parenthesis at the end
+  if (num_arrays > 1) {
+    pos += snprintf(expression_goal_id_arrays + pos, expression_capacity - pos, ")");
+  }
+
+  *filter_expression = expression_goal_id_arrays;
+
+  return RCL_RET_OK;
+}
+
+rcl_ret_t
+rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
+  rcl_action_client_t * action_client,
+  uint8_t * goal_id_array,
+  size_t array_size)
+{
+  if (!rcl_action_client_is_valid(action_client)) {
+    return RCL_RET_ACTION_CLIENT_INVALID;
+  }
+
+  RCL_CHECK_ARGUMENT_FOR_NULL(goal_id_array, RCL_RET_INVALID_ARGUMENT);
+  if (array_size != UUID_SIZE) {
+    return RCL_RET_INVALID_ARGUMENT;
+  }
+
+  // Converts goal ID array (uint8_t) to an array of strings.
+  char * goal_id_string_memory_block = NULL;
+  char * goal_id_str_array[array_size];
+  rcl_ret_t ret = _goal_id_to_string_array(
+    &action_client->impl->options.allocator,
+    goal_id_array,
+    array_size,
+    &goal_id_string_memory_block,
+    goal_id_str_array);
+  if (RCL_RET_OK != ret) {
+    return RCL_RET_ERROR;
+  }
+
+  bool is_cft_enabled =
+    rcl_subscription_is_cft_enabled(&action_client->impl->feedback_subscription);
+
+  rcl_subscription_content_filter_options_t content_filter_options =
+    rcl_get_zero_initialized_subscription_content_filter_options();
+
+  size_t existing_expression_params_size = 0;
+  char ** existing_expression_params = NULL;
+
+  ret = RCL_RET_ERROR;
+
+  if (is_cft_enabled) {
+    // Existing content filter and append new goal ID to it.
+    ret = rcl_subscription_get_content_filter(
+        &action_client->impl->feedback_subscription, &content_filter_options);
+    if (RCL_RET_OK != ret) {
+      RCL_SET_ERROR_MSG("Failed to get cft expression parameters");
+      return ret;
+    }
+    existing_expression_params_size = content_filter_options
+      .rmw_subscription_content_filter_options.expression_parameters.size;
+    existing_expression_params = content_filter_options
+      .rmw_subscription_content_filter_options.expression_parameters.data;
+  }
+
+  size_t new_expression_params_size =
+    existing_expression_params_size + array_size;
+  char * new_expression_params[new_expression_params_size];
+  // Collect existing expression parameters
+  for (size_t i = 0; i < existing_expression_params_size; ++i) {
+    new_expression_params[i] = existing_expression_params[i];
+  }
+  // Append new goal ID array
+  for (size_t i = 0; i < array_size; ++i) {
+    new_expression_params[existing_expression_params_size + i] = goal_id_str_array[i];
+  }
+
+  // Generate new filter expression string
+  char * goal_id_filter_expression = NULL;
+  if (_generate_goal_id_filter_expression(
+      new_expression_params_size,
+      &goal_id_filter_expression,
+      &action_client->impl->options.allocator) != RCL_RET_OK)
+  {
+    RCL_SET_ERROR_MSG("Failed to generate new filter expression");
+    goto err;
+  }
+
+  // Update content filter options
+  rcl_subscription_content_filter_options_t new_content_filter_options =
+    rcl_get_zero_initialized_subscription_content_filter_options();
+  ret = rcl_subscription_content_filter_options_init(
+    &action_client->impl->feedback_subscription,
+    goal_id_filter_expression,
+    new_expression_params_size,
+    (const char **)new_expression_params,
+    &new_content_filter_options);
+  if (RCL_RET_OK != ret) {
+    RCL_SET_ERROR_MSG("Failed to initialize cft options");
+    goto err;
+  }
+
+  // Set new content filter options
+  ret = rcl_subscription_set_content_filter(
+    &action_client->impl->feedback_subscription,
+    &new_content_filter_options);
+  if (RCL_RET_OK == ret) {
+    is_cft_enabled =
+      rcl_subscription_is_cft_enabled(&action_client->impl->feedback_subscription);
+    if (!is_cft_enabled) {
+      ret = RCL_RET_UNSUPPORTED;  // RMW middleware doesn't support content filter
+    }
+  } else {
+    RCL_SET_ERROR_MSG("Failed to set cft expression parameters");
+  }
+
+  ret = rcl_subscription_content_filter_options_fini(
+    &action_client->impl->feedback_subscription, &new_content_filter_options);
+  if (RCL_RET_OK != ret) {
+    RCL_SET_ERROR_MSG("Failed to finalize cft options");
+  }
+
+err:
+  if (goal_id_string_memory_block != NULL) {
+    action_client->impl->options.allocator.deallocate(
+      goal_id_string_memory_block, action_client->impl->options.allocator.state);
+  }
+
+  if (goal_id_filter_expression != NULL) {
+    action_client->impl->options.allocator.deallocate(
+      goal_id_filter_expression, action_client->impl->options.allocator.state);
+  }
+
+  rcl_ret_t ret_tmp = rcl_subscription_content_filter_options_fini(
+    &action_client->impl->feedback_subscription, &content_filter_options);
+  if (RCL_RET_OK != ret_tmp) {
+    RCL_SET_ERROR_MSG("Failed to finalize cft options");
+  }
+
+  return ret;
+}
+
+rcl_ret_t
+rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
+  rcl_action_client_t * action_client,
+  uint8_t * goal_id_array,
+  size_t array_size)
+{
+  if (!rcl_action_client_is_valid(action_client)) {
+    return RCL_RET_ACTION_CLIENT_INVALID;
+  }
+
+  RCL_CHECK_ARGUMENT_FOR_NULL(goal_id_array, RCL_RET_INVALID_ARGUMENT);
+  if (array_size != UUID_SIZE) {
+    return RCL_RET_INVALID_ARGUMENT;
+  }
+
+  // If content filter isn't configured or rmw middleware doesn't support content filter,
+  // do nothing.
+  bool is_cft_enabled =
+    rcl_subscription_is_cft_enabled(&action_client->impl->feedback_subscription);
+  if (!is_cft_enabled) {
+    return RCL_RET_OK;
+  }
+
+  // Converts goal ID array (uint8_t) to an array of strings.
+  char * goal_id_string_memory_block = NULL;
+  char * goal_id_str_array[array_size];
+  rcl_ret_t ret = _goal_id_to_string_array(
+    &action_client->impl->options.allocator,
+    goal_id_array,
+    array_size,
+    &goal_id_string_memory_block,
+    goal_id_str_array);
+  if (RCL_RET_OK != ret) {
+    return RCL_RET_ERROR;
+  }
+
+  // Get existing content filter options
+  rcl_subscription_content_filter_options_t content_filter_options =
+    rcl_get_zero_initialized_subscription_content_filter_options();
+  ret = rcl_subscription_get_content_filter(
+      &action_client->impl->feedback_subscription, &content_filter_options);
+  if (RCL_RET_OK != ret) {
+    RCL_SET_ERROR_MSG("Failed to get cft expression parameters");
+    return ret;
+  }
+
+  char * new_filter_expression = NULL;
+
+  // Check if goal ID is in expression_parameters in content_filter_options
+  size_t expression_params_size = content_filter_options
+    .rmw_subscription_content_filter_options.expression_parameters.size;
+  char ** expression_params =
+    content_filter_options.rmw_subscription_content_filter_options.expression_parameters.data;
+  if (expression_params_size % array_size != 0u) {
+    RCL_SET_ERROR_MSG("Expression parameters size is not divisible by goal ID array size");
+    ret = RCL_RET_ERROR;
+    goto err;
+  }
+  size_t index_expression_params = 0;
+  while (index_expression_params < expression_params_size) {
+    // one_goal_id_array points to the start of one goal ID array in expression_parameters
+    char ** one_goal_id_array = &expression_params[index_expression_params];
+    bool is_matched = true;
+    for (size_t i = 0; i < array_size; ++i) {
+      if (strcmp(one_goal_id_array[i], goal_id_str_array[i]) != 0) {
+        is_matched = false;
+        break;
+      }
+    }
+    if (is_matched) {
+      break;
+    }
+    index_expression_params += array_size;
+  }
+
+  // If found the goal ID in content filter, remove it
+  if (index_expression_params != expression_params_size) {
+    // Prepare new content filter options
+    rcl_subscription_content_filter_options_t new_content_filter_options =
+      rcl_get_zero_initialized_subscription_content_filter_options();
+
+    size_t new_expression_params_size = expression_params_size - array_size;
+    if (new_expression_params_size == 0) {
+      // All goal IDs are removed, disable content filter
+      // Generate empty filter expression options
+      ret = rcl_subscription_content_filter_options_init(
+        &action_client->impl->feedback_subscription,
+        "",
+        0,
+        NULL,
+        &new_content_filter_options);
+      if (RCL_RET_OK != ret) {
+        RCL_SET_ERROR_MSG("Failed to initialize cft options");
+        goto err;
+      }
+    } else {
+      // Create new expression parameters array without the removed goal ID
+      char * new_expression_params[new_expression_params_size];
+      size_t new_index = 0;
+      for (size_t i = 0; i < expression_params_size; ++i) {
+        if (i >= index_expression_params && i < (index_expression_params + array_size)) {
+          // Skip the goal ID to be removed
+          continue;
+        }
+        new_expression_params[new_index++] = expression_params[i];
+      }
+
+      // Generate new filter expression string
+      ret = _generate_goal_id_filter_expression(
+        (expression_params_size - array_size),
+        &new_filter_expression,
+        &action_client->impl->options.allocator);
+      if (RCL_RET_OK != ret) {
+        RCL_SET_ERROR_MSG("Failed to generate new filter expression");
+        goto err;
+      }
+
+      // Generate new filter expression options
+      ret = rcl_subscription_content_filter_options_init(
+        &action_client->impl->feedback_subscription,
+        new_filter_expression,
+        expression_params_size - array_size,
+        (const char **)new_expression_params,
+        &new_content_filter_options);
+      if (RCL_RET_OK != ret) {
+        RCL_SET_ERROR_MSG("Failed to initialize cft options");
+        goto err;
+      }
+    }
+
+    // Update new content filter options
+    ret = rcl_subscription_set_content_filter(
+      &action_client->impl->feedback_subscription,
+      &new_content_filter_options);
+    if (RCL_RET_OK != ret) {
+      RCL_SET_ERROR_MSG("Failed to set cft expression parameters");
+    }
+
+    ret = rcl_subscription_content_filter_options_fini(
+      &action_client->impl->feedback_subscription, &new_content_filter_options);
+    if (RCL_RET_OK != ret) {
+      RCL_SET_ERROR_MSG("Failed to finalize cft options");
+    }
+  }
+
+err:
+  if (goal_id_string_memory_block != NULL) {
+    action_client->impl->options.allocator.deallocate(
+      goal_id_string_memory_block, action_client->impl->options.allocator.state);
+  }
+
+  if (new_filter_expression != NULL) {
+    action_client->impl->options.allocator.deallocate(
+      new_filter_expression, action_client->impl->options.allocator.state);
+  }
+
+  rcl_ret_t ret_tmp = rcl_subscription_content_filter_options_fini(
+    &action_client->impl->feedback_subscription, &content_filter_options);
+  if (RCL_RET_OK != ret_tmp) {
+    RCL_SET_ERROR_MSG("Failed to finalize cft options");
+  }
+
+  return ret;
+}
 #ifdef __cplusplus
 }
 #endif

--- a/rcl_action/src/rcl_action/action_client.c
+++ b/rcl_action/src/rcl_action/action_client.c
@@ -280,6 +280,7 @@ rcl_action_client_get_default_options(void)
   default_options.feedback_topic_qos = rmw_qos_profile_default;
   default_options.status_topic_qos = rcl_action_qos_profile_status_default;
   default_options.allocator = rcl_get_default_allocator();
+  default_options.disable_feedback_sub_cft = false;
   return default_options;
 }
 
@@ -907,6 +908,39 @@ _generate_goal_id_filter_expression(
   return RCL_RET_OK;
 }
 
+static
+void
+_clear_setting_content_filter_on_error(rcl_subscription_t * feedback_subscription)
+{
+  rcl_subscription_content_filter_options_t content_filter_options =
+    rcl_get_zero_initialized_subscription_content_filter_options();
+
+  rcl_ret_t ret = rcl_subscription_content_filter_options_init(
+    feedback_subscription,
+    "",
+    0,
+    NULL,
+    &content_filter_options);
+  if (RCL_RET_OK != ret) {
+    RCL_SET_ERROR_MSG("Failed to initialize cft options to clear existing filter");
+    return;
+  }
+
+  // Update content filter options
+  ret = rcl_subscription_set_content_filter(
+    feedback_subscription,
+    &content_filter_options);
+  if (RCL_RET_OK != ret) {
+    RCL_SET_ERROR_MSG("Failed to clear existing cft expression parameters");
+  }
+
+  ret = rcl_subscription_content_filter_options_fini(
+    feedback_subscription, &content_filter_options);
+  if (RCL_RET_OK != ret) {
+    RCL_SET_ERROR_MSG("Failed to finalize cft options");
+  }
+}
+
 rcl_ret_t
 rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
   const rcl_action_client_t * action_client,
@@ -915,6 +949,11 @@ rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
 {
   if (!rcl_action_client_is_valid(action_client)) {
     return RCL_RET_ACTION_CLIENT_INVALID;
+  }
+
+  if (action_client->impl->options.disable_feedback_sub_cft) {
+    RCL_SET_ERROR_MSG("Content filter has been disabled for feedback subscription.");
+    return RCL_RET_ERROR;
   }
 
   RCL_CHECK_ARGUMENT_FOR_NULL(goal_id_array, RCL_RET_INVALID_ARGUMENT);
@@ -1033,6 +1072,12 @@ rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
   }
 
 err:
+  if (RCL_RET_OK != ret && RCL_RET_UNSUPPORTED != ret) {
+    // Clear existing content filter
+    action_client->impl->options.disable_feedback_sub_cft = true;
+    _clear_setting_content_filter_on_error(&action_client->impl->feedback_subscription);
+  }
+
   if (new_expression_params != NULL) {
     action_client->impl->options.allocator.deallocate(
       new_expression_params, action_client->impl->options.allocator.state);
@@ -1065,6 +1110,11 @@ rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
 {
   if (!rcl_action_client_is_valid(action_client)) {
     return RCL_RET_ACTION_CLIENT_INVALID;
+  }
+
+  if (action_client->impl->options.disable_feedback_sub_cft) {
+    RCL_SET_ERROR_MSG("Content filter has been disabled for feedback subscription.");
+    return RCL_RET_ERROR;
   }
 
   RCL_CHECK_ARGUMENT_FOR_NULL(goal_id_array, RCL_RET_INVALID_ARGUMENT);
@@ -1206,6 +1256,12 @@ rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
   }
 
 err:
+  if (RCL_RET_OK != ret) {
+    // Clear existing content filter
+    action_client->impl->options.disable_feedback_sub_cft = true;
+    _clear_setting_content_filter_on_error(&action_client->impl->feedback_subscription);
+  }
+
   if (goal_id_string_memory_block != NULL) {
     action_client->impl->options.allocator.deallocate(
       goal_id_string_memory_block, action_client->impl->options.allocator.state);

--- a/rcl_action/src/rcl_action/action_client.c
+++ b/rcl_action/src/rcl_action/action_client.c
@@ -958,6 +958,7 @@ rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
   }
 
   if (!rcl_subscription_is_cft_supported(&action_client->impl->feedback_subscription)) {
+    RCL_SET_ERROR_MSG("RMW implementation does not support content filter.");
     return RCL_RET_UNSUPPORTED;
   }
 
@@ -1117,6 +1118,7 @@ rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
   }
 
   if (!rcl_subscription_is_cft_supported(&action_client->impl->feedback_subscription)) {
+    RCL_SET_ERROR_MSG("RMW implementation does not support content filter.");
     return RCL_RET_UNSUPPORTED;
   }
 

--- a/rcl_action/src/rcl_action/action_client.c
+++ b/rcl_action/src/rcl_action/action_client.c
@@ -859,35 +859,48 @@ _generate_goal_id_filter_expression(
   int pos = 0;
   size_t num_arrays = goal_id_array_size / UUID_SIZE;
 
+  // Helper macro to append formatted string and check for errors
+  #define APPEND_TO_EXPRESSION(...) \
+    do { \
+      int written = snprintf( \
+        expression_goal_id_arrays + pos, expression_capacity - pos, __VA_ARGS__); \
+      if (written < 0 || \
+        written >= expression_capacity - pos || pos + written >= expression_capacity) { \
+        allocator->deallocate(expression_goal_id_arrays, allocator->state); \
+        return RCL_RET_ERROR; \
+      } \
+      pos += written; \
+    } while (0)
+
   // Traverse each goal ID array
   for (size_t i = 0; i < num_arrays; i++) {
     if (i > 0) {
       // Not the first goal ID array, add a separator
-      pos += snprintf(expression_goal_id_arrays + pos, expression_capacity - pos, ") OR (");
+      APPEND_TO_EXPRESSION(") OR (");
     } else if (num_arrays > 1) {
       // First array: if there are multiple arrays, add an opening parenthesis
-      pos += snprintf(expression_goal_id_arrays + pos, expression_capacity - pos, "(");
+      APPEND_TO_EXPRESSION("(");
     }
 
     // Generate expression for one goal ID array
     for (int j = 0; j < UUID_SIZE; j++) {
       if (j > 0) {
-        pos += snprintf(expression_goal_id_arrays + pos, expression_capacity - pos, " AND ");
+        APPEND_TO_EXPRESSION(" AND ");
       }
       // goal_id.uuid[XX]: the index range of the UUID array is 0-15
-      // The parameter index is global and the index range of the UUID array is 0-99
+      // The parameter index is global and the index range is 0-99 (Since DDS spec requires
+      // less than 100 parameters in a filter expression)
       int param_index = i * UUID_SIZE + j;
-      pos += snprintf(
-        expression_goal_id_arrays + pos,
-        expression_capacity - pos,
-        "goal_id.uuid[%d] = %%%d", j, param_index);
+      APPEND_TO_EXPRESSION("goal_id.uuid[%d] = %%%d", j, param_index);
     }
   }
 
   // Add the closing parenthesis at the end
   if (num_arrays > 1) {
-    pos += snprintf(expression_goal_id_arrays + pos, expression_capacity - pos, ")");
+    APPEND_TO_EXPRESSION(")");
   }
+
+  #undef APPEND_TO_EXPRESSION
 
   *filter_expression = expression_goal_id_arrays;
 
@@ -906,12 +919,13 @@ rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
 
   RCL_CHECK_ARGUMENT_FOR_NULL(goal_id_array, RCL_RET_INVALID_ARGUMENT);
   if (array_size != UUID_SIZE) {
+    RCL_SET_ERROR_MSG("Goal id array size must be equal to UUID_SIZE.");
     return RCL_RET_INVALID_ARGUMENT;
   }
 
   // Converts goal ID array (uint8_t) to an array of strings.
   char * goal_id_string_memory_block = NULL;
-  char * goal_id_str_array[array_size];
+  char * goal_id_str_array[UUID_SIZE];
   rcl_ret_t ret = _goal_id_to_string_array(
     &action_client->impl->options.allocator,
     goal_id_array,
@@ -930,6 +944,8 @@ rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
 
   size_t existing_expression_params_size = 0;
   char ** existing_expression_params = NULL;
+  char ** new_expression_params = NULL;
+  char * new_filter_expression = NULL;
 
   ret = RCL_RET_ERROR;
 
@@ -939,7 +955,7 @@ rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
         &action_client->impl->feedback_subscription, &content_filter_options);
     if (RCL_RET_OK != ret) {
       RCL_SET_ERROR_MSG("Failed to get cft expression parameters");
-      return ret;
+      goto err;
     }
     existing_expression_params_size = content_filter_options
       .rmw_subscription_content_filter_options.expression_parameters.size;
@@ -949,7 +965,20 @@ rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
 
   size_t new_expression_params_size =
     existing_expression_params_size + array_size;
-  char * new_expression_params[new_expression_params_size];
+  if (new_expression_params_size > 100) {
+    RCL_SET_ERROR_MSG("Exceeded maximum number of filter expression parameters (100)");
+    ret = RCL_RET_ERROR;
+    goto err;
+  }
+
+  new_expression_params = (char **)action_client->impl->options.allocator.allocate(
+    sizeof(char *) * new_expression_params_size, action_client->impl->options.allocator.state);
+  if (new_expression_params == NULL) {
+    RCL_SET_ERROR_MSG("Failed to allocate memory for expression parameters");
+    ret = RCL_RET_BAD_ALLOC;
+    goto err;
+  }
+
   // Collect existing expression parameters
   for (size_t i = 0; i < existing_expression_params_size; ++i) {
     new_expression_params[i] = existing_expression_params[i];
@@ -960,10 +989,9 @@ rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
   }
 
   // Generate new filter expression string
-  char * goal_id_filter_expression = NULL;
   if (_generate_goal_id_filter_expression(
       new_expression_params_size,
-      &goal_id_filter_expression,
+      &new_filter_expression,
       &action_client->impl->options.allocator) != RCL_RET_OK)
   {
     RCL_SET_ERROR_MSG("Failed to generate new filter expression");
@@ -975,7 +1003,7 @@ rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
     rcl_get_zero_initialized_subscription_content_filter_options();
   ret = rcl_subscription_content_filter_options_init(
     &action_client->impl->feedback_subscription,
-    goal_id_filter_expression,
+    new_filter_expression,
     new_expression_params_size,
     (const char **)new_expression_params,
     &new_content_filter_options);
@@ -998,26 +1026,31 @@ rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
     RCL_SET_ERROR_MSG("Failed to set cft expression parameters");
   }
 
-  ret = rcl_subscription_content_filter_options_fini(
+  rcl_ret_t fini_ret = rcl_subscription_content_filter_options_fini(
     &action_client->impl->feedback_subscription, &new_content_filter_options);
-  if (RCL_RET_OK != ret) {
+  if (RCL_RET_OK != fini_ret) {
     RCL_SET_ERROR_MSG("Failed to finalize cft options");
   }
 
 err:
+  if (new_expression_params != NULL) {
+    action_client->impl->options.allocator.deallocate(
+      new_expression_params, action_client->impl->options.allocator.state);
+  }
+
   if (goal_id_string_memory_block != NULL) {
     action_client->impl->options.allocator.deallocate(
       goal_id_string_memory_block, action_client->impl->options.allocator.state);
   }
 
-  if (goal_id_filter_expression != NULL) {
+  if (new_filter_expression != NULL) {
     action_client->impl->options.allocator.deallocate(
-      goal_id_filter_expression, action_client->impl->options.allocator.state);
+      new_filter_expression, action_client->impl->options.allocator.state);
   }
 
-  rcl_ret_t ret_tmp = rcl_subscription_content_filter_options_fini(
+  fini_ret = rcl_subscription_content_filter_options_fini(
     &action_client->impl->feedback_subscription, &content_filter_options);
-  if (RCL_RET_OK != ret_tmp) {
+  if (RCL_RET_OK != fini_ret) {
     RCL_SET_ERROR_MSG("Failed to finalize cft options");
   }
 
@@ -1036,6 +1069,7 @@ rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
 
   RCL_CHECK_ARGUMENT_FOR_NULL(goal_id_array, RCL_RET_INVALID_ARGUMENT);
   if (array_size != UUID_SIZE) {
+    RCL_SET_ERROR_MSG("Goal id array size must be equal to UUID_SIZE.");
     return RCL_RET_INVALID_ARGUMENT;
   }
 
@@ -1049,7 +1083,7 @@ rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
 
   // Converts goal ID array (uint8_t) to an array of strings.
   char * goal_id_string_memory_block = NULL;
-  char * goal_id_str_array[array_size];
+  char * goal_id_str_array[UUID_SIZE];
   rcl_ret_t ret = _goal_id_to_string_array(
     &action_client->impl->options.allocator,
     goal_id_array,
@@ -1121,6 +1155,8 @@ rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
       }
     } else {
       // Create new expression parameters array without the removed goal ID
+      // DDS spec requires less than 100 parameters in a filter expression, so
+      // new_expression_params_size is guaranteed to be less than 100.
       char * new_expression_params[new_expression_params_size];
       size_t new_index = 0;
       for (size_t i = 0; i < expression_params_size; ++i) {
@@ -1162,9 +1198,9 @@ rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
       RCL_SET_ERROR_MSG("Failed to set cft expression parameters");
     }
 
-    ret = rcl_subscription_content_filter_options_fini(
+    rcl_ret_t fini_ret = rcl_subscription_content_filter_options_fini(
       &action_client->impl->feedback_subscription, &new_content_filter_options);
-    if (RCL_RET_OK != ret) {
+    if (RCL_RET_OK != fini_ret) {
       RCL_SET_ERROR_MSG("Failed to finalize cft options");
     }
   }
@@ -1180,9 +1216,9 @@ err:
       new_filter_expression, action_client->impl->options.allocator.state);
   }
 
-  rcl_ret_t ret_tmp = rcl_subscription_content_filter_options_fini(
+  rcl_ret_t fini_ret = rcl_subscription_content_filter_options_fini(
     &action_client->impl->feedback_subscription, &content_filter_options);
-  if (RCL_RET_OK != ret_tmp) {
+  if (RCL_RET_OK != fini_ret) {
     RCL_SET_ERROR_MSG("Failed to finalize cft options");
   }
 

--- a/rcl_action/src/rcl_action/action_client.c
+++ b/rcl_action/src/rcl_action/action_client.c
@@ -793,7 +793,7 @@ static
 rcl_ret_t
 _goal_id_to_string_array(
   const rcl_allocator_t * allocator,
-  uint8_t * goal_id_array,
+  const uint8_t * goal_id_array,
   size_t array_size,
   char ** goal_id_string_memory_block,
   char ** goal_id_str_array)
@@ -909,8 +909,8 @@ _generate_goal_id_filter_expression(
 
 rcl_ret_t
 rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
-  rcl_action_client_t * action_client,
-  uint8_t * goal_id_array,
+  const rcl_action_client_t * action_client,
+  const uint8_t * goal_id_array,
   size_t array_size)
 {
   if (!rcl_action_client_is_valid(action_client)) {
@@ -1059,8 +1059,8 @@ err:
 
 rcl_ret_t
 rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
-  rcl_action_client_t * action_client,
-  uint8_t * goal_id_array,
+  const rcl_action_client_t * action_client,
+  const uint8_t * goal_id_array,
   size_t array_size)
 {
   if (!rcl_action_client_is_valid(action_client)) {

--- a/rcl_action/src/rcl_action/action_client.c
+++ b/rcl_action/src/rcl_action/action_client.c
@@ -951,15 +951,19 @@ rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
     return RCL_RET_ACTION_CLIENT_INVALID;
   }
 
-  if (action_client->impl->disable_feedback_sub_cft) {
-    RCL_SET_ERROR_MSG("Content filter has been disabled for feedback subscription.");
-    return RCL_RET_ERROR;
-  }
-
   RCL_CHECK_ARGUMENT_FOR_NULL(goal_id_array, RCL_RET_INVALID_ARGUMENT);
   if (array_size != UUID_SIZE) {
     RCL_SET_ERROR_MSG("Goal id array size must be equal to UUID_SIZE.");
     return RCL_RET_INVALID_ARGUMENT;
+  }
+
+  if (!rcl_subscription_is_cft_supported(&action_client->impl->feedback_subscription)) {
+    return RCL_RET_UNSUPPORTED;
+  }
+
+  if (action_client->impl->disable_feedback_sub_cft) {
+    RCL_SET_ERROR_MSG("Content filter has been disabled for feedback subscription.");
+    return RCL_RET_ERROR;
   }
 
   // Converts goal ID array (uint8_t) to an array of strings.
@@ -1055,13 +1059,7 @@ rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
   ret = rcl_subscription_set_content_filter(
     &action_client->impl->feedback_subscription,
     &new_content_filter_options);
-  if (RCL_RET_OK == ret) {
-    is_cft_enabled =
-      rcl_subscription_is_cft_enabled(&action_client->impl->feedback_subscription);
-    if (!is_cft_enabled) {
-      ret = RCL_RET_UNSUPPORTED;  // RMW middleware doesn't support content filter
-    }
-  } else {
+  if (RCL_RET_OK != ret) {
     RCL_SET_ERROR_MSG("Failed to set cft expression parameters");
   }
 
@@ -1072,8 +1070,8 @@ rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
   }
 
 err:
-  if (RCL_RET_OK != ret && RCL_RET_UNSUPPORTED != ret) {
-    // Clear existing content filter
+  if (RCL_RET_OK != ret) {
+    // Clear existing content filter and disable content filter for feedback subscription
     action_client->impl->disable_feedback_sub_cft = true;
     _clear_setting_content_filter_on_error(&action_client->impl->feedback_subscription);
   }
@@ -1112,19 +1110,22 @@ rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
     return RCL_RET_ACTION_CLIENT_INVALID;
   }
 
-  if (action_client->impl->disable_feedback_sub_cft) {
-    RCL_SET_ERROR_MSG("Content filter has been disabled for feedback subscription.");
-    return RCL_RET_ERROR;
-  }
-
   RCL_CHECK_ARGUMENT_FOR_NULL(goal_id_array, RCL_RET_INVALID_ARGUMENT);
   if (array_size != UUID_SIZE) {
     RCL_SET_ERROR_MSG("Goal id array size must be equal to UUID_SIZE.");
     return RCL_RET_INVALID_ARGUMENT;
   }
 
-  // If content filter isn't configured or rmw middleware doesn't support content filter,
-  // do nothing.
+  if (!rcl_subscription_is_cft_supported(&action_client->impl->feedback_subscription)) {
+    return RCL_RET_UNSUPPORTED;
+  }
+
+  if (action_client->impl->disable_feedback_sub_cft) {
+    RCL_SET_ERROR_MSG("Content filter has been disabled for feedback subscription.");
+    return RCL_RET_ERROR;
+  }
+
+  // If content filter isn't configured, do nothing.
   bool is_cft_enabled =
     rcl_subscription_is_cft_enabled(&action_client->impl->feedback_subscription);
   if (!is_cft_enabled) {
@@ -1257,7 +1258,7 @@ rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
 
 err:
   if (RCL_RET_OK != ret) {
-    // Clear existing content filter
+    // Clear existing content filter and disable content filter for feedback subscription
     action_client->impl->disable_feedback_sub_cft = true;
     _clear_setting_content_filter_on_error(&action_client->impl->feedback_subscription);
   }

--- a/rcl_action/src/rcl_action/action_client.c
+++ b/rcl_action/src/rcl_action/action_client.c
@@ -1158,6 +1158,7 @@ rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
   }
 
   char * new_filter_expression = NULL;
+  char ** new_expression_params = NULL;
 
   // Check if goal ID is in expression_parameters in content_filter_options
   size_t expression_params_size = content_filter_options
@@ -1210,7 +1211,15 @@ rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
       // Create new expression parameters array without the removed goal ID
       // DDS spec requires less than 100 parameters in a filter expression, so
       // new_expression_params_size is guaranteed to be less than 100.
-      char * new_expression_params[new_expression_params_size];
+      new_expression_params =
+        (char **)action_client->impl->options.allocator.allocate(
+          sizeof(char *) * new_expression_params_size,
+          action_client->impl->options.allocator.state);
+      if (new_expression_params == NULL) {
+        RCL_SET_ERROR_MSG("Failed to allocate memory for expression parameters");
+        ret = RCL_RET_BAD_ALLOC;
+        goto err;
+      }
       size_t new_index = 0;
       for (size_t i = 0; i < expression_params_size; ++i) {
         if (i >= index_expression_params && i < (index_expression_params + array_size)) {
@@ -1259,6 +1268,11 @@ rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
   }
 
 err:
+  if (NULL != new_expression_params) {
+    action_client->impl->options.allocator.deallocate(
+      new_expression_params, action_client->impl->options.allocator.state);
+  }
+
   if (RCL_RET_OK != ret) {
     // Clear existing content filter and disable content filter for feedback subscription
     action_client->impl->disable_feedback_sub_cft = true;

--- a/rcl_action/src/rcl_action/action_client_impl.h
+++ b/rcl_action/src/rcl_action/action_client_impl.h
@@ -38,9 +38,12 @@ typedef struct rcl_action_client_impl_s
   /// Disable the content filter feature for feedback subscription.
   /**
    * The default value is false.
-   * Set to true to disable the content filter feature of the feedback subscription
-   * - When the parameter limit of the content filter is exceeded (>100)
-   * - When configuring (adding/removing goal ID) the feedback subscription return error
+   * Set to true to disable the content filter feature of the feedback subscription. This field is
+   * set automatically in rcl_action_client_configure_feedback_subscription_filter_add_goal_id() and
+   * rcl_action_client_configure_feedback_subscription_filter_remove_goal_id()
+   * - When the parameter limit of the content filter is exceeded (>100, That is, the number of
+   *   goal ids is greater than 6.)
+   * - When calling the content filter-related functions returns RCL_RET_ERROR.
    */
   bool disable_feedback_sub_cft;
 } rcl_action_client_impl_t;

--- a/rcl_action/src/rcl_action/action_client_impl.h
+++ b/rcl_action/src/rcl_action/action_client_impl.h
@@ -34,6 +34,15 @@ typedef struct rcl_action_client_impl_s
   size_t wait_set_feedback_subscription_index;
   size_t wait_set_status_subscription_index;
   rosidl_type_hash_t type_hash;
+
+  /// Disable the content filter feature for feedback subscription.
+  /**
+   * The default value is false.
+   * Set to true to disable the content filter feature of the feedback subscription
+   * - When the parameter limit of the content filter is exceeded (>100)
+   * - When configuring (adding/removing goal ID) the feedback subscription return error
+   */
+  bool disable_feedback_sub_cft;
 } rcl_action_client_impl_t;
 
 

--- a/rcl_action/test/rcl_action/test_action_client.cpp
+++ b/rcl_action/test/rcl_action/test_action_client.cpp
@@ -576,6 +576,21 @@ TEST_F(TestActionClientFixture, test_configure_feedback_subscription_filter_goal
 TEST_F(
   TestActionClientFixture, test_configure_feedback_subscription_filter_goal_id_reach_limitation)
 {
+  // Skip the test if content filter isn't supported.
+  if (!rcl_subscription_is_cft_supported(&this->action_client.impl->feedback_subscription)) {
+    GTEST_SKIP() << "RMW implementation does not support content filter.";
+  }
+
+  // Skip the test if the RMW implementation is ConnextDDS.
+  // ConnextDDS has restrictions on the length of content filter expressions. Please refer to
+  // the definition of RMW_CONNEXT_CONTENTFILTER_PROPERTY_MAX_LENGTH. The current default value
+  // is 1024, which cannot support setting 6 goal IDs. So the test will be skipped for ConnextDDS
+  // to avoid failure. If the default value is increased in the future, this test can be enabled
+  // for ConnextDDS as well.
+  if (strcmp(rmw_get_implementation_identifier(), "rmw_connextdds") == 0) {
+    GTEST_SKIP() << "RMW implementation is ConnextDDS.";
+  }
+
   // A maximum of 6 goal IDs are supported. Configuring a 7th goal ID will exceed the content
   // filter's maximum limit of 100 parameters. An error should be returned.
   constexpr uint8_t MAX_SUPPORTED_GOAL_IDS = 6;

--- a/rcl_action/test/rcl_action/test_action_client.cpp
+++ b/rcl_action/test/rcl_action/test_action_client.cpp
@@ -485,3 +485,85 @@ TEST_F(TestActionClientFixture, test_set_internal_services_introspection_content
 {
   check_set_services_introspection(RCL_SERVICE_INTROSPECTION_CONTENTS, 1);
 }
+
+TEST_F(TestActionClientFixture, test_configure_feedback_subscription_filter_goal_id_invalid_inputs)
+{
+  uint8_t goal_id[UUID_SIZE] = {0};
+
+  rcl_ret_t ret = rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
+    nullptr, goal_id, UUID_SIZE);
+  EXPECT_EQ(RCL_RET_ACTION_CLIENT_INVALID, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
+
+  rcl_action_client_t invalid_client = rcl_action_get_zero_initialized_client();
+  ret = rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
+    &invalid_client, goal_id, UUID_SIZE);
+  EXPECT_EQ(RCL_RET_ACTION_CLIENT_INVALID, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
+
+  ret = rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
+    &this->action_client, nullptr, UUID_SIZE);
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
+
+  ret = rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
+    &this->action_client, goal_id, UUID_SIZE - 1);
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
+
+  ret = rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
+    nullptr, goal_id, UUID_SIZE);
+  EXPECT_EQ(RCL_RET_ACTION_CLIENT_INVALID, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
+
+  ret = rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
+    &invalid_client, goal_id, UUID_SIZE);
+  EXPECT_EQ(RCL_RET_ACTION_CLIENT_INVALID, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
+
+  ret = rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
+    &this->action_client, nullptr, UUID_SIZE);
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
+
+  ret = rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
+    &this->action_client, goal_id, UUID_SIZE - 1);
+  EXPECT_EQ(RCL_RET_INVALID_ARGUMENT, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
+}
+
+TEST_F(TestActionClientFixture, test_configure_feedback_subscription_filter_goal_id_add)
+{
+  const char * rmw_implementation = rmw_get_implementation_identifier();
+
+  uint8_t goal_id[UUID_SIZE];
+  for (size_t i = 0; i < UUID_SIZE; ++i) {
+    goal_id[i] = static_cast<uint8_t>(i);
+  }
+
+  rcl_ret_t ret = rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
+    &this->action_client, goal_id, UUID_SIZE);
+  // Only FastDDS and ConnextDDS support content filtering
+  if (strcmp(rmw_implementation, "rmw_fastrtps_cpp") == 0 ||
+    strcmp(rmw_implementation, "rmw_connextdds") == 0)
+  {
+    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+    rcl_reset_error();
+  } else {
+    EXPECT_EQ(RCL_RET_UNSUPPORTED, ret) << rcl_get_error_string().str;
+    rcl_reset_error();
+  }
+}
+
+TEST_F(TestActionClientFixture, test_configure_feedback_subscription_filter_goal_id_remove)
+{
+  uint8_t goal_id[UUID_SIZE];
+  for (size_t i = 0; i < UUID_SIZE; ++i) {
+    goal_id[i] = static_cast<uint8_t>(i);
+  }
+
+  rcl_ret_t ret = rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
+    &this->action_client, goal_id, UUID_SIZE);
+  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+  rcl_reset_error();
+}

--- a/rcl_action/test/rcl_action/test_action_client.cpp
+++ b/rcl_action/test/rcl_action/test_action_client.cpp
@@ -567,3 +567,29 @@ TEST_F(TestActionClientFixture, test_configure_feedback_subscription_filter_goal
   EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   rcl_reset_error();
 }
+
+TEST_F(
+  TestActionClientFixture, test_configure_feedback_subscription_filter_goal_id_reach_limitation)
+{
+  // A maximum of 6 goal IDs are supported. Configuring a 7th goal ID will exceed the content
+  // filter's maximum limit of 100 parameters. An error should be returned.
+  constexpr uint8_t MAX_SUPPORTED_GOAL_IDS = 6;
+  constexpr uint8_t num_goal_ids_exceeding_limit = MAX_SUPPORTED_GOAL_IDS + 1;
+  uint8_t goal_id_base[UUID_SIZE] = {0};
+  for (size_t i = 0; i < num_goal_ids_exceeding_limit; ++i) {
+    goal_id_base[UUID_SIZE - 1] = static_cast<uint8_t>(i);
+    rcl_ret_t ret = rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
+      &this->action_client, goal_id_base, UUID_SIZE);
+    if (i < MAX_SUPPORTED_GOAL_IDS) {
+      EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+      rcl_reset_error();
+      EXPECT_EQ(action_client.impl->options.disable_feedback_sub_cft, false);
+    } else {
+      EXPECT_EQ(RCL_RET_ERROR, ret) << rcl_get_error_string().str;
+      rcl_reset_error();
+      // The content filter should be disabled since the maximum number of content filter
+      // parameters has been reached.
+      EXPECT_EQ(action_client.impl->options.disable_feedback_sub_cft, true);
+    }
+  }
+}

--- a/rcl_action/test/rcl_action/test_action_client.cpp
+++ b/rcl_action/test/rcl_action/test_action_client.cpp
@@ -583,13 +583,13 @@ TEST_F(
     if (i < MAX_SUPPORTED_GOAL_IDS) {
       EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
       rcl_reset_error();
-      EXPECT_EQ(action_client.impl->options.disable_feedback_sub_cft, false);
+      EXPECT_EQ(action_client.impl->disable_feedback_sub_cft, false);
     } else {
       EXPECT_EQ(RCL_RET_ERROR, ret) << rcl_get_error_string().str;
       rcl_reset_error();
       // The content filter should be disabled since the maximum number of content filter
       // parameters has been reached.
-      EXPECT_EQ(action_client.impl->options.disable_feedback_sub_cft, true);
+      EXPECT_EQ(action_client.impl->disable_feedback_sub_cft, true);
     }
   }
 }

--- a/rcl_action/test/rcl_action/test_action_client.cpp
+++ b/rcl_action/test/rcl_action/test_action_client.cpp
@@ -534,8 +534,6 @@ TEST_F(TestActionClientFixture, test_configure_feedback_subscription_filter_goal
 
 TEST_F(TestActionClientFixture, test_configure_feedback_subscription_filter_goal_id_add)
 {
-  const char * rmw_implementation = rmw_get_implementation_identifier();
-
   uint8_t goal_id[UUID_SIZE];
   for (size_t i = 0; i < UUID_SIZE; ++i) {
     goal_id[i] = static_cast<uint8_t>(i);
@@ -543,10 +541,10 @@ TEST_F(TestActionClientFixture, test_configure_feedback_subscription_filter_goal
 
   rcl_ret_t ret = rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
     &this->action_client, goal_id, UUID_SIZE);
-  // Only FastDDS and ConnextDDS support content filtering
-  if (strcmp(rmw_implementation, "rmw_fastrtps_cpp") == 0 ||
-    strcmp(rmw_implementation, "rmw_connextdds") == 0)
-  {
+
+  // If rmw implementation supports content filter, the function should succeed. Otherwise,
+  // it should return RCL_RET_UNSUPPORTED.
+  if (rcl_subscription_is_cft_supported(&this->action_client.impl->feedback_subscription)) {
     EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
     rcl_reset_error();
   } else {
@@ -564,8 +562,15 @@ TEST_F(TestActionClientFixture, test_configure_feedback_subscription_filter_goal
 
   rcl_ret_t ret = rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
     &this->action_client, goal_id, UUID_SIZE);
-  EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
-  rcl_reset_error();
+  // If rmw implementation supports content filter, the function should succeed. Otherwise,
+  // it should return RCL_RET_UNSUPPORTED.
+  if (rcl_subscription_is_cft_supported(&this->action_client.impl->feedback_subscription)) {
+    EXPECT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
+    rcl_reset_error();
+  } else {
+    EXPECT_EQ(RCL_RET_UNSUPPORTED, ret) << rcl_get_error_string().str;
+    rcl_reset_error();
+  }
 }
 
 TEST_F(

--- a/rcl_action/test/rcl_action/test_action_communication.cpp
+++ b/rcl_action/test/rcl_action/test_action_communication.cpp
@@ -1736,8 +1736,7 @@ TEST_F(TestActionIntrospection, test_action_client_valid_get_result_service_even
 TEST_F(TestActionCommunication, test_valid_feedback_content_filter_add_one_goal_id)
 {
   const char * rmw_implementation = rmw_get_implementation_identifier();
-  if (!rcl_subscription_is_cft_supported(&this->action_client.impl->feedback_subscription))
-  {
+  if (!rcl_subscription_is_cft_supported(&this->action_client.impl->feedback_subscription)) {
     GTEST_SKIP() << rmw_implementation << " does not support content filtering.";
   }
 
@@ -1834,8 +1833,7 @@ TEST_F(TestActionCommunication, test_valid_feedback_content_filter_add_one_goal_
 TEST_F(TestActionCommunication, test_valid_feedback_content_filter_add_two_goal_ids)
 {
   const char * rmw_implementation = rmw_get_implementation_identifier();
-  if (!rcl_subscription_is_cft_supported(&this->action_client.impl->feedback_subscription))
-  {
+  if (!rcl_subscription_is_cft_supported(&this->action_client.impl->feedback_subscription)) {
     GTEST_SKIP() << rmw_implementation << " does not support content filtering.";
   }
 
@@ -1944,8 +1942,7 @@ TEST_F(TestActionCommunication, test_valid_feedback_content_filter_add_two_goal_
 TEST_F(TestActionCommunication, test_valid_feedback_content_filter_remove_one_goal_id)
 {
   const char * rmw_implementation = rmw_get_implementation_identifier();
-  if (!rcl_subscription_is_cft_supported(&this->action_client.impl->feedback_subscription))
-  {
+  if (!rcl_subscription_is_cft_supported(&this->action_client.impl->feedback_subscription)) {
     GTEST_SKIP() << rmw_implementation << " does not support content filtering.";
   }
 
@@ -2046,8 +2043,7 @@ TEST_F(TestActionCommunication, test_valid_feedback_content_filter_remove_one_go
 TEST_F(TestActionCommunication, test_valid_feedback_content_filter_remove_one_goal_id_from_two)
 {
   const char * rmw_implementation = rmw_get_implementation_identifier();
-  if (!rcl_subscription_is_cft_supported(&this->action_client.impl->feedback_subscription))
-  {
+  if (!rcl_subscription_is_cft_supported(&this->action_client.impl->feedback_subscription)) {
     GTEST_SKIP() << rmw_implementation << " does not support content filtering.";
   }
 

--- a/rcl_action/test/rcl_action/test_action_communication.cpp
+++ b/rcl_action/test/rcl_action/test_action_communication.cpp
@@ -1875,6 +1875,8 @@ TEST_F(TestActionCommunication, test_valid_feedback_content_filter_add_two_goal_
     sizeof(outgoing_feedback2.goal_id.uuid));
   ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
 
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
   // Publish feedback1 for uuid0
   ret = rcl_action_publish_feedback(&this->action_server, &outgoing_feedback1);
   ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;

--- a/rcl_action/test/rcl_action/test_action_communication.cpp
+++ b/rcl_action/test/rcl_action/test_action_communication.cpp
@@ -1992,6 +1992,9 @@ TEST_F(TestActionCommunication, test_valid_feedback_content_filter_remove_one_go
     sizeof(uuid1));
   ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
 
+  // Make sure the content filter update is processed before publishing feedback again
+  std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
   // Publish feedback for uuid0, this time it should be received
   ret = rcl_action_publish_feedback(&this->action_server, &outgoing_feedback);
   ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;

--- a/rcl_action/test/rcl_action/test_action_communication.cpp
+++ b/rcl_action/test/rcl_action/test_action_communication.cpp
@@ -1731,3 +1731,429 @@ TEST_F(TestActionIntrospection, test_action_client_valid_get_result_service_even
   test_msgs__action__Fibonacci_GetResult_Request__fini(&incoming_result_request);
   test_msgs__action__Fibonacci_GetResult_Request__fini(&outgoing_result_request);
 }
+
+TEST_F(TestActionCommunication, test_valid_feedback_content_filter_add_one_goal_id)
+{
+  const char * rmw_implementation = rmw_get_implementation_identifier();
+  if (strcmp(rmw_implementation, "rmw_fastrtps_cpp") != 0 &&
+    strcmp(rmw_implementation, "rmw_connextdds") != 0)
+  {
+    // Content filtering is only supported in FastDDS and ConnextDDS
+    GTEST_SKIP() << "Content filtering is only supported in FastDDS and ConnextDDS.";
+  }
+
+  test_msgs__action__Fibonacci_FeedbackMessage outgoing_feedback1;
+  test_msgs__action__Fibonacci_FeedbackMessage outgoing_feedback2;
+  test_msgs__action__Fibonacci_FeedbackMessage incoming_feedback1;
+  test_msgs__action__Fibonacci_FeedbackMessage incoming_feedback2;
+  test_msgs__action__Fibonacci_FeedbackMessage__init(&outgoing_feedback1);
+  test_msgs__action__Fibonacci_FeedbackMessage__init(&outgoing_feedback2);
+  test_msgs__action__Fibonacci_FeedbackMessage__init(&incoming_feedback1);
+  test_msgs__action__Fibonacci_FeedbackMessage__init(&incoming_feedback2);
+
+  // Initialize feedback1 and feedback2
+  ASSERT_TRUE(
+    rosidl_runtime_c__int32__Sequence__init(
+      &outgoing_feedback1.feedback.sequence, 3));
+  outgoing_feedback1.feedback.sequence.data[0] = 0;
+  outgoing_feedback1.feedback.sequence.data[1] = 1;
+  outgoing_feedback1.feedback.sequence.data[2] = 2;
+  init_test_uuid0(outgoing_feedback1.goal_id.uuid);
+
+  ASSERT_TRUE(
+    rosidl_runtime_c__int32__Sequence__init(
+      &outgoing_feedback2.feedback.sequence, 3));
+  outgoing_feedback2.feedback.sequence.data[0] = 3;
+  outgoing_feedback2.feedback.sequence.data[1] = 4;
+  outgoing_feedback2.feedback.sequence.data[2] = 5;
+  init_test_uuid1(outgoing_feedback2.goal_id.uuid);
+
+  // Add content filter for feedback1(uuid0) only
+  rcl_ret_t ret = rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
+    &this->action_client,
+    outgoing_feedback1.goal_id.uuid,
+    sizeof(outgoing_feedback1.goal_id.uuid));
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  // Publish feedback1 for uuid0
+  ret = rcl_action_publish_feedback(&this->action_server, &outgoing_feedback1);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  // Publish feedback2 for uuid1
+  ret = rcl_action_publish_feedback(&this->action_server, &outgoing_feedback2);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  ret = rcl_action_wait_set_add_action_client(
+    &this->wait_set, &this->action_client, NULL, NULL);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  ret = rcl_wait(&this->wait_set, RCL_S_TO_NS(10));
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  ret = rcl_action_client_wait_set_get_entities_ready(
+    &this->wait_set,
+    &this->action_client,
+    &this->is_feedback_ready,
+    &this->is_status_ready,
+    &this->is_goal_response_ready,
+    &this->is_cancel_response_ready,
+    &this->is_result_response_ready);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  ASSERT_TRUE(this->is_feedback_ready);
+  EXPECT_FALSE(this->is_status_ready);
+  EXPECT_FALSE(this->is_result_response_ready);
+  EXPECT_FALSE(this->is_cancel_response_ready);
+  EXPECT_FALSE(this->is_goal_response_ready);
+
+  // Take feedback1
+  ret = rcl_action_take_feedback(&this->action_client, &incoming_feedback1);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  // Check that feedback1 was received correctly
+  EXPECT_TRUE(
+    uuidcmp(
+      outgoing_feedback1.goal_id.uuid,
+      incoming_feedback1.goal_id.uuid));
+  ASSERT_EQ(outgoing_feedback1.feedback.sequence.size, incoming_feedback1.feedback.sequence.size);
+  EXPECT_TRUE(
+    !memcmp(
+      outgoing_feedback1.feedback.sequence.data,
+      incoming_feedback1.feedback.sequence.data,
+      outgoing_feedback1.feedback.sequence.size));
+
+  // Take feedback2 -- should fail since feedback2's goal_id was not added to the content filter
+  ret = rcl_action_take_feedback(&this->action_client, &incoming_feedback2);
+  ASSERT_EQ(ret, RCL_RET_ACTION_CLIENT_TAKE_FAILED);
+
+  test_msgs__action__Fibonacci_FeedbackMessage__fini(&incoming_feedback1);
+  test_msgs__action__Fibonacci_FeedbackMessage__fini(&incoming_feedback2);
+  test_msgs__action__Fibonacci_FeedbackMessage__fini(&outgoing_feedback1);
+  test_msgs__action__Fibonacci_FeedbackMessage__fini(&outgoing_feedback2);
+}
+
+TEST_F(TestActionCommunication, test_valid_feedback_content_filter_add_two_goal_ids)
+{
+  const char * rmw_implementation = rmw_get_implementation_identifier();
+  if (strcmp(rmw_implementation, "rmw_fastrtps_cpp") != 0 &&
+    strcmp(rmw_implementation, "rmw_connextdds") != 0)
+  {
+    // Content filtering is only supported in FastDDS and ConnextDDS
+    GTEST_SKIP() << "Content filtering is only supported in FastDDS and ConnextDDS.";
+  }
+
+  test_msgs__action__Fibonacci_FeedbackMessage outgoing_feedback1;
+  test_msgs__action__Fibonacci_FeedbackMessage outgoing_feedback2;
+  test_msgs__action__Fibonacci_FeedbackMessage incoming_feedback1;
+  test_msgs__action__Fibonacci_FeedbackMessage incoming_feedback2;
+  test_msgs__action__Fibonacci_FeedbackMessage__init(&outgoing_feedback1);
+  test_msgs__action__Fibonacci_FeedbackMessage__init(&outgoing_feedback2);
+  test_msgs__action__Fibonacci_FeedbackMessage__init(&incoming_feedback1);
+  test_msgs__action__Fibonacci_FeedbackMessage__init(&incoming_feedback2);
+
+  // Initialize feedback1 and feedback2
+  ASSERT_TRUE(
+    rosidl_runtime_c__int32__Sequence__init(
+      &outgoing_feedback1.feedback.sequence, 3));
+  outgoing_feedback1.feedback.sequence.data[0] = 0;
+  outgoing_feedback1.feedback.sequence.data[1] = 1;
+  outgoing_feedback1.feedback.sequence.data[2] = 2;
+  init_test_uuid0(outgoing_feedback1.goal_id.uuid);
+
+  ASSERT_TRUE(
+    rosidl_runtime_c__int32__Sequence__init(
+      &outgoing_feedback2.feedback.sequence, 3));
+  outgoing_feedback2.feedback.sequence.data[0] = 3;
+  outgoing_feedback2.feedback.sequence.data[1] = 4;
+  outgoing_feedback2.feedback.sequence.data[2] = 5;
+  init_test_uuid1(outgoing_feedback2.goal_id.uuid);
+
+  // Add content filter for feedback1(uuid0) and feedback2(uuid1)
+  rcl_ret_t ret = rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
+    &this->action_client,
+    outgoing_feedback1.goal_id.uuid,
+    sizeof(outgoing_feedback1.goal_id.uuid));
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+  ret = rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
+    &this->action_client,
+    outgoing_feedback2.goal_id.uuid,
+    sizeof(outgoing_feedback2.goal_id.uuid));
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  // Publish feedback1 for uuid0
+  ret = rcl_action_publish_feedback(&this->action_server, &outgoing_feedback1);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+  // Publish feedback2 for uuid1
+  ret = rcl_action_publish_feedback(&this->action_server, &outgoing_feedback2);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  ret = rcl_action_wait_set_add_action_client(
+    &this->wait_set, &this->action_client, NULL, NULL);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  ret = rcl_wait(&this->wait_set, RCL_S_TO_NS(10));
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  ret = rcl_action_client_wait_set_get_entities_ready(
+    &this->wait_set,
+    &this->action_client,
+    &this->is_feedback_ready,
+    &this->is_status_ready,
+    &this->is_goal_response_ready,
+    &this->is_cancel_response_ready,
+    &this->is_result_response_ready);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  ASSERT_TRUE(this->is_feedback_ready);
+  EXPECT_FALSE(this->is_status_ready);
+  EXPECT_FALSE(this->is_result_response_ready);
+  EXPECT_FALSE(this->is_cancel_response_ready);
+  EXPECT_FALSE(this->is_goal_response_ready);
+
+  // Take feedback1
+  ret = rcl_action_take_feedback(&this->action_client, &incoming_feedback1);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+  EXPECT_TRUE(
+    uuidcmp(
+      outgoing_feedback1.goal_id.uuid,
+      incoming_feedback1.goal_id.uuid));
+  ASSERT_EQ(outgoing_feedback1.feedback.sequence.size, incoming_feedback1.feedback.sequence.size);
+  EXPECT_TRUE(
+    !memcmp(
+      outgoing_feedback1.feedback.sequence.data,
+      incoming_feedback1.feedback.sequence.data,
+      outgoing_feedback1.feedback.sequence.size));
+
+  // Take feedback2
+  ret = rcl_action_take_feedback(&this->action_client, &incoming_feedback2);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+  EXPECT_TRUE(
+    uuidcmp(
+      outgoing_feedback2.goal_id.uuid,
+      incoming_feedback2.goal_id.uuid));
+  ASSERT_EQ(outgoing_feedback2.feedback.sequence.size, incoming_feedback2.feedback.sequence.size);
+  EXPECT_TRUE(
+    !memcmp(
+      outgoing_feedback2.feedback.sequence.data,
+      incoming_feedback2.feedback.sequence.data,
+      outgoing_feedback2.feedback.sequence.size));
+
+  test_msgs__action__Fibonacci_FeedbackMessage__fini(&incoming_feedback1);
+  test_msgs__action__Fibonacci_FeedbackMessage__fini(&incoming_feedback2);
+  test_msgs__action__Fibonacci_FeedbackMessage__fini(&outgoing_feedback1);
+  test_msgs__action__Fibonacci_FeedbackMessage__fini(&outgoing_feedback2);
+}
+
+TEST_F(TestActionCommunication, test_valid_feedback_content_filter_remove_one_goal_id)
+{
+  const char * rmw_implementation = rmw_get_implementation_identifier();
+  if (strcmp(rmw_implementation, "rmw_fastrtps_cpp") != 0 &&
+    strcmp(rmw_implementation, "rmw_connextdds") != 0)
+  {
+    // Content filtering is only supported in FastDDS and ConnextDDS
+    GTEST_SKIP() << "Content filtering is only supported in FastDDS and ConnextDDS.";
+  }
+
+  test_msgs__action__Fibonacci_FeedbackMessage outgoing_feedback;
+  test_msgs__action__Fibonacci_FeedbackMessage incoming_feedback;
+  test_msgs__action__Fibonacci_FeedbackMessage__init(&outgoing_feedback);
+  test_msgs__action__Fibonacci_FeedbackMessage__init(&incoming_feedback);
+
+  // Initialize feedback
+  ASSERT_TRUE(
+    rosidl_runtime_c__int32__Sequence__init(
+      &outgoing_feedback.feedback.sequence, 3));
+  outgoing_feedback.feedback.sequence.data[0] = 0;
+  outgoing_feedback.feedback.sequence.data[1] = 1;
+  outgoing_feedback.feedback.sequence.data[2] = 2;
+  init_test_uuid0(outgoing_feedback.goal_id.uuid);
+
+  uint8_t uuid1[16];
+  init_test_uuid1(uuid1);
+
+  // Add content filter for uuid1 only
+  rcl_ret_t ret = rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
+    &this->action_client,
+    uuid1,
+    sizeof(uuid1));
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  // Publish feedback for uuid0
+  ret = rcl_action_publish_feedback(&this->action_server, &outgoing_feedback);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  ret = rcl_action_wait_set_add_action_client(
+    &this->wait_set, &this->action_client, NULL, NULL);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  // Nothing should be ready
+  ret = rcl_wait(&this->wait_set, RCL_S_TO_NS(1));
+  ASSERT_EQ(ret, RCL_RET_TIMEOUT) << rcl_get_error_string().str;
+
+  ret = rcl_wait_set_clear(&this->wait_set);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  // Remove content filter for uuid1, so that no content filter is set
+  ret = rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
+    &this->action_client,
+    uuid1,
+    sizeof(uuid1));
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  // Publish feedback for uuid0, this time it should be received
+  ret = rcl_action_publish_feedback(&this->action_server, &outgoing_feedback);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  ret = rcl_action_wait_set_add_action_client(
+    &this->wait_set, &this->action_client, NULL, NULL);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  ret = rcl_wait(&this->wait_set, RCL_S_TO_NS(10));
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  ret = rcl_action_client_wait_set_get_entities_ready(
+    &this->wait_set,
+    &this->action_client,
+    &this->is_feedback_ready,
+    &this->is_status_ready,
+    &this->is_goal_response_ready,
+    &this->is_cancel_response_ready,
+    &this->is_result_response_ready);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  // feedback subscription should be ready
+  EXPECT_TRUE(this->is_feedback_ready);
+  EXPECT_FALSE(this->is_status_ready);
+  EXPECT_FALSE(this->is_result_response_ready);
+  EXPECT_FALSE(this->is_cancel_response_ready);
+  EXPECT_FALSE(this->is_goal_response_ready);
+
+  // Take feedback with valid arguments
+  ret = rcl_action_take_feedback(&this->action_client, &incoming_feedback);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  // Check that feedback was received correctly
+  EXPECT_TRUE(
+    uuidcmp(
+      outgoing_feedback.goal_id.uuid,
+      incoming_feedback.goal_id.uuid));
+  ASSERT_EQ(outgoing_feedback.feedback.sequence.size, incoming_feedback.feedback.sequence.size);
+  EXPECT_TRUE(
+    !memcmp(
+      outgoing_feedback.feedback.sequence.data,
+      incoming_feedback.feedback.sequence.data,
+      outgoing_feedback.feedback.sequence.size));
+
+  test_msgs__action__Fibonacci_FeedbackMessage__fini(&incoming_feedback);
+  test_msgs__action__Fibonacci_FeedbackMessage__fini(&outgoing_feedback);
+}
+
+TEST_F(TestActionCommunication, test_valid_feedback_content_filter_remove_one_goal_id_from_two)
+{
+  const char * rmw_implementation = rmw_get_implementation_identifier();
+  if (strcmp(rmw_implementation, "rmw_fastrtps_cpp") != 0 &&
+    strcmp(rmw_implementation, "rmw_connextdds") != 0)
+  {
+    // Content filtering is only supported in FastDDS and ConnextDDS
+    GTEST_SKIP() << "Content filtering is only supported in FastDDS and ConnextDDS.";
+  }
+
+  test_msgs__action__Fibonacci_FeedbackMessage outgoing_feedback1;
+  test_msgs__action__Fibonacci_FeedbackMessage outgoing_feedback2;
+  test_msgs__action__Fibonacci_FeedbackMessage incoming_feedback1;
+  test_msgs__action__Fibonacci_FeedbackMessage incoming_feedback2;
+  test_msgs__action__Fibonacci_FeedbackMessage__init(&outgoing_feedback1);
+  test_msgs__action__Fibonacci_FeedbackMessage__init(&outgoing_feedback2);
+  test_msgs__action__Fibonacci_FeedbackMessage__init(&incoming_feedback1);
+  test_msgs__action__Fibonacci_FeedbackMessage__init(&incoming_feedback2);
+
+  // Initialize feedback
+  ASSERT_TRUE(
+    rosidl_runtime_c__int32__Sequence__init(
+      &outgoing_feedback1.feedback.sequence, 3));
+  outgoing_feedback1.feedback.sequence.data[0] = 0;
+  outgoing_feedback1.feedback.sequence.data[1] = 1;
+  outgoing_feedback1.feedback.sequence.data[2] = 2;
+  init_test_uuid0(outgoing_feedback1.goal_id.uuid);
+
+  ASSERT_TRUE(
+    rosidl_runtime_c__int32__Sequence__init(
+      &outgoing_feedback2.feedback.sequence, 3));
+  outgoing_feedback2.feedback.sequence.data[0] = 3;
+  outgoing_feedback2.feedback.sequence.data[1] = 4;
+  outgoing_feedback2.feedback.sequence.data[2] = 5;
+  init_test_uuid1(outgoing_feedback2.goal_id.uuid);
+
+  // Add content filter for uuid0 and uuid1
+  rcl_ret_t ret = rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
+    &this->action_client,
+    outgoing_feedback1.goal_id.uuid,
+    sizeof(outgoing_feedback1.goal_id.uuid));
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+  ret = rcl_action_client_configure_feedback_subscription_filter_add_goal_id(
+    &this->action_client,
+    outgoing_feedback2.goal_id.uuid,
+    sizeof(outgoing_feedback2.goal_id.uuid));
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  // Remove content filter for uuid0
+  ret = rcl_action_client_configure_feedback_subscription_filter_remove_goal_id(
+    &this->action_client,
+    outgoing_feedback1.goal_id.uuid,
+    sizeof(outgoing_feedback1.goal_id.uuid));
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  // Now only uuid1 is filtered, so only feedback2 should be received
+  // Publish feedback1 for uuid0
+  ret = rcl_action_publish_feedback(&this->action_server, &outgoing_feedback1);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  // Publish feedback2 for uuid1
+  ret = rcl_action_publish_feedback(&this->action_server, &outgoing_feedback2);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  ret = rcl_action_wait_set_add_action_client(
+    &this->wait_set, &this->action_client, NULL, NULL);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  ret = rcl_wait(&this->wait_set, RCL_S_TO_NS(10));
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  ret = rcl_action_client_wait_set_get_entities_ready(
+    &this->wait_set,
+    &this->action_client,
+    &this->is_feedback_ready,
+    &this->is_status_ready,
+    &this->is_goal_response_ready,
+    &this->is_cancel_response_ready,
+    &this->is_result_response_ready);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+
+  ASSERT_TRUE(this->is_feedback_ready);
+  EXPECT_FALSE(this->is_status_ready);
+  EXPECT_FALSE(this->is_result_response_ready);
+  EXPECT_FALSE(this->is_cancel_response_ready);
+  EXPECT_FALSE(this->is_goal_response_ready);
+
+  // Take feedback2 with valid arguments
+  ret = rcl_action_take_feedback(&this->action_client, &incoming_feedback2);
+  ASSERT_EQ(ret, RCL_RET_OK) << rcl_get_error_string().str;
+  EXPECT_TRUE(
+    uuidcmp(
+      outgoing_feedback2.goal_id.uuid,
+      incoming_feedback2.goal_id.uuid));
+  ASSERT_EQ(outgoing_feedback2.feedback.sequence.size, incoming_feedback2.feedback.sequence.size);
+  EXPECT_TRUE(
+    !memcmp(
+      outgoing_feedback2.feedback.sequence.data,
+      incoming_feedback2.feedback.sequence.data,
+      outgoing_feedback2.feedback.sequence.size));
+
+  ret = rcl_action_take_feedback(&this->action_client, &incoming_feedback1);
+  EXPECT_EQ(ret, RCL_RET_ACTION_CLIENT_TAKE_FAILED);
+
+  test_msgs__action__Fibonacci_FeedbackMessage__fini(&incoming_feedback1);
+  test_msgs__action__Fibonacci_FeedbackMessage__fini(&incoming_feedback2);
+  test_msgs__action__Fibonacci_FeedbackMessage__fini(&outgoing_feedback1);
+  test_msgs__action__Fibonacci_FeedbackMessage__fini(&outgoing_feedback2);
+}

--- a/rcl_action/test/rcl_action/test_action_communication.cpp
+++ b/rcl_action/test/rcl_action/test_action_communication.cpp
@@ -19,6 +19,7 @@
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 
 #include "rcl_action/action_client.h"
+#include "rcl_action/action_client_impl.h"
 #include "rcl_action/action_server.h"
 #include "rcl_action/action_server_impl.h"
 #include "rcl_action/wait.h"
@@ -1735,11 +1736,9 @@ TEST_F(TestActionIntrospection, test_action_client_valid_get_result_service_even
 TEST_F(TestActionCommunication, test_valid_feedback_content_filter_add_one_goal_id)
 {
   const char * rmw_implementation = rmw_get_implementation_identifier();
-  if (strcmp(rmw_implementation, "rmw_fastrtps_cpp") != 0 &&
-    strcmp(rmw_implementation, "rmw_connextdds") != 0)
+  if (!rcl_subscription_is_cft_supported(&this->action_client.impl->feedback_subscription))
   {
-    // Content filtering is only supported in FastDDS and ConnextDDS
-    GTEST_SKIP() << "Content filtering is only supported in FastDDS and ConnextDDS.";
+    GTEST_SKIP() << rmw_implementation << " does not support content filtering.";
   }
 
   test_msgs__action__Fibonacci_FeedbackMessage outgoing_feedback1;
@@ -1835,11 +1834,9 @@ TEST_F(TestActionCommunication, test_valid_feedback_content_filter_add_one_goal_
 TEST_F(TestActionCommunication, test_valid_feedback_content_filter_add_two_goal_ids)
 {
   const char * rmw_implementation = rmw_get_implementation_identifier();
-  if (strcmp(rmw_implementation, "rmw_fastrtps_cpp") != 0 &&
-    strcmp(rmw_implementation, "rmw_connextdds") != 0)
+  if (!rcl_subscription_is_cft_supported(&this->action_client.impl->feedback_subscription))
   {
-    // Content filtering is only supported in FastDDS and ConnextDDS
-    GTEST_SKIP() << "Content filtering is only supported in FastDDS and ConnextDDS.";
+    GTEST_SKIP() << rmw_implementation << " does not support content filtering.";
   }
 
   test_msgs__action__Fibonacci_FeedbackMessage outgoing_feedback1;
@@ -1947,11 +1944,9 @@ TEST_F(TestActionCommunication, test_valid_feedback_content_filter_add_two_goal_
 TEST_F(TestActionCommunication, test_valid_feedback_content_filter_remove_one_goal_id)
 {
   const char * rmw_implementation = rmw_get_implementation_identifier();
-  if (strcmp(rmw_implementation, "rmw_fastrtps_cpp") != 0 &&
-    strcmp(rmw_implementation, "rmw_connextdds") != 0)
+  if (!rcl_subscription_is_cft_supported(&this->action_client.impl->feedback_subscription))
   {
-    // Content filtering is only supported in FastDDS and ConnextDDS
-    GTEST_SKIP() << "Content filtering is only supported in FastDDS and ConnextDDS.";
+    GTEST_SKIP() << rmw_implementation << " does not support content filtering.";
   }
 
   test_msgs__action__Fibonacci_FeedbackMessage outgoing_feedback;
@@ -2051,11 +2046,9 @@ TEST_F(TestActionCommunication, test_valid_feedback_content_filter_remove_one_go
 TEST_F(TestActionCommunication, test_valid_feedback_content_filter_remove_one_goal_id_from_two)
 {
   const char * rmw_implementation = rmw_get_implementation_identifier();
-  if (strcmp(rmw_implementation, "rmw_fastrtps_cpp") != 0 &&
-    strcmp(rmw_implementation, "rmw_connextdds") != 0)
+  if (!rcl_subscription_is_cft_supported(&this->action_client.impl->feedback_subscription))
   {
-    // Content filtering is only supported in FastDDS and ConnextDDS
-    GTEST_SKIP() << "Content filtering is only supported in FastDDS and ConnextDDS.";
+    GTEST_SKIP() << rmw_implementation << " does not support content filtering.";
   }
 
   test_msgs__action__Fibonacci_FeedbackMessage outgoing_feedback1;

--- a/rcl_action/test/rcl_action/test_action_communication.cpp
+++ b/rcl_action/test/rcl_action/test_action_communication.cpp
@@ -1837,6 +1837,16 @@ TEST_F(TestActionCommunication, test_valid_feedback_content_filter_add_two_goal_
     GTEST_SKIP() << rmw_implementation << " does not support content filtering.";
   }
 
+  // Skip the test if the RMW implementation is ConnextDDS.
+  // ConnextDDS has restrictions on the length of content filter expressions. Please refer to
+  // the definition of RMW_CONNEXT_CONTENTFILTER_PROPERTY_MAX_LENGTH. The current default value
+  // is 1024, which cannot support setting 2 goal IDs. So the test will be skipped for ConnextDDS
+  // to avoid failure. If the default value is increased in the future, this test can be enabled
+  // for ConnextDDS as well.
+  if (strcmp(rmw_get_implementation_identifier(), "rmw_connextdds") == 0) {
+    GTEST_SKIP() << "RMW implementation is ConnextDDS.";
+  }
+
   test_msgs__action__Fibonacci_FeedbackMessage outgoing_feedback1;
   test_msgs__action__Fibonacci_FeedbackMessage outgoing_feedback2;
   test_msgs__action__Fibonacci_FeedbackMessage incoming_feedback1;
@@ -2050,6 +2060,16 @@ TEST_F(TestActionCommunication, test_valid_feedback_content_filter_remove_one_go
   const char * rmw_implementation = rmw_get_implementation_identifier();
   if (!rcl_subscription_is_cft_supported(&this->action_client.impl->feedback_subscription)) {
     GTEST_SKIP() << rmw_implementation << " does not support content filtering.";
+  }
+
+  // Skip the test if the RMW implementation is ConnextDDS.
+  // ConnextDDS has restrictions on the length of content filter expressions. Please refer to
+  // the definition of RMW_CONNEXT_CONTENTFILTER_PROPERTY_MAX_LENGTH. The current default value
+  // is 1024, which cannot support setting 2 goal IDs. So the test will be skipped for ConnextDDS
+  // to avoid failure. If the default value is increased in the future, this test can be enabled
+  // for ConnextDDS as well.
+  if (strcmp(rmw_get_implementation_identifier(), "rmw_connextdds") == 0) {
+    GTEST_SKIP() << "RMW implementation is ConnextDDS.";
   }
 
   test_msgs__action__Fibonacci_FeedbackMessage outgoing_feedback1;


### PR DESCRIPTION
## Description

Use Content Filtering for action feedback topic on action clients #1258  
This new interface will be called in rclcpp/rclpy while action client gets Goal ID.

### Is this user-facing behavior change?

No. 

### Did you use Generative AI?

Use github copilot (GPT-5.1-Codex) for test codes

### Additional Information