### PR TITLE
Add tests isolation for rmw_zenoh

### DIFF
--- a/rcl/test/rcl/test_rmw_impl_id_check.py.in
+++ b/rcl/test/rcl/test_rmw_impl_id_check.py.in
@@ -43,6 +43,13 @@ def generate_test_description(
     if rcl_assert_rmw_id_matches_env is not None:
         env['RCL_ASSERT_RMW_ID_MATCHES'] = rcl_assert_rmw_id_matches_env
 
+    if rmw_implementation_env is 'rmw_zenoh_cpp':
+        # Since the test is purely local (checks on loaded rmw_implementation lib),
+        # avoid connection to a Zenoh router in case rmw_zenoh_cpp is loaded.
+        # This avoids unecessary warning logs and saves time at rmw_init()
+        env['ZENOH_CONFIG_OVERRIDE'] = 'connect/endpoints=[]'
+        env['ZENOH_ROUTER_CHECK_ATTEMPTS'] = '-1'
+
     executable_under_test = ExecuteProcess(
         cmd=['@TEST_RMW_IMPL_ID_CHECK_EXECUTABLE_NAME@'],
         name='@TEST_RMW_IMPL_ID_CHECK_EXECUTABLE_NAME@',

--- a/rcl/test/rcl/test_rmw_impl_id_check.py.in
+++ b/rcl/test/rcl/test_rmw_impl_id_check.py.in
@@ -46,7 +46,7 @@ def generate_test_description(
     if rmw_implementation_env == 'rmw_zenoh_cpp':
         # Since the test is purely local (checks on loaded rmw_implementation lib),
         # avoid connection to a Zenoh router in case rmw_zenoh_cpp is loaded.
-        # This avoids unecessary warning logs and saves time at rmw_init()
+        # This avoids unnecessary warning logs and saves time at rmw_init()
         env['ZENOH_CONFIG_OVERRIDE'] = 'connect/endpoints=[]'
         env['ZENOH_ROUTER_CHECK_ATTEMPTS'] = '-1'
 

--- a/rcl/test/rcl/test_rmw_impl_id_check.py.in
+++ b/rcl/test/rcl/test_rmw_impl_id_check.py.in
@@ -43,7 +43,7 @@ def generate_test_description(
     if rcl_assert_rmw_id_matches_env is not None:
         env['RCL_ASSERT_RMW_ID_MATCHES'] = rcl_assert_rmw_id_matches_env
 
-    if rmw_implementation_env is 'rmw_zenoh_cpp':
+    if rmw_implementation_env == 'rmw_zenoh_cpp':
         # Since the test is purely local (checks on loaded rmw_implementation lib),
         # avoid connection to a Zenoh router in case rmw_zenoh_cpp is loaded.
         # This avoids unecessary warning logs and saves time at rmw_init()

--- a/rcl_action/CMakeLists.txt
+++ b/rcl_action/CMakeLists.txt
@@ -77,7 +77,7 @@ install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
 )
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_cmake_ros REQUIRED)
   find_package(ament_lint_auto REQUIRED)
   find_package(osrf_testing_tools_cpp REQUIRED)
   find_package(test_msgs REQUIRED)
@@ -136,25 +136,17 @@ if(BUILD_TESTING)
     message(STATUS "Creating tests for '${rmw_implementation}'")
     set(rmw_implementation_env_var RMW_IMPLEMENTATION=${rmw_implementation})
 
-    # If the rmw_implementation is rmw_zenoh_cpp, run the tests with multicast discovery enabled.
-    # Note: This is a temporary change that will be reverted before we branch into Kilted.
-    if(rmw_implementation STREQUAL "rmw_zenoh_cpp")
-      list(APPEND rmw_implementation_env_var
-        ZENOH_CONFIG_OVERRIDE=scouting/multicast/enabled=true
-      )
-    endif()
-
-    ament_add_gtest_test(test_action_communication
+    ament_add_ros_isolated_gtest_test(test_action_communication
       TEST_NAME test_action_communication${target_suffix}
       ENV ${rmw_implementation_env_var}
     )
 
-    ament_add_gtest_test(test_action_interaction
+    ament_add_ros_isolated_gtest_test(test_action_interaction
       TEST_NAME test_action_interaction${target_suffix}
       ENV ${rmw_implementation_env_var}
     )
 
-    ament_add_gtest_test(test_graph
+    ament_add_ros_isolated_gtest_test(test_graph
       TEST_NAME test_graph${target_suffix}
       ENV ${rmw_implementation_env_var}
       TIMEOUT 180

--- a/rcl_action/package.xml
+++ b/rcl_action/package.xml
@@ -22,7 +22,7 @@
   <depend>rmw</depend>
   <depend>rosidl_runtime_c</depend>
 
-  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>osrf_testing_tools_cpp</test_depend>


### PR DESCRIPTION
## Description

As discussed in https://github.com/ros2/rmw_zenoh/issues/881#issuecomment-3891134977, this PR adds tests isolation:
- in `rcl_action` using `ament_add_ros_isolated_gtest_test` in CMakeLists.txt
- in `rcl/test_rmw_impl_id_check` setting `ZENOH_CONFIG_OVERRIDE` to not attempt connection to any router.


### Is this user-facing behavior change?

No

### Did you use Generative AI?

No
