### PR TITLE
Add content filtering support check for subscriptions

### DIFF
--- a/rcl/include/rcl/subscription.h
+++ b/rcl/include/rcl/subscription.h
@@ -910,6 +910,16 @@ rcl_subscription_set_on_new_message_callback(
   rcl_event_callback_t callback,
   const void * user_data);
 
+/// Check if subscription instance supports content filtering.
+/**
+ * \param[in] subscription The subscription instance to check for content filtering support
+ * \return `true` if the subscription instance supports content filtering, `false` otherwise
+ *   (including when \p subscription is `NULL` or invalid).
+ */
+RCL_PUBLIC
+bool
+rcl_subscription_is_cft_supported(const rcl_subscription_t * subscription);
+
 #ifdef __cplusplus
 }
 #endif

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -145,10 +145,10 @@ rcl_subscription_init(
   if (rmw_subscription_get_content_filter(
     subscription->impl->rmw_handle, NULL, NULL) == RMW_RET_UNSUPPORTED)
   {
-    subscription->impl->rmw_handle->cft_is_supported = false;
+    subscription->impl->rmw_handle->is_cft_supported = false;
   } else {
     rcutils_reset_error();
-    subscription->impl->rmw_handle->cft_is_supported = true;
+    subscription->impl->rmw_handle->is_cft_supported = true;
   }
 
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Subscription initialized");
@@ -855,7 +855,7 @@ rcl_subscription_is_cft_supported(const rcl_subscription_t * subscription)
   if (!rcl_subscription_is_valid(subscription)) {
     return false;  // error message already set
   }
-  return subscription->impl->rmw_handle->cft_is_supported;
+  return subscription->impl->rmw_handle->is_cft_supported;
 }
 
 #ifdef __cplusplus

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -138,6 +138,19 @@ rcl_subscription_init(
   }
   subscription->impl->type_hash = *type_support->get_type_hash_func(type_support);
 
+  // Check if the subscription supports content filtering
+  // If RMW implementation doesn't support content filtering, calling
+  // rmw_subscription_get_content_filter() with unavailable parameters will always return
+  // RMW_RET_UNSUPPORTED.
+  if (rmw_subscription_get_content_filter(
+    subscription->impl->rmw_handle, NULL, NULL) == RMW_RET_UNSUPPORTED)
+  {
+    subscription->impl->rmw_handle->cft_is_supported = false;
+  } else {
+    rcutils_reset_error();
+    subscription->impl->rmw_handle->cft_is_supported = true;
+  }
+
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Subscription initialized");
   ret = RCL_RET_OK;
   TRACETOOLS_TRACEPOINT(
@@ -834,6 +847,15 @@ rcl_subscription_set_on_new_message_callback(
     subscription->impl->rmw_handle,
     callback,
     user_data);
+}
+
+bool
+rcl_subscription_is_cft_supported(const rcl_subscription_t * subscription)
+{
+  if (!rcl_subscription_is_valid(subscription)) {
+    return false;  // error message already set
+  }
+  return subscription->impl->rmw_handle->cft_is_supported;
 }
 
 #ifdef __cplusplus

--- a/rcl/test/rcl/test_subscription.cpp
+++ b/rcl/test/rcl/test_subscription.cpp
@@ -1717,6 +1717,8 @@ TEST_F(TestSubscriptionFixtureInit, test_subscription_bad_argument) {
   rcl_reset_error();
   EXPECT_FALSE(rcl_subscription_is_cft_enabled(nullptr));
   rcl_reset_error();
+  EXPECT_FALSE(rcl_subscription_is_cft_supported(nullptr));
+  rcl_reset_error();
 
   EXPECT_EQ(NULL, rcl_subscription_get_actual_qos(&subscription_zero_init));
   rcl_reset_error();
@@ -1729,6 +1731,8 @@ TEST_F(TestSubscriptionFixtureInit, test_subscription_bad_argument) {
   EXPECT_EQ(NULL, rcl_subscription_get_options(&subscription_zero_init));
   rcl_reset_error();
   EXPECT_FALSE(rcl_subscription_is_cft_enabled(&subscription_zero_init));
+  rcl_reset_error();
+  EXPECT_FALSE(rcl_subscription_is_cft_supported(&subscription_zero_init));
   rcl_reset_error();
 }
 
@@ -1832,6 +1836,20 @@ TEST_F(TestSubscriptionFixtureInit, test_bad_rcl_subscription_get_content_filter
         &subscription, &options));
     rcl_reset_error();
   }
+}
+
+TEST_F(TestSubscriptionFixtureInit, test_rcl_subscription_is_cft_supported) {
+  // The current implementations for content filter support
+  // rmw_fastrtps_cpp: Yes
+  // rmw_connextdds: Yes
+  // rmw_cyclonedds: No
+  // rmw_zenoh: No
+  const char * impl_id = rmw_get_implementation_identifier();
+  bool is_cft_support =
+    (strncmp(impl_id, "rmw_connextdds", strlen("rmw_connextdds")) == 0 ||
+    strncmp(impl_id, "rmw_fastrtps_cpp", strlen("rmw_fastrtps_cpp")) == 0);
+
+  EXPECT_EQ(is_cft_support, rcl_subscription_is_cft_supported(&subscription));
 }
 
 TEST_F(TestSubscriptionFixture, test_init_fini_maybe_fail)


### PR DESCRIPTION
## Description

Currently, RMW does not provide an interface to directly determine whether a subscription supports content filtering. Implementing this interface in rcl allows other code that uses the content filter feature to be optimized, making the implementation code clearer.

Depened on ros2/rmw#415

### Is this user-facing behavior change?

No.

### Did you use Generative AI?

No.

### Additional Information
