### PR TITLE
improve rcl_action tests failures non-default RMW impls.

### DIFF
--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -145,6 +145,10 @@ rcl_subscription_init(
   if (rmw_subscription_get_content_filter(
     subscription->impl->rmw_handle, NULL, NULL) == RMW_RET_UNSUPPORTED)
   {
+    // depending on rmw implementation, this call may set an error string (e.g. "unimplemented")
+    // so we must call rcutils_reset_error() in both branches to avoid leaking a stale error
+    // state out of subscription init.
+    rcutils_reset_error();
     subscription->impl->rmw_handle->is_cft_supported = false;
   } else {
     rcutils_reset_error();


### PR DESCRIPTION
## Description

different approach from https://github.com/ros2/rmw_cyclonedds/pull/565

this PR fixes the following failures with `rmw_cyclonedds_cpp`,

```console
export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
colcon test --event-handlers console_direct+ --packages-select rcl_action
...
     3 FAILED TESTS
    -- run_test.py: return code 1
    -- run_test.py: inject classname prefix into gtest result file '/root/ros2_ws/colcon_ws/build/rcl_action/test_results/rcl_action/test_wait.gtest.xml'
    -- run_test.py: verify result file '/root/ros2_ws/colcon_ws/build/rcl_action/test_results/rcl_action/test_wait.gtest.xml'
  >>>
build/rcl_action/test_results/rcl_action/test_action_client.gtest.xml: 11 tests, 0 errors, 1 failure, 0 skipped
- rcl_action.TestActionClientBaseFixture test_action_client_init_fini (/root/ros2_ws/colcon_ws/src/ros2/rcl/rcl_action/test/rcl_action/test_action_client.cpp:87)
  <<< failure message
    /root/ros2_ws/colcon_ws/src/ros2/rcl/rcl_action/test/rcl_action/test_action_client.cpp:183
    Value of: rcutils_error_is_set()
      Actual: true
    Expected: false
  >>>
build/rcl_action/test_results/rcl_action/test_action_server.gtest.xml: 22 tests, 0 errors, 1 failure, 0 skipped
- rcl_action.TestActionServer test_set_internal_services_introspection_contents (/root/ros2_ws/colcon_ws/src/ros2/rcl/rcl_action/test/rcl_action/test_action_server.cpp:896)
  <<< failure message
    /root/ros2_ws/colcon_ws/src/ros2/rcl/rcl_action/test/rcl_action/test_action_server.cpp:287
    Value of: get_publisher_count(get_result_service_event_topic_name) == expect_publisher_count
      Actual: false
    Expected: true
  >>>
build/rcl_action/test_results/rcl_action/test_wait.gtest.xml: 6 tests, 0 errors, 3 failures, 0 skipped
- rcl_action.TestActionClientWait test_wait_set_add_action_client (/root/ros2_ws/colcon_ws/src/ros2/rcl/rcl_action/test/rcl_action/test_wait.cpp:153)
  <<< failure message
    /root/ros2_ws/colcon_ws/src/ros2/rcl/rcl_action/test/rcl_action/test_wait.cpp:64
    Value of: rcutils_error_is_set()
      Actual: true
    Expected: false
    rmw_subscription_get_content_filter: unimplemented, at /root/ros2_ws/colcon_ws/src/ros2/rmw_cyclonedds/rmw_cyclonedds_cpp/src/rmw_node.cpp:3255
  >>>
- rcl_action.TestActionClientWait test_client_wait_set_get_num_entities (/root/ros2_ws/colcon_ws/src/ros2/rcl/rcl_action/test/rcl_action/test_wait.cpp:362)
  <<< failure message
    /root/ros2_ws/colcon_ws/src/ros2/rcl/rcl_action/test/rcl_action/test_wait.cpp:64
    Value of: rcutils_error_is_set()
      Actual: true
    Expected: false
    rmw_subscription_get_content_filter: unimplemented, at /root/ros2_ws/colcon_ws/src/ros2/rmw_cyclonedds/rmw_cyclonedds_cpp/src/rmw_node.cpp:3255
  >>>
- rcl_action.TestActionClientWait test_client_wait_set_get_entities_ready (/root/ros2_ws/colcon_ws/src/ros2/rcl/rcl_action/test/rcl_action/test_wait.cpp:527)
  <<< failure message
    /root/ros2_ws/colcon_ws/src/ros2/rcl/rcl_action/test/rcl_action/test_wait.cpp:64
    Value of: rcutils_error_is_set()
      Actual: true
    Expected: false
    rmw_subscription_get_content_filter: unimplemented, at /root/ros2_ws/colcon_ws/src/ros2/rmw_cyclonedds/rmw_cyclonedds_cpp/src/rmw_node.cpp:3255
  >>>
```

this PR just call `rcutils_reset_error` right after `rmw_subscription_get_content_filter` during the construction of subscription. this is being done in the ROS 2 system library, not issued by user application by purpose. so we should reset the error strings to avoid leaking a stale error state out of subscription init.

this can fix the many warnings at once. the thing is that, some unit tests are only running with default rmw implementation which is rmw_fastrtps that supports content filtering feature. so those warnings are not observed before unless specific rmw configuration is set to start the test. 

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

part of https://github.com/ros2/rmw_cyclonedds/pull/550

### Is this user-facing behavior change?

No

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
