### PR TITLE
Added tracepoint to rcl_take_loaned_message

### DIFF
--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -715,6 +715,7 @@ rcl_take_loaned_message(
   }
   RCUTILS_LOG_DEBUG_NAMED(
     ROS_PACKAGE_NAME, "Subscription loaned take succeeded: %s", taken ? "true" : "false");
+  TRACETOOLS_TRACEPOINT(rcl_take, (const void *)(*loaned_message));
   if (!taken) {
     return RCL_RET_SUBSCRIPTION_TAKE_FAILED;
   }


### PR DESCRIPTION
## Description

It's impossible to fully trace a ROS2 system that uses zero copy, because the rcl_take_loaned_message call doesn't invoke the rcl_take tracepoint, like all the other rcl_take variants. This corrects for that.


### Is this user-facing behavior change?


### Did you use Generative AI?

No, it's a one-line fix

### Additional Information


