### PR TITLE
Add API for client libraries to set action server goal expiration callbacks

### DIFF
--- a/rcl/CMakeLists.txt
+++ b/rcl/CMakeLists.txt
@@ -49,6 +49,7 @@ set(${PROJECT_NAME}_sources
   src/rcl/domain_id.c
   src/rcl/dynamic_message_type_support.c
   src/rcl/event.c
+  src/rcl/event_callback.c
   src/rcl/expand_topic_name.c
   src/rcl/graph.c
   src/rcl/guard_condition.c

--- a/rcl/include/rcl/event_callback.h
+++ b/rcl/include/rcl/event_callback.h
@@ -16,6 +16,8 @@
 #define RCL__EVENT_CALLBACK_H_
 
 #include "rmw/event_callback_type.h"
+#include "rcl/visibility_control.h"
+#include "rcl/macros.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -23,6 +25,17 @@ extern "C"
 #endif
 
 typedef rmw_event_callback_t rcl_event_callback_t;
+
+typedef struct rcl_event_callback_with_data_s
+{
+  rcl_event_callback_t callback;
+  const void * user_data;
+} rcl_event_callback_with_data_t;
+
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_event_callback_with_data_t
+rcl_get_zero_initialized_event_callback_with_data();
 
 #ifdef __cplusplus
 }

--- a/rcl/include/rcl/timer.h
+++ b/rcl/include/rcl/timer.h
@@ -70,8 +70,10 @@ typedef struct rcl_timer_call_info_s
  * Therefore the second argument given is the time since the previous callback
  * was called, because that information is no longer accessible via the timer.
  * The time since the last callback call is given in nanoseconds.
+ *
+ * The third argument allows for type erased data to be passed into the timer callback.
  */
-typedef void (* rcl_timer_callback_t)(rcl_timer_t *, int64_t);
+typedef void (* rcl_timer_callback_t)(rcl_timer_t *, int64_t, const void *);
 
 /// Return a zero initialized timer.
 RCL_PUBLIC
@@ -535,6 +537,33 @@ RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_timer_callback_t
 rcl_timer_exchange_callback(rcl_timer_t * timer, const rcl_timer_callback_t new_callback);
+
+/// Set the type erased data that the timer callback will be called with.
+/**
+ * This function can fail, and therefore return `NULL`, if:
+ *   - timer is `NULL`
+ *   - timer has not been initialized (the implementation is invalid)
+ *
+ * This function can set callback to `NULL`, in which case the callback is
+ * ignored when rcl_timer_call is called.
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | Yes
+ *
+ * \param[inout] timer handle to the timer from the callback should be exchanged
+ * \param[in] data pointer to user data to be passed into the callback
+ * \return #RCL_RET_OK if the data was set successfully, or
+ * \return #RCL_RET_TIMER_INVALID if the timer is invalid. */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_timer_set_user_callback_data(rcl_timer_t * timer, const void * data);
+
 
 /// Cancel a timer.
 /**

--- a/rcl/include/rcl/timer.h
+++ b/rcl/include/rcl/timer.h
@@ -562,7 +562,7 @@ rcl_timer_exchange_callback(rcl_timer_t * timer, const rcl_timer_callback_t new_
 RCL_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t
-rcl_timer_set_user_callback_data(rcl_timer_t * timer, const void * data);
+rcl_timer_set_user_callback_data(rcl_timer_t * timer, void * data);
 
 
 /// Cancel a timer.

--- a/rcl/include/rcl/timer.h
+++ b/rcl/include/rcl/timer.h
@@ -511,6 +511,29 @@ RCL_WARN_UNUSED
 rcl_timer_callback_t
 rcl_timer_get_callback(const rcl_timer_t * timer);
 
+/// Return the current timer callback data.
+/**
+ * This function can fail, and therefore return `NULL`, if:
+ *   - timer is `NULL`
+ *   - timer has not been initialized (the implementation is invalid)
+ *
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | Yes
+ * Uses Atomics       | Yes
+ * Lock-Free          | Yes [1]
+ * <i>[1] if `atomic_is_lock_free()` returns true for `atomic_int_least64_t`</i>
+ *
+ * \param[in] timer handle to the timer from the callback data that should be returned
+ * \return pointer to the callback data, or `NULL` if an error occurred
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+uintptr_t
+rcl_timer_get_callback_data(const rcl_timer_t * timer);
+
 /// Exchange the current timer callback and return the current callback.
 /**
  * This function can fail, and therefore return `NULL`, if:

--- a/rcl/include/rcl/timer.h
+++ b/rcl/include/rcl/timer.h
@@ -558,6 +558,7 @@ rcl_timer_exchange_callback(rcl_timer_t * timer, const rcl_timer_callback_t new_
  * \param[inout] timer handle to the timer from the callback should be exchanged
  * \param[in] data pointer to user data to be passed into the callback
  * \return #RCL_RET_OK if the data was set successfully, or
+ * \return #RCL_RET_INVALID_ARGUMENT if any arguments are invalid, or
  * \return #RCL_RET_TIMER_INVALID if the timer is invalid. */
 RCL_PUBLIC
 RCL_WARN_UNUSED

--- a/rcl/include/rcl/timer.h
+++ b/rcl/include/rcl/timer.h
@@ -552,7 +552,7 @@ rcl_timer_exchange_callback(rcl_timer_t * timer, const rcl_timer_callback_t new_
  * ------------------ | -------------
  * Allocates Memory   | No
  * Thread-Safe        | No
- * Uses Atomics       | No
+ * Uses Atomics       | Yes
  * Lock-Free          | Yes
  *
  * \param[inout] timer handle to the timer from the callback should be exchanged

--- a/rcl/include/rcl/timer.h
+++ b/rcl/include/rcl/timer.h
@@ -551,7 +551,7 @@ rcl_timer_exchange_callback(rcl_timer_t * timer, const rcl_timer_callback_t new_
  * Attribute          | Adherence
  * ------------------ | -------------
  * Allocates Memory   | No
- * Thread-Safe        | No
+ * Thread-Safe        | Yes
  * Uses Atomics       | Yes
  * Lock-Free          | Yes
  *

--- a/rcl/include/rcl/timer.h
+++ b/rcl/include/rcl/timer.h
@@ -73,7 +73,7 @@ typedef struct rcl_timer_call_info_s
  *
  * The third argument allows for type erased data to be passed into the timer callback.
  */
-typedef void (* rcl_timer_callback_t)(rcl_timer_t *, int64_t, const void *);
+typedef void (* rcl_timer_callback_t)(rcl_timer_t *, int64_t, uintptr_t);
 
 /// Return a zero initialized timer.
 RCL_PUBLIC
@@ -561,8 +561,8 @@ rcl_timer_exchange_callback(rcl_timer_t * timer, const rcl_timer_callback_t new_
  * \return #RCL_RET_TIMER_INVALID if the timer is invalid. */
 RCL_PUBLIC
 RCL_WARN_UNUSED
-rcl_ret_t
-rcl_timer_set_user_callback_data(rcl_timer_t * timer, void * data);
+uintptr_t
+rcl_timer_exchange_callback_data(rcl_timer_t * timer, uintptr_t data);
 
 
 /// Cancel a timer.

--- a/rcl/src/rcl/event_callback.c
+++ b/rcl/src/rcl/event_callback.c
@@ -1,3 +1,17 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "rcl/event_callback.h"
 
 #ifdef __cplusplus

--- a/rcl/src/rcl/event_callback.c
+++ b/rcl/src/rcl/event_callback.c
@@ -1,0 +1,18 @@
+#include "rcl/event_callback.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+
+rcl_event_callback_with_data_t
+rcl_get_zero_initialized_event_callback_with_data()
+{
+  static rcl_event_callback_with_data_t event_callback;
+  return event_callback;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -438,7 +438,7 @@ rcl_timer_exchange_callback(rcl_timer_t * timer, const rcl_timer_callback_t new_
 }
 
 rcl_ret_t
-rcl_timer_set_user_callback_data(rcl_timer_t * timer, const void * user_data)
+rcl_timer_set_user_callback_data(rcl_timer_t * timer, void * user_data)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(timer, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_FOR_NULL_WITH_MSG(timer->impl, "timer is invalid", return RCL_RET_TIMER_INVALID);

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -55,7 +55,7 @@ struct rcl_timer_impl_s
   // The user supplied allocator.
   rcl_allocator_t allocator;
   // The user supplied on reset callback data.
-  rcl_timer_on_reset_callback_data_t callback_data;
+  rcl_timer_on_reset_callback_data_t reset_callback_data;
 };
 
 rcl_timer_t
@@ -177,9 +177,9 @@ rcl_timer_init2(
   impl.allocator = allocator;
 
   // Empty init on reset callback data
-  impl.callback_data.on_reset_callback = NULL;
-  impl.callback_data.user_data = NULL;
-  impl.callback_data.reset_counter = 0;
+  impl.reset_callback_data.on_reset_callback = NULL;
+  impl.reset_callback_data.user_data = NULL;
+  impl.reset_callback_data.reset_counter = 0;
 
   timer->impl = (rcl_timer_impl_t *)allocator.allocate(sizeof(rcl_timer_impl_t), allocator.state);
   if (NULL == timer->impl) {
@@ -487,7 +487,7 @@ rcl_timer_reset(rcl_timer_t * timer)
   rcutils_atomic_store(&timer->impl->canceled, false);
   rcl_ret_t ret = rcl_trigger_guard_condition(&timer->impl->guard_condition);
 
-  rcl_timer_on_reset_callback_data_t * cb_data = &timer->impl->callback_data;
+  rcl_timer_on_reset_callback_data_t * cb_data = &timer->impl->reset_callback_data;
 
   if (cb_data->on_reset_callback) {
     cb_data->on_reset_callback(cb_data->user_data, 1);
@@ -527,7 +527,7 @@ rcl_timer_set_on_reset_callback(
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(timer, RCL_RET_INVALID_ARGUMENT);
 
-  rcl_timer_on_reset_callback_data_t * cb_data = &timer->impl->callback_data;
+  rcl_timer_on_reset_callback_data_t * cb_data = &timer->impl->reset_callback_data;
 
   if (on_reset_callback) {
     cb_data->on_reset_callback = on_reset_callback;

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -38,8 +38,8 @@ struct rcl_timer_impl_s
   rcl_guard_condition_t guard_condition;
   // The user supplied callback.
   atomic_uintptr_t callback;
-  // optional tyoe-erased data which will be passed into the callback
-  void * user_callback_data;
+  // optionally user supplied data which will be passed into the callback
+  atomic_uintptr_t callback_data;
 
   // This is a duration in nanoseconds, which is initialized as int64_t
   // to be used for internal time calculation.
@@ -318,7 +318,7 @@ rcl_timer_call_with_info(rcl_timer_t * timer, rcl_timer_call_info_t * call_info)
 
   if (typed_callback != NULL) {
     int64_t since_last_call = now - previous_ns;
-    typed_callback(timer, since_last_call, timer->impl->user_callback_data);
+    typed_callback(timer, since_last_call, timer->impl->callback_data);
   }
   return RCL_RET_OK;
 }
@@ -437,14 +437,13 @@ rcl_timer_exchange_callback(rcl_timer_t * timer, const rcl_timer_callback_t new_
     &timer->impl->callback, (uintptr_t)new_callback);
 }
 
-rcl_ret_t
-rcl_timer_set_user_callback_data(rcl_timer_t * timer, void * user_data)
+uintptr_t
+rcl_timer_exchange_callback_data(rcl_timer_t * timer, uintptr_t data)
 {
   RCL_CHECK_ARGUMENT_FOR_NULL(timer, RCL_RET_INVALID_ARGUMENT);
   RCL_CHECK_FOR_NULL_WITH_MSG(timer->impl, "timer is invalid", return RCL_RET_TIMER_INVALID);
 
-  timer->impl->user_callback_data = user_data;
-  return RCL_RET_OK;
+  return rcutils_atomic_exchange_uintptr_t(&timer->impl->callback_data, data);
 }
 
 rcl_ret_t

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -38,6 +38,9 @@ struct rcl_timer_impl_s
   rcl_guard_condition_t guard_condition;
   // The user supplied callback.
   atomic_uintptr_t callback;
+  // optional tyoe-erased data which will be passed into the callback
+  void * user_callback_data;
+
   // This is a duration in nanoseconds, which is initialized as int64_t
   // to be used for internal time calculation.
   atomic_int_least64_t period;
@@ -315,7 +318,7 @@ rcl_timer_call_with_info(rcl_timer_t * timer, rcl_timer_call_info_t * call_info)
 
   if (typed_callback != NULL) {
     int64_t since_last_call = now - previous_ns;
-    typed_callback(timer, since_last_call);
+    typed_callback(timer, since_last_call, timer->impl->user_callback_data);
   }
   return RCL_RET_OK;
 }
@@ -432,6 +435,16 @@ rcl_timer_exchange_callback(rcl_timer_t * timer, const rcl_timer_callback_t new_
   RCL_CHECK_FOR_NULL_WITH_MSG(timer->impl, "timer is invalid", return NULL);
   return (rcl_timer_callback_t)rcutils_atomic_exchange_uintptr_t(
     &timer->impl->callback, (uintptr_t)new_callback);
+}
+
+rcl_ret_t
+rcl_timer_set_user_callback_data(rcl_timer_t * timer, const void * user_data)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(timer, RCL_RET_INVALID_ARGUMENT);
+  RCL_CHECK_FOR_NULL_WITH_MSG(timer->impl, "timer is invalid", return RCL_RET_TIMER_INVALID);
+
+  timer->impl->user_callback_data = user_data;
+  return RCL_RET_OK;
 }
 
 rcl_ret_t

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -169,6 +169,7 @@ rcl_timer_init2(
   }
 
   atomic_init(&impl.callback, (uintptr_t)callback);
+  atomic_init(&impl.callback_data, (uintptr_t)NULL);
   atomic_init(&impl.period, period);
   atomic_init(&impl.time_credit, 0);
   atomic_init(&impl.last_call_time, now);

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -318,7 +318,8 @@ rcl_timer_call_with_info(rcl_timer_t * timer, rcl_timer_call_info_t * call_info)
 
   if (typed_callback != NULL) {
     int64_t since_last_call = now - previous_ns;
-    typed_callback(timer, since_last_call, timer->impl->callback_data);
+    uintptr_t callback_data = rcl_timer_get_callback_data(timer);
+    typed_callback(timer, since_last_call, callback_data);
   }
   return RCL_RET_OK;
 }
@@ -425,6 +426,14 @@ rcl_timer_get_callback(const rcl_timer_t * timer)
   RCL_CHECK_ARGUMENT_FOR_NULL(timer, NULL);
   RCL_CHECK_FOR_NULL_WITH_MSG(timer->impl, "timer is invalid", return NULL);
   return (rcl_timer_callback_t)rcutils_atomic_load_uintptr_t(&timer->impl->callback);
+}
+
+uintptr_t
+rcl_timer_get_callback_data(const rcl_timer_t * timer)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(timer, (uintptr_t)NULL);
+  RCL_CHECK_FOR_NULL_WITH_MSG(timer->impl, "timer is invalid", return (uintptr_t)NULL);
+  return (uintptr_t)rcutils_atomic_load_uintptr_t(&timer->impl->callback_data);
 }
 
 rcl_timer_callback_t

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -72,7 +72,8 @@ static void callback_function(rcl_timer_t * timer, int64_t last_call, const uint
 {
   (void) timer;
   (void) last_call;
-  (void) data;
+  const char * typed_data = (char *)data;
+  ASSERT_EQ(strcmp("callback_data", typed_data), 0);
   times_called++;
 }
 static void callback_function_changed(rcl_timer_t * timer, int64_t last_call, const uintptr_t data)
@@ -103,6 +104,8 @@ public:
   rcl_timer_t timer;
   rcl_timer_callback_t timer_callback_test = &callback_function;
   rcl_timer_callback_t timer_callback_changed = &callback_function_changed;
+  const char * test_string = "callback_data";
+  uintptr_t timer_callback_test_data = (uintptr_t)test_string;
 
   void SetUp() override
   {
@@ -117,6 +120,10 @@ public:
     ret = rcl_timer_init2(
       &timer, &clock, this->context_ptr, RCL_S_TO_NS(1), timer_callback_test,
       rcl_get_default_allocator(), true);
+
+    uintptr_t dontcare = rcl_timer_exchange_callback_data(&timer, timer_callback_test_data);
+    (void) dontcare;
+
     ASSERT_EQ(RCL_RET_OK, ret) << rcl_get_error_string().str;
   }
 

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -68,14 +68,14 @@ public:
 };
 
 static uint8_t times_called = 0;
-static void callback_function(rcl_timer_t * timer, int64_t last_call, const void * data)
+static void callback_function(rcl_timer_t * timer, int64_t last_call, const uintptr_t data)
 {
   (void) timer;
   (void) last_call;
   (void) data;
   times_called++;
 }
-static void callback_function_changed(rcl_timer_t * timer, int64_t last_call, const void * data)
+static void callback_function_changed(rcl_timer_t * timer, int64_t last_call, const uintptr_t data)
 {
   (void) timer;
   (void) last_call;

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -72,7 +72,7 @@ static void callback_function(rcl_timer_t * timer, int64_t last_call, const uint
 {
   (void) timer;
   (void) last_call;
-  const char * typed_data = (char *)data;
+  const char * typed_data = reinterpret_cast<char *>(data);
   ASSERT_EQ(strcmp("callback_data", typed_data), 0);
   times_called++;
 }

--- a/rcl/test/rcl/test_timer.cpp
+++ b/rcl/test/rcl/test_timer.cpp
@@ -68,16 +68,18 @@ public:
 };
 
 static uint8_t times_called = 0;
-static void callback_function(rcl_timer_t * timer, int64_t last_call)
+static void callback_function(rcl_timer_t * timer, int64_t last_call, const void * data)
 {
   (void) timer;
   (void) last_call;
+  (void) data;
   times_called++;
 }
-static void callback_function_changed(rcl_timer_t * timer, int64_t last_call)
+static void callback_function_changed(rcl_timer_t * timer, int64_t last_call, const void * data)
 {
   (void) timer;
   (void) last_call;
+  (void) data;
   times_called--;
 }
 

--- a/rcl_action/include/rcl_action/action_server.h
+++ b/rcl_action/include/rcl_action/action_server.h
@@ -986,7 +986,7 @@ rcl_action_server_configure_action_introspection(
   const rcl_publisher_options_t publisher_options,
   rcl_service_introspection_state_t introspection_state);
 
-///Set an event callback which will be called when the action goal expiration timer fires.
+/// Set an event callback which will be called when the action goal expiration timer fires.
 /**
  * This should be invoked from action servers registering callbacks
  * for events based execution.

--- a/rcl_action/include/rcl_action/action_server.h
+++ b/rcl_action/include/rcl_action/action_server.h
@@ -986,6 +986,30 @@ rcl_action_server_configure_action_introspection(
   const rcl_publisher_options_t publisher_options,
   rcl_service_introspection_state_t introspection_state);
 
+///Set an event callback which will be called when the action goal expiration timer fires.
+/**
+ * This should be invoked from action servers registering callbacks
+ * for events based execution.
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | No
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | No
+ *
+ * \param[in] action_server the action server on which to add a callback
+ * \param[in] callback *event* callback which will be invoked by the expire timer's *timer* callback
+ * \param[in] user_data data that can be passed to the *event* callback
+ */
+RCL_ACTION_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_action_server_set_expired_event_callback(
+  const rcl_action_server_t * action_server,
+  const rcl_event_callback_t callback,
+  const void * user_data);
+
 RCL_ACTION_PUBLIC
 RCL_WARN_UNUSED
 rcl_ret_t

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -101,6 +101,24 @@ rcl_action_get_zero_initialized_server(void)
     goto fail; \
   }
 
+// Implementation only
+static void
+_enqueue_check_expired_goals(
+  rcl_timer_t * timer,
+  int64_t last_call,
+  const uintptr_t type_erased_event_callback)
+{
+  (void)timer;
+  (void)last_call;
+
+  rcl_event_callback_with_data_t * typed_cb_with_data =
+    (rcl_event_callback_with_data_t *)type_erased_event_callback;
+
+  if (typed_cb_with_data->callback) {
+    typed_cb_with_data->callback(typed_cb_with_data->user_data, 1);
+  }
+}
+
 rcl_ret_t
 rcl_action_server_init(
   rcl_action_server_t * action_server,
@@ -135,7 +153,7 @@ rcl_action_server_init(
 
   ret = rcl_action_server_init2(action_server, node, &expire_timer,
                                 type_support, action_name, options);
-  if(ret != RCL_RET_OK) {
+  if(RCL_RET_OK != ret) {
     // we need to release the timer in error case
     if (rcl_timer_fini(&expire_timer) != RCL_RET_OK) {
       ret = RCL_RET_ERROR;
@@ -184,6 +202,9 @@ rcl_action_server_init2(
   action_server->impl->cancel_service = rcl_get_zero_initialized_service();
   action_server->impl->result_service = rcl_get_zero_initialized_service();
   action_server->impl->expire_timer = *expire_timer;
+  action_server->impl->goal_expire_callback =
+    rcl_get_zero_initialized_event_callback_with_data();
+
   action_server->impl->owns_expire_timer = false;
   action_server->impl->feedback_publisher = rcl_get_zero_initialized_publisher();
   action_server->impl->status_publisher = rcl_get_zero_initialized_publisher();
@@ -246,6 +267,11 @@ rcl_action_server_init2(
   if (RCL_RET_OK != ret) {
     goto fail;
   }
+
+  // Set the callback for the timer to call the callback that enqueues action expiration events
+  rcl_timer_callback_t dont_care = rcl_timer_exchange_callback(&action_server->impl->expire_timer,
+    &_enqueue_check_expired_goals);
+  (void) dont_care;
 
   // Store type hash
   ret = rcl_node_type_cache_register_type(
@@ -1263,6 +1289,23 @@ rcl_action_server_configure_action_introspection(
   SERVER_CONFIGURE_SERVICE_INTROSPECTION(goal, introspection_state);
   SERVER_CONFIGURE_SERVICE_INTROSPECTION(cancel, introspection_state);
   SERVER_CONFIGURE_SERVICE_INTROSPECTION(result, introspection_state);
+  return RCL_RET_OK;
+}
+
+rcl_ret_t
+rcl_action_server_set_expired_event_callback(
+  const rcl_action_server_t * action_server,
+  const rcl_event_callback_t callback,
+  const void * user_data)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(action_server, RCL_RET_INVALID_ARGUMENT);
+
+  action_server->impl->goal_expire_callback.callback = callback;
+  action_server->impl->goal_expire_callback.user_data = user_data;
+
+  uintptr_t dont_care = rcl_timer_exchange_callback_data(&action_server->impl->expire_timer,
+      (uintptr_t)&action_server->impl->goal_expire_callback);
+  (void) dont_care;
   return RCL_RET_OK;
 }
 

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -111,11 +111,13 @@ _enqueue_check_expired_goals(
   (void)timer;
   (void)last_call;
 
-  rcl_event_callback_with_data_t * typed_cb_with_data =
-    (rcl_event_callback_with_data_t *)type_erased_event_callback;
+  if ((uintptr_t)NULL != type_erased_event_callback) {
+    rcl_event_callback_with_data_t * typed_cb_with_data =
+      (rcl_event_callback_with_data_t *)type_erased_event_callback;
 
-  if (typed_cb_with_data->callback) {
-    typed_cb_with_data->callback(typed_cb_with_data->user_data, 1);
+    if (typed_cb_with_data->callback) {
+      typed_cb_with_data->callback(typed_cb_with_data->user_data, 1);
+    }
   }
 }
 

--- a/rcl_action/src/rcl_action/action_server_impl.h
+++ b/rcl_action/src/rcl_action/action_server_impl.h
@@ -27,6 +27,7 @@ typedef struct rcl_action_server_impl_s
   rcl_publisher_t feedback_publisher;
   rcl_publisher_t status_publisher;
   rcl_timer_t expire_timer;
+  rcl_event_callback_with_data_t goal_expire_callback;
   char * remapped_action_name;
   bool owns_expire_timer;
   rcl_action_server_options_t options;


### PR DESCRIPTION
## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.      
-->
This PR allows for client libraries to set an event callback which will be called by the action server's expire timer. This is achieved by extending the timers C api to allow for type-erased callback data to be passed into the timer callback.  The type-erased data is then used within the action server implementation specific timer callback `_enqueue_check_expire_goals`, where the type-erased data passed into the callback is cast to an `rcl_event_callback_t` and called. This eliminates the need to run `execute_check_expire_goals` in the timer callback itself, allows the expire timer to directly enqueue ready expired events, and ensures that goal expiration will happen through the mechanism of `take_data_by_entity_id` and `execute`. 

<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->
No 
### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
Companion PR to https://github.com/ros2/rclcpp/pull/3018

Additional note: While this works with all existing executors in rclcpp (single, multi, experimental events executor), one modification needed to be made to the `EventsCBGExecutor` to [change `ready_mutex` into a `std::recursive_mutex`](https://github.com/cellumation/cm_executors/blob/1c980b3876e52240bee175ba21f08ec1d9b18b9a/include/cm_executors/scheduler.hpp#L163). This is because when getting the next ready entity (the expire timer that's firing), and calling its callback, the `get_ready_callback_for_entity` function from the scheduler that's passed into the timer at the rcl layer also needs to acquire `ready_mutex` to enqueue the action server as having a ready expired event. I think this is fine to do since it would all happen within the same thread. 