### PR TITLE
Improved documentation of rcl_XYZ_set_on_new_XYZ_callback

### DIFF
--- a/rcl/include/rcl/client.h
+++ b/rcl/include/rcl/client.h
@@ -477,14 +477,14 @@ rcl_client_response_subscription_get_actual_qos(const rcl_client_t * client);
  *
  * Since this callback is called from the middleware, you should
  * aim to make it fast and not blocking. This callback is intended to implement an event driven executor and
- * not process data directly.  
- * 
+ * not process data directly.
+ *
  * Doing work in this callback can cause delays,
  * deadlocks, or latency due to cross thread waiting
  * as this process runs on middleware managed threads
- * and is meant only to notify the executor that new data 
+ * and is meant only to notify the executor that new data
  * is available in the middleware queue
- * 
+ *
  * <hr>
  * Attribute          | Adherence
  * ------------------ | -------------

--- a/rcl/include/rcl/client.h
+++ b/rcl/include/rcl/client.h
@@ -479,9 +479,9 @@ rcl_client_response_subscription_get_actual_qos(const rcl_client_t * client);
  * aim to make it fast and not blocking. This callback is intended to implement an event driven executor and
  * not process data directly.  
  * 
- * Using blocking operators, waiting for other syncronized actions, 
- * or sending responses directly using this callback will result in
- * the thread being called from an unexpected/different thread context.
+ * Blocking or performing synchronous work here may cause subsequent callbacks
+ * or responses to execute in executor threads different than the current 
+ * middleware thread.
  * 
  * <hr>
  * Attribute          | Adherence

--- a/rcl/include/rcl/client.h
+++ b/rcl/include/rcl/client.h
@@ -476,14 +476,15 @@ rcl_client_response_subscription_get_actual_qos(const rcl_client_t * client);
  * \sa rmw_client_set_on_new_response_callback for details about this function.
  *
  * Since this callback is called from the middleware, you should
- * aim to make it fast and not blocking. This callback is intended to implement an event driven executor and
+ * aim to make it fast and not blocking. This callback
+ * is intended to implement an event driven executor and
  * not process data directly.
  *
  * Doing work in this callback can cause delays,
  * deadlocks, or latency due to cross thread waiting
  * as this process runs on middleware managed threads
  * and is meant only to notify the executor that new data
- * is available in the middleware queue
+ * is available in the middleware queue.
  *
  * <hr>
  * Attribute          | Adherence

--- a/rcl/include/rcl/client.h
+++ b/rcl/include/rcl/client.h
@@ -479,9 +479,11 @@ rcl_client_response_subscription_get_actual_qos(const rcl_client_t * client);
  * aim to make it fast and not blocking. This callback is intended to implement an event driven executor and
  * not process data directly.  
  * 
- * Blocking or performing synchronous work here may cause subsequent callbacks
- * or responses to execute in executor threads different than the current 
- * middleware thread.
+ * Doing work in this callback can cause delays,
+ * deadlocks, or latency due to cross thread waiting
+ * as this process runs on middleware managed threads
+ * and is meant only to notify the executor that new data 
+ * is available in the middleware queue
  * 
  * <hr>
  * Attribute          | Adherence

--- a/rcl/include/rcl/client.h
+++ b/rcl/include/rcl/client.h
@@ -475,6 +475,14 @@ rcl_client_response_subscription_get_actual_qos(const rcl_client_t * client);
  *
  * \sa rmw_client_set_on_new_response_callback for details about this function.
  *
+ * Since this callback is called from the middleware, you should
+ * aim to make it fast and not blocking. This callback is intended to implement an event driven executor and
+ * not process data directly.  
+ * 
+ * Using blocking operators, waiting for other syncronized actions, 
+ * or sending responses directly using this callback will result in
+ * unexpected behavior
+ * 
  * <hr>
  * Attribute          | Adherence
  * ------------------ | -------------

--- a/rcl/include/rcl/client.h
+++ b/rcl/include/rcl/client.h
@@ -481,7 +481,7 @@ rcl_client_response_subscription_get_actual_qos(const rcl_client_t * client);
  * 
  * Using blocking operators, waiting for other syncronized actions, 
  * or sending responses directly using this callback will result in
- * unexpected behavior
+ * the thread being called from an unexpected/different thread context.
  * 
  * <hr>
  * Attribute          | Adherence

--- a/rcl/include/rcl/service.h
+++ b/rcl/include/rcl/service.h
@@ -508,14 +508,15 @@ rcl_service_response_publisher_get_actual_qos(const rcl_service_t * service);
  * \sa rmw_service_set_on_new_request_callback for details about this function.
  *
  * Since this callback is called from the middleware, you should
- * aim to make it fast and not blocking. This callback is intended to implement an event driven executor and
+ * aim to make it fast and not blocking. This callback
+ * is intended to implement an event driven executor and
  * not process data directly.
  *
  * Doing work in this callback can cause delays,
  * deadlocks, or latency due to cross thread waiting
  * as this process runs on middleware managed threads
  * and is meant only to notify the executor that new data
- * is available in the middleware queue
+ * is available in the middleware queue.
  *
  * <hr>
  * Attribute          | Adherence

--- a/rcl/include/rcl/service.h
+++ b/rcl/include/rcl/service.h
@@ -513,7 +513,7 @@ rcl_service_response_publisher_get_actual_qos(const rcl_service_t * service);
  * 
  * Using blocking operators, waiting for other syncronized actions, 
  * or sending responses directly using this callback will result in
- * unexpected behavior
+ * the thread being called from an unexpected/different thread context.
  * 
  * <hr>
  * Attribute          | Adherence

--- a/rcl/include/rcl/service.h
+++ b/rcl/include/rcl/service.h
@@ -511,9 +511,11 @@ rcl_service_response_publisher_get_actual_qos(const rcl_service_t * service);
  * aim to make it fast and not blocking. This callback is intended to implement an event driven executor and
  * not process data directly.  
  * 
- * Blocking or performing synchronous work here may cause subsequent callbacks
- * or responses to execute in executor threads different than the current 
- * middleware thread.
+ * Doing work in this callback can cause delays,
+ * deadlocks, or latency due to cross thread waiting
+ * as this process runs on middleware managed threads
+ * and is meant only to notify the executor that new data 
+ * is available in the middleware queue
  * 
  * <hr>
  * Attribute          | Adherence

--- a/rcl/include/rcl/service.h
+++ b/rcl/include/rcl/service.h
@@ -509,14 +509,14 @@ rcl_service_response_publisher_get_actual_qos(const rcl_service_t * service);
  *
  * Since this callback is called from the middleware, you should
  * aim to make it fast and not blocking. This callback is intended to implement an event driven executor and
- * not process data directly.  
- * 
+ * not process data directly.
+ *
  * Doing work in this callback can cause delays,
  * deadlocks, or latency due to cross thread waiting
  * as this process runs on middleware managed threads
- * and is meant only to notify the executor that new data 
+ * and is meant only to notify the executor that new data
  * is available in the middleware queue
- * 
+ *
  * <hr>
  * Attribute          | Adherence
  * ------------------ | -------------

--- a/rcl/include/rcl/service.h
+++ b/rcl/include/rcl/service.h
@@ -507,6 +507,14 @@ rcl_service_response_publisher_get_actual_qos(const rcl_service_t * service);
  *
  * \sa rmw_service_set_on_new_request_callback for details about this function.
  *
+ * Since this callback is called from the middleware, you should
+ * aim to make it fast and not blocking. This callback is intended to implement an event driven executor and
+ * not process data directly.  
+ * 
+ * Using blocking operators, waiting for other syncronized actions, 
+ * or sending responses directly using this callback will result in
+ * unexpected behavior
+ * 
  * <hr>
  * Attribute          | Adherence
  * ------------------ | -------------

--- a/rcl/include/rcl/service.h
+++ b/rcl/include/rcl/service.h
@@ -511,9 +511,9 @@ rcl_service_response_publisher_get_actual_qos(const rcl_service_t * service);
  * aim to make it fast and not blocking. This callback is intended to implement an event driven executor and
  * not process data directly.  
  * 
- * Using blocking operators, waiting for other syncronized actions, 
- * or sending responses directly using this callback will result in
- * the thread being called from an unexpected/different thread context.
+ * Blocking or performing synchronous work here may cause subsequent callbacks
+ * or responses to execute in executor threads different than the current 
+ * middleware thread.
  * 
  * <hr>
  * Attribute          | Adherence

--- a/rcl/include/rcl/subscription.h
+++ b/rcl/include/rcl/subscription.h
@@ -887,14 +887,15 @@ rcl_subscription_can_loan_messages(const rcl_subscription_t * subscription);
  * function.
  *
  * Since this callback is called from the middleware, you should
- * aim to make it fast and not blocking. This callback is intended to implement an event driven executor and
+ * aim to make it fast and not blocking. This callback
+ * is intended to implement an event driven executor and
  * not process data directly.
  *
  * Doing work in this callback can cause delays,
  * deadlocks, or latency due to cross thread waiting
  * as this process runs on middleware managed threads
  * and is meant only to notify the executor that new data
- * is available in the middleware queue
+ * is available in the middleware queue.
  *
  * <hr>
  * Attribute          | Adherence

--- a/rcl/include/rcl/subscription.h
+++ b/rcl/include/rcl/subscription.h
@@ -888,14 +888,14 @@ rcl_subscription_can_loan_messages(const rcl_subscription_t * subscription);
  *
  * Since this callback is called from the middleware, you should
  * aim to make it fast and not blocking. This callback is intended to implement an event driven executor and
- * not process data directly.  
- * 
+ * not process data directly.
+ *
  * Doing work in this callback can cause delays,
  * deadlocks, or latency due to cross thread waiting
  * as this process runs on middleware managed threads
- * and is meant only to notify the executor that new data 
+ * and is meant only to notify the executor that new data
  * is available in the middleware queue
- * 
+ *
  * <hr>
  * Attribute          | Adherence
  * ------------------ | -------------

--- a/rcl/include/rcl/subscription.h
+++ b/rcl/include/rcl/subscription.h
@@ -890,9 +890,11 @@ rcl_subscription_can_loan_messages(const rcl_subscription_t * subscription);
  * aim to make it fast and not blocking. This callback is intended to implement an event driven executor and
  * not process data directly.  
  * 
- * Blocking or performing synchronous work here may cause subsequent callbacks
- * or responses to execute in executor threads different than the current 
- * middleware thread.
+ * Doing work in this callback can cause delays,
+ * deadlocks, or latency due to cross thread waiting
+ * as this process runs on middleware managed threads
+ * and is meant only to notify the executor that new data 
+ * is available in the middleware queue
  * 
  * <hr>
  * Attribute          | Adherence

--- a/rcl/include/rcl/subscription.h
+++ b/rcl/include/rcl/subscription.h
@@ -890,9 +890,9 @@ rcl_subscription_can_loan_messages(const rcl_subscription_t * subscription);
  * aim to make it fast and not blocking. This callback is intended to implement an event driven executor and
  * not process data directly.  
  * 
- * Using blocking operators, waiting for other syncronized actions, 
- * or sending responses directly using this callback will result in
- * the thread being called from an unexpected/different thread context.
+ * Blocking or performing synchronous work here may cause subsequent callbacks
+ * or responses to execute in executor threads different than the current 
+ * middleware thread.
  * 
  * <hr>
  * Attribute          | Adherence

--- a/rcl/include/rcl/subscription.h
+++ b/rcl/include/rcl/subscription.h
@@ -892,7 +892,7 @@ rcl_subscription_can_loan_messages(const rcl_subscription_t * subscription);
  * 
  * Using blocking operators, waiting for other syncronized actions, 
  * or sending responses directly using this callback will result in
- * unexpected behavior
+ * the thread being called from an unexpected/different thread context.
  * 
  * <hr>
  * Attribute          | Adherence

--- a/rcl/include/rcl/subscription.h
+++ b/rcl/include/rcl/subscription.h
@@ -886,6 +886,14 @@ rcl_subscription_can_loan_messages(const rcl_subscription_t * subscription);
  * \sa rmw_subscription_set_on_new_message_callback for details about this
  * function.
  *
+ * Since this callback is called from the middleware, you should
+ * aim to make it fast and not blocking. This callback is intended to implement an event driven executor and
+ * not process data directly.  
+ * 
+ * Using blocking operators, waiting for other syncronized actions, 
+ * or sending responses directly using this callback will result in
+ * unexpected behavior
+ * 
  * <hr>
  * Attribute          | Adherence
  * ------------------ | -------------


### PR DESCRIPTION
## Description
Signed off: Rushhaank Sahay rushhaank.sahay@gmail.com
Updates the documentation for rcl_service_set_on_new_request_callback and rcl_subscription_set_on_new_message_callback methods to encourage users to make the process non-blocking and warn them of unexpected behavior if it is blocked
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes #1282 
Addresses #1277 

### Is this user-facing behavior change?

Yes. It changes user behavior as it specifies to users the proper way to use these methods to avoid unexpected behaviors.

### Did you use Generative AI?

No

