### PR TITLE
fix: Prevent short time endless loop in expire_timer

### DIFF
--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -111,6 +111,12 @@ _enqueue_check_expired_goals(
   (void)timer;
   (void)last_call;
 
+  rcl_ret_t ret = rcl_timer_cancel(timer);
+  if(ret != RCL_RET_OK) {
+    RCUTILS_LOG_ERROR_NAMED(
+      ROS_PACKAGE_NAME, "_enqueue_check_expired_goals cancel of timer failed !");
+  }
+
   if ((uintptr_t)NULL != type_erased_event_callback) {
     rcl_event_callback_with_data_t * typed_cb_with_data =
       (rcl_event_callback_with_data_t *)type_erased_event_callback;
@@ -564,14 +570,16 @@ _recalculate_expire_timer(
       // Time jumped backwards
       minimum_period = 0;
     }
-    // Un-cancel timer
-    ret = rcl_timer_reset(expire_timer);
+    // Make timer fire when next goal expires
+    // this need to be called before reset, as reset computes
+    // the next time the timer fires
+    int64_t old_period;
+    ret = rcl_timer_exchange_period(expire_timer, minimum_period, &old_period);
     if (RCL_RET_OK != ret) {
       return ret;
     }
-    // Make timer fire when next goal expires
-    int64_t old_period;
-    ret = rcl_timer_exchange_period(expire_timer, minimum_period, &old_period);
+    // Un-cancel timer
+    ret = rcl_timer_reset(expire_timer);
     if (RCL_RET_OK != ret) {
       return ret;
     }
@@ -746,7 +754,7 @@ rcl_action_expire_goals(
       continue;
     }
 
-    if ((current_time - goal_terminal_timestamp) > timeout) {
+    if ((current_time - goal_terminal_timestamp) >= timeout) {
       // Deallocate space used to store pointer to goal handle
       allocator.deallocate(action_server->impl->goal_handles[i], allocator.state);
       action_server->impl->goal_handles[i] = NULL;

--- a/rcl_action/src/rcl_action/action_server.c
+++ b/rcl_action/src/rcl_action/action_server.c
@@ -108,7 +108,6 @@ _enqueue_check_expired_goals(
   int64_t last_call,
   const uintptr_t type_erased_event_callback)
 {
-  (void)timer;
   (void)last_call;
 
   rcl_ret_t ret = rcl_timer_cancel(timer);


### PR DESCRIPTION
There were multiple bugs in this area:
- The expire of goals and the re computation of the expire period had a < vs <= issue, leading to goals not expiring, while the period for the next expire was compute as 0 leading to a direct recall of the expire timer. In combination with sim time this lead to 100% CPU spikes.
- The period of the expire timer was changed after the reset of the timer, leading to an incorrect next call time of the timer.
- The timer was not canceled after the expire event was issued

