### PR TITLE
Add rcl_subscription_options_set_acceptable_buffer_backends with proper lifetime management

### DIFF
--- a/rcl/include/rcl/subscription.h
+++ b/rcl/include/rcl/subscription.h
@@ -268,6 +268,30 @@ rcl_subscription_options_set_content_filter_options(
   const char * expression_parameter_argv[],
   rcl_subscription_options_t * options);
 
+/// Set the acceptable buffer backends for the given subscription options.
+/**
+ * <hr>
+ * Attribute          | Adherence
+ * ------------------ | -------------
+ * Allocates Memory   | Yes
+ * Thread-Safe        | No
+ * Uses Atomics       | No
+ * Lock-Free          | No
+ *
+ * \param[in] acceptable_buffer_backends Comma-separated list of acceptable buffer backend names.
+ *   NULL or empty string means CPU-only (default). "any" means all installed backends.
+ * \param[out] options The subscription options to be set.
+ * \return `RCL_RET_OK` if set options successfully, or
+ * \return `RCL_RET_INVALID_ARGUMENT` if options is NULL, or
+ * \return `RCL_RET_BAD_ALLOC` if allocating memory fails.
+ */
+RCL_PUBLIC
+RCL_WARN_UNUSED
+rcl_ret_t
+rcl_subscription_options_set_acceptable_buffer_backends(
+  const char * acceptable_buffer_backends,
+  rcl_subscription_options_t * options);
+
 /// Return the zero initialized subscription content filter options.
 RCL_PUBLIC
 RCL_WARN_UNUSED

--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -273,6 +273,43 @@ rcl_subscription_options_fini(rcl_subscription_options_t * option)
       option->rmw_subscription_options.content_filter_options, allocator->state);
     option->rmw_subscription_options.content_filter_options = NULL;
   }
+
+  if (option->rmw_subscription_options.acceptable_buffer_backends) {
+    allocator->deallocate(
+      (char *)option->rmw_subscription_options.acceptable_buffer_backends, allocator->state);
+    option->rmw_subscription_options.acceptable_buffer_backends = NULL;
+  }
+
+  return RCL_RET_OK;
+}
+
+rcl_ret_t
+rcl_subscription_options_set_acceptable_buffer_backends(
+  const char * acceptable_buffer_backends,
+  rcl_subscription_options_t * options)
+{
+  RCL_CHECK_ARGUMENT_FOR_NULL(options, RCL_RET_INVALID_ARGUMENT);
+  const rcl_allocator_t * allocator = &options->allocator;
+  RCL_CHECK_ALLOCATOR_WITH_MSG(allocator, "invalid allocator", return RCL_RET_INVALID_ARGUMENT);
+
+  // Free any previously allocated value
+  if (options->rmw_subscription_options.acceptable_buffer_backends) {
+    allocator->deallocate(
+      (char *)options->rmw_subscription_options.acceptable_buffer_backends, allocator->state);
+    options->rmw_subscription_options.acceptable_buffer_backends = NULL;
+  }
+
+  if (NULL == acceptable_buffer_backends || '\0' == acceptable_buffer_backends[0]) {
+    return RCL_RET_OK;
+  }
+
+  char * dup = rcutils_strdup(acceptable_buffer_backends, *allocator);
+  if (NULL == dup) {
+    RCL_SET_ERROR_MSG("failed to allocate acceptable_buffer_backends string");
+    return RCL_RET_BAD_ALLOC;
+  }
+  options->rmw_subscription_options.acceptable_buffer_backends = dup;
+
   return RCL_RET_OK;
 }
 

--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -537,6 +537,12 @@ rcl_add_custom_gtest(test_subscription_content_filter_options
   LIBRARIES ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools test_msgs::test_msgs
 )
 
+rcl_add_custom_gtest(test_subscription_buffer_backend_options
+  SRCS rcl/test_subscription_buffer_backend_options.cpp
+  APPEND_LIBRARY_DIRS ${extra_lib_dirs}
+  LIBRARIES ${PROJECT_NAME}
+)
+
 rcl_add_custom_gtest(test_type_hash
   SRCS rcl/test_type_hash.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}

--- a/rcl/test/rcl/test_subscription_buffer_backend_options.cpp
+++ b/rcl/test/rcl/test_subscription_buffer_backend_options.cpp
@@ -1,0 +1,106 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "rcl/error_handling.h"
+#include "rcl/subscription.h"
+
+
+TEST(TestSubscriptionOptionsBufferBackends, set_null_options) {
+  EXPECT_EQ(
+    RCL_RET_INVALID_ARGUMENT,
+    rcl_subscription_options_set_acceptable_buffer_backends("cpu", nullptr)
+  );
+  rcl_reset_error();
+}
+
+TEST(TestSubscriptionOptionsBufferBackends, set_and_verify) {
+  rcl_subscription_options_t options = rcl_subscription_get_default_options();
+
+  // Default should be NULL
+  EXPECT_EQ(options.rmw_subscription_options.acceptable_buffer_backends, nullptr);
+
+  // Set a single backend
+  EXPECT_EQ(
+    RCL_RET_OK,
+    rcl_subscription_options_set_acceptable_buffer_backends("cuda", &options)
+  );
+  ASSERT_NE(options.rmw_subscription_options.acceptable_buffer_backends, nullptr);
+  EXPECT_STREQ(options.rmw_subscription_options.acceptable_buffer_backends, "cuda");
+
+  // Overwrite with a comma-separated list
+  EXPECT_EQ(
+    RCL_RET_OK,
+    rcl_subscription_options_set_acceptable_buffer_backends("cuda,demo", &options)
+  );
+  ASSERT_NE(options.rmw_subscription_options.acceptable_buffer_backends, nullptr);
+  EXPECT_STREQ(options.rmw_subscription_options.acceptable_buffer_backends, "cuda,demo");
+
+  // Set to "any"
+  EXPECT_EQ(
+    RCL_RET_OK,
+    rcl_subscription_options_set_acceptable_buffer_backends("any", &options)
+  );
+  ASSERT_NE(options.rmw_subscription_options.acceptable_buffer_backends, nullptr);
+  EXPECT_STREQ(options.rmw_subscription_options.acceptable_buffer_backends, "any");
+
+  EXPECT_EQ(RCL_RET_OK, rcl_subscription_options_fini(&options));
+  EXPECT_EQ(options.rmw_subscription_options.acceptable_buffer_backends, nullptr);
+}
+
+TEST(TestSubscriptionOptionsBufferBackends, set_null_clears) {
+  rcl_subscription_options_t options = rcl_subscription_get_default_options();
+
+  EXPECT_EQ(
+    RCL_RET_OK,
+    rcl_subscription_options_set_acceptable_buffer_backends("demo", &options)
+  );
+  ASSERT_NE(options.rmw_subscription_options.acceptable_buffer_backends, nullptr);
+
+  // Setting NULL should clear
+  EXPECT_EQ(
+    RCL_RET_OK,
+    rcl_subscription_options_set_acceptable_buffer_backends(NULL, &options)
+  );
+  EXPECT_EQ(options.rmw_subscription_options.acceptable_buffer_backends, nullptr);
+
+  EXPECT_EQ(RCL_RET_OK, rcl_subscription_options_fini(&options));
+}
+
+TEST(TestSubscriptionOptionsBufferBackends, set_empty_string_clears) {
+  rcl_subscription_options_t options = rcl_subscription_get_default_options();
+
+  EXPECT_EQ(
+    RCL_RET_OK,
+    rcl_subscription_options_set_acceptable_buffer_backends("demo", &options)
+  );
+  ASSERT_NE(options.rmw_subscription_options.acceptable_buffer_backends, nullptr);
+
+  // Setting empty string should clear
+  EXPECT_EQ(
+    RCL_RET_OK,
+    rcl_subscription_options_set_acceptable_buffer_backends("", &options)
+  );
+  EXPECT_EQ(options.rmw_subscription_options.acceptable_buffer_backends, nullptr);
+
+  EXPECT_EQ(RCL_RET_OK, rcl_subscription_options_fini(&options));
+}
+
+TEST(TestSubscriptionOptionsBufferBackends, fini_with_no_backends_set) {
+  rcl_subscription_options_t options = rcl_subscription_get_default_options();
+
+  // fini on default options (NULL backends) should succeed
+  EXPECT_EQ(RCL_RET_OK, rcl_subscription_options_fini(&options));
+}


### PR DESCRIPTION
## Description

This pull request adds `rcl_subscription_options_set_acceptable_buffer_backends()` to properly manage the lifetime of the `acceptable_buffer_backends` string in subscription options, following the same pattern used by `rcl_subscription_options_set_content_filter_options()`.

This PR introduces the following changes:
* **New function `rcl_subscription_options_set_acceptable_buffer_backends()`**: Allocates an owned copy of the string using `rcutils_strdup()` with the rcl allocator, matching the lifetime management pattern of content filter options.
* **Updated `rcl_subscription_options_fini()`**: Frees the allocated `acceptable_buffer_backends` string when subscription options are finalized.

This change is part of the broader ROS 2 native buffer feature.
It addresses review feedback on [ros2/rclcpp#3098](https://github.com/ros2/rclcpp/pull/3098).


### Is this user-facing behavior change?
No. This is an internal lifetime safety improvement.

### Did you use Generative AI?
Yes. Claude (claude-4.6-opus) via Cursor was used to assist with creating an initial prototype version of the changes contained in this PR.

### Additional Information
This PR is a dependency for the `acceptable_buffer_backends` changes in:
- [ros2/rclcpp#3098](https://github.com/ros2/rclcpp/pull/3098)
- [ros2/rclpy#1628](https://github.com/ros2/rclpy/pull/1628)