### PR TITLE
Remove the check for content filter support at the RCL layer

### DIFF
--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -138,19 +138,6 @@ rcl_subscription_init(
   }
   subscription->impl->type_hash = *type_support->get_type_hash_func(type_support);
 
-  // Check if the subscription supports content filtering
-  // If RMW implementation doesn't support content filtering, calling
-  // rmw_subscription_get_content_filter() with unavailable parameters will always return
-  // RMW_RET_UNSUPPORTED.
-  if (rmw_subscription_get_content_filter(
-    subscription->impl->rmw_handle, NULL, NULL) == RMW_RET_UNSUPPORTED)
-  {
-    subscription->impl->rmw_handle->is_cft_supported = false;
-  } else {
-    rcutils_reset_error();
-    subscription->impl->rmw_handle->is_cft_supported = true;
-  }
-
   RCUTILS_LOG_DEBUG_NAMED(ROS_PACKAGE_NAME, "Subscription initialized");
   ret = RCL_RET_OK;
   TRACETOOLS_TRACEPOINT(


### PR DESCRIPTION
## Description

Remove the check for content filter support at the RCL layer

Depend on ros2/rmw_fastrtps#869 and ros2/rmw_connextdds#223

This PR can resolve this #1301

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information
