### PR TITLE
Use the POSIX locale to parse YAML double

### DIFF
--- a/rcl_yaml_param_parser/src/parse.c
+++ b/rcl_yaml_param_parser/src/parse.c
@@ -14,6 +14,7 @@
 
 #include <ctype.h>
 #include <errno.h>
+#include <locale.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -779,6 +780,20 @@ _get_int_value(
   return RCUTILS_RET_ERROR;
 }
 
+///
+/// Calls strtod with the default "POSIX/C" locale.
+///
+static double strtod_posix_locale(const char *restrict nptr, char **restrict endptr)
+{
+    static locale_t c_locale = 0;
+    if (c_locale == 0)
+        c_locale = newlocale(LC_ALL_MASK, "C", 0);
+    locale_t old_locale = uselocale(c_locale);
+    double result = strtod(nptr, endptr);
+    uselocale(old_locale);
+    return result;
+}
+
 rcutils_ret_t
 _get_float_value(
   const char * const value,
@@ -807,12 +822,12 @@ _get_float_value(
     for (iter_ptr = value; !isalpha(*iter_ptr); ) {
       iter_ptr += 1;
     }
-    dval = strtod(iter_ptr, &endptr);
+    dval = strtod_posix_locale(iter_ptr, &endptr);
     if (*value == '-') {
       dval = -dval;
     }
   } else {
-    dval = strtod(value, &endptr);
+    dval = strtod_posix_locale(value, &endptr);
   }
   if ((0 == errno) && (NULL != endptr)) {
     if ((NULL != endptr) && (endptr != value)) {

--- a/rcl_yaml_param_parser/src/parse.c
+++ b/rcl_yaml_param_parser/src/parse.c
@@ -18,6 +18,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <threads.h>
+#endif
+
 #include <yaml.h>
 
 #include "rcutils/allocator.h"
@@ -780,6 +786,32 @@ _get_int_value(
   return RCUTILS_RET_ERROR;
 }
 
+// Initialization of c_locale, used by strtod_locale_independent.
+#ifdef _WIN32
+static _locale_t c_locale = NULL;
+static INIT_ONCE c_locale_once_flag = INIT_ONCE_STATIC_INIT;
+
+BOOL CALLBACK init_c_locale(
+  PINIT_ONCE init_once,
+  PVOID parameter,
+  PVOID *context)
+{
+  (void)init_once;
+  (void)parameter;
+  (void)context;
+  c_locale = _create_locale(LC_NUMERIC, "C");
+  return TRUE;
+}
+#else
+static locale_t c_locale = 0;
+static once_flag c_locale_once_flag = ONCE_FLAG_INIT;
+
+static void init_c_locale()
+{
+  c_locale = newlocale(LC_NUMERIC_MASK, "C", 0);
+}
+#endif
+
 ///
 /// Calls strtod with the default "C" locale.
 /// \param[in] nptr the string to parse.
@@ -791,30 +823,24 @@ _get_int_value(
 static double strtod_locale_independent(const char *restrict nptr, char **restrict endptr)
 {
 #ifdef _WIN32
-  static _locale_t c_locale = NULL;
+  InitOnceExecuteOnce(&c_locale_once_flag, init_c_locale, NULL, NULL);
 
   if (NULL == c_locale) {
-    c_locale = _create_locale(LC_NUMERIC, "C");
-    if (NULL == c_locale) {
-      if (NULL != endptr) {
-        *endptr = (char *)nptr;
-      }
-      return 0.;
+    if (NULL != endptr) {
+      *endptr = (char *)nptr;
     }
+    return 0.;
   }
 
   return _strtod_l(nptr, endptr, c_locale);
 #else
-  static locale_t c_locale = 0;
+  call_once(&c_locale_once_flag, init_c_locale);
 
   if (0 == c_locale) {
-    c_locale = newlocale(LC_NUMERIC_MASK, "C", 0);
-    if (0 == c_locale) {
-      if (NULL != endptr) {
-        *endptr = (char *)nptr;
-      }
-      return 0.;
+    if (NULL != endptr) {
+      *endptr = (char *)nptr;
     }
+    return 0.;
   }
 
   locale_t old_locale = uselocale(c_locale);

--- a/rcl_yaml_param_parser/src/parse.c
+++ b/rcl_yaml_param_parser/src/parse.c
@@ -781,17 +781,26 @@ _get_int_value(
 }
 
 ///
-/// Calls strtod with the default "POSIX/C" locale.
+/// Calls strtod with the default "C" locale.
 ///
-static double strtod_posix_locale(const char *restrict nptr, char **restrict endptr)
+static double strtod_locale_independent(const char *restrict nptr, char **restrict endptr)
 {
-    static locale_t c_locale = 0;
-    if (c_locale == 0)
-        c_locale = newlocale(LC_ALL_MASK, "C", 0);
-    locale_t old_locale = uselocale(c_locale);
-    double result = strtod(nptr, endptr);
-    uselocale(old_locale);
-    return result;
+#ifdef __WIN32
+  static _locale_t c_locale = 0;
+  if (c_locale == 0) {
+    c_locale = _create_locale(LC_NUMERIC, "C");
+  }
+  return _strtod_l(nptr, endptr, c_locale);
+#else
+  static locale_t c_locale = 0;
+  if (c_locale == 0) {
+    c_locale = newlocale(LC_NUMERIC_MASK, "C", 0);
+  }
+  locale_t old_locale = uselocale(c_locale);
+  double result = strtod(nptr, endptr);
+  uselocale(old_locale);
+  return result;
+#endif
 }
 
 rcutils_ret_t
@@ -822,12 +831,12 @@ _get_float_value(
     for (iter_ptr = value; !isalpha(*iter_ptr); ) {
       iter_ptr += 1;
     }
-    dval = strtod_posix_locale(iter_ptr, &endptr);
+    dval = strtod_locale_independent(iter_ptr, &endptr);
     if (*value == '-') {
       dval = -dval;
     }
   } else {
-    dval = strtod_posix_locale(value, &endptr);
+    dval = strtod_locale_independent(value, &endptr);
   }
   if ((0 == errno) && (NULL != endptr)) {
     if ((NULL != endptr) && (endptr != value)) {

--- a/rcl_yaml_param_parser/src/parse.c
+++ b/rcl_yaml_param_parser/src/parse.c
@@ -782,20 +782,41 @@ _get_int_value(
 
 ///
 /// Calls strtod with the default "C" locale.
+/// \param[in] nptr the string to parse.
+/// \param[out] endptr if not NULL, the location to store the end of the parsed string.
+/// \return The parsed value if something was parsed.
+/// \return 0. if no conversion could be performed.
+/// \return 0. if an error occured, errno will be set, and if not NULL, endptr will be set to nptr.
 ///
 static double strtod_locale_independent(const char *restrict nptr, char **restrict endptr)
 {
-#ifdef __WIN32
-  static _locale_t c_locale = 0;
-  if (c_locale == 0) {
+#ifdef _WIN32
+  static _locale_t c_locale = NULL;
+
+  if (NULL == c_locale) {
     c_locale = _create_locale(LC_NUMERIC, "C");
+    if (NULL == c_locale) {
+      if (NULL != endptr) {
+        *endptr = (char *)nptr;
+      }
+      return 0.;
+    }
   }
+
   return _strtod_l(nptr, endptr, c_locale);
 #else
   static locale_t c_locale = 0;
-  if (c_locale == 0) {
+
+  if (0 == c_locale) {
     c_locale = newlocale(LC_NUMERIC_MASK, "C", 0);
+    if (0 == c_locale) {
+      if (NULL != endptr) {
+        *endptr = (char *)nptr;
+      }
+      return 0.;
+    }
   }
+
   locale_t old_locale = uselocale(c_locale);
   double result = strtod(nptr, endptr);
   uselocale(old_locale);

--- a/rcl_yaml_param_parser/test/test_parse.cpp
+++ b/rcl_yaml_param_parser/test/test_parse.cpp
@@ -12,13 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <locale>
-
 #include <gtest/gtest.h>
 
 #include <yaml.h>
 
 #include <cstring>
+#include <locale>
 
 #include "osrf_testing_tools_cpp/scope_exit.hpp"
 #include "rcl_yaml_param_parser/parser.h"
@@ -156,10 +155,8 @@ TEST(TestParse, parse_value) {
 }
 
 TEST(TestParse, parse_value_locale_independent) {
-  if (!std::setlocale(LC_NUMERIC, "fr_FR.UTF-8") && !std::setlocale(LC_NUMERIC, "de_DE.UTF-8"))
-  {
+  if (!std::setlocale(LC_NUMERIC, "fr_FR.UTF-8") && !std::setlocale(LC_NUMERIC, "de_DE.UTF-8")) {
     GTEST_SKIP() << "Could not set LC_NUMERIC to FR or DE";
-    return;
   }
   OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
   {

--- a/rcl_yaml_param_parser/test/test_parse.cpp
+++ b/rcl_yaml_param_parser/test/test_parse.cpp
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <locale>
+
 #include <gtest/gtest.h>
 
 #include <yaml.h>
@@ -151,6 +153,55 @@ TEST(TestParse, parse_value) {
   params_st->params[node_idx].parameter_values[parameter_idx].byte_array_value = nullptr;
   // reset tag
   event.data.scalar.tag = NULL;
+}
+
+TEST(TestParse, parse_value_locale_independent) {
+  if (!std::setlocale(LC_NUMERIC, "fr_FR.UTF-8") && !std::setlocale(LC_NUMERIC, "de_DE.UTF-8"))
+  {
+    GTEST_SKIP() << "Could not set LC_NUMERIC to FR or DE";
+    return;
+  }
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    std::setlocale(LC_NUMERIC, "C");
+  });
+
+  rcutils_allocator_t allocator = rcutils_get_default_allocator();
+  yaml_event_t event;
+  event.type = YAML_NO_EVENT;
+  event.start_mark = {0u, 0u, 0u};
+  event.end_mark = {0u, 0u, 0u};
+  event.data.scalar = {NULL, NULL, NULL, 1u, 0, 0, YAML_ANY_SCALAR_STYLE};
+
+  bool is_seq = false;
+  size_t node_idx = 0u;
+  size_t parameter_idx = 0u;
+  data_types_t seq_data_type = DATA_TYPE_UNKNOWN;
+  rcl_params_t * params_st = rcl_yaml_node_struct_init(allocator);
+  ASSERT_NE(nullptr, params_st);
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    rcl_yaml_node_struct_fini(params_st);
+  });
+
+  ASSERT_EQ(RCUTILS_RET_OK, node_params_init(&params_st->params[0], allocator));
+  params_st->num_nodes = 1u;
+
+  // double value
+  yaml_char_t double_value[] = "3.14159";
+  const size_t double_value_length = sizeof(double_value) / sizeof(double_value[0]);
+  event.data.scalar.value = double_value;
+  event.data.scalar.length = double_value_length;
+
+  EXPECT_EQ(
+    RCUTILS_RET_OK,
+    parse_value(event, is_seq, node_idx, parameter_idx, &seq_data_type, params_st)) <<
+    rcutils_get_error_string().str;
+  ASSERT_NE(nullptr, params_st->params[node_idx].parameter_values[parameter_idx].double_value);
+  EXPECT_EQ(3.14159, *params_st->params[node_idx].parameter_values[parameter_idx].double_value);
+  allocator.deallocate(
+    params_st->params[node_idx].parameter_values[parameter_idx].double_value, allocator.state);
+  params_st->params[node_idx].parameter_values[parameter_idx].double_value = nullptr;
 }
 
 TEST(TestParse, parse_value_sequence) {


### PR DESCRIPTION
## Description

Call `strtod` surrounded with `uselocale(POSIX-locale)`, `uselocale(previous-locale)` to parse double following the YAML standard even if the LC_NUMERIC locale do not uses dots as the decimal separator.

Fixes #1288

### Is this user-facing behavior change?

User using a LC_NUMERIC locale with dot as the decimal separator will not see any changes. Users using other LC_NUMERIC locale will not have issues parsing doubles with `--ros-args`.

### Did you use Generative AI?

No.

### Additional Information

I am not super happy to have to instantiate a new locale and store it in a static variable. I would have preferred a locale-independent parsing function, but I did not find one without using GNU extension, add another dependency or use the C++ library.

Performance-wise, this adds a few nanoseconds to the double parsing. Moreover, in RCL, get_value this is not in the hot-path.