### PR TITLE
Convert more "*_TARGET" variables to new aggregate rosidl target.

### DIFF
--- a/rcl/test/CMakeLists.txt
+++ b/rcl/test/CMakeLists.txt
@@ -142,7 +142,7 @@ target_link_libraries(test_wait ${PROJECT_NAME} mimick osrf_testing_tools_cpp::m
 ament_add_gtest_executable(test_logging_rosout
   rcl/test_logging_rosout.cpp
 )
-target_link_libraries(test_logging_rosout ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools ${rcl_interfaces_TARGETS})
+target_link_libraries(test_logging_rosout ${PROJECT_NAME} osrf_testing_tools_cpp::memory_tools rcl_interfaces::rcl_interfaces)
 
 ament_add_gtest_executable(test_namespace
   rcl/test_namespace.cpp
@@ -182,7 +182,8 @@ ament_add_gtest_executable(test_get_type_description_service
 )
 target_include_directories(test_get_type_description_service PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/rcl/)
 target_link_libraries(test_get_type_description_service
-  ${PROJECT_NAME} mimick wait_for_entity_helpers osrf_testing_tools_cpp::memory_tools ${type_description_interfaces_TARGETS})
+  ${PROJECT_NAME} mimick wait_for_entity_helpers osrf_testing_tools_cpp::memory_tools
+  type_description_interfaces::type_description_interfaces)
 
 function(test_target)
   message(STATUS "Creating tests for '${rmw_implementation}'")
@@ -491,7 +492,7 @@ ament_add_test_label(test_domain_id mimick)
 rcl_add_custom_gtest(test_logging
   SRCS rcl/test_logging.cpp
   APPEND_LIBRARY_DIRS ${extra_lib_dirs}
-  LIBRARIES ${PROJECT_NAME} mimick ${rcl_interfaces_TARGETS}
+  LIBRARIES ${PROJECT_NAME} mimick rcl_interfaces::rcl_interfaces
     rcl_logging_interface::rcl_logging_interface ${RCL_LOGGING_IMPL}::${RCL_LOGGING_IMPL} osrf_testing_tools_cpp::memory_tools
 )
 ament_add_test_label(test_logging mimick)

--- a/rcl_action/CMakeLists.txt
+++ b/rcl_action/CMakeLists.txt
@@ -50,7 +50,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
 target_link_libraries(${PROJECT_NAME} PUBLIC
-  ${action_msgs_TARGETS}
+  action_msgs::action_msgs
   rcl::rcl
   rmw::rmw
   rosidl_runtime_c::rosidl_runtime_c
@@ -97,7 +97,7 @@ if(BUILD_TESTING)
       osrf_testing_tools_cpp::memory_tools
       rcl::rcl
       rcutils::rcutils
-      ${test_msgs_TARGETS}
+      test_msgs::test_msgs
     )
     target_compile_definitions(test_action_client PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
   endif()
@@ -106,31 +106,31 @@ if(BUILD_TESTING)
   target_include_directories(test_action_communication PUBLIC src)
   target_link_libraries(test_action_communication
     ${PROJECT_NAME}
-    ${action_msgs_TARGETS}
+    action_msgs::action_msgs
     osrf_testing_tools_cpp::memory_tools
     rcl::rcl
     rosidl_runtime_c::rosidl_runtime_c
-    ${test_msgs_TARGETS})
+    test_msgs::test_msgs)
 
   ament_add_gtest_executable(test_action_interaction test/rcl_action/test_action_interaction.cpp)
   target_link_libraries(test_action_interaction
     ${PROJECT_NAME}
-    ${action_msgs_TARGETS}
+    action_msgs::action_msgs
     osrf_testing_tools_cpp::memory_tools
     rcl::rcl
     rosidl_runtime_c::rosidl_runtime_c
-    ${test_msgs_TARGETS})
+    test_msgs::test_msgs)
 
   ament_add_gtest_executable(test_graph test/rcl_action/test_graph.cpp)
   target_compile_definitions(test_graph PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
   target_link_libraries(test_graph
     ${PROJECT_NAME}
-    ${action_msgs_TARGETS}
+    action_msgs::action_msgs
     osrf_testing_tools_cpp::memory_tools
     rcl::rcl
     rcutils::rcutils
     rosidl_runtime_c::rosidl_runtime_c
-    ${test_msgs_TARGETS})
+    test_msgs::test_msgs)
 
   function(test_targets)
     message(STATUS "Creating tests for '${rmw_implementation}'")
@@ -173,10 +173,10 @@ if(BUILD_TESTING)
     )
     target_link_libraries(test_action_server
       ${PROJECT_NAME}
-      ${action_msgs_TARGETS}
+      action_msgs::action_msgs
       osrf_testing_tools_cpp::memory_tools
       rcl::rcl
-      ${test_msgs_TARGETS}
+      test_msgs::test_msgs
     )
     target_compile_definitions(test_action_server PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
   endif()
@@ -223,7 +223,7 @@ if(BUILD_TESTING)
       ${PROJECT_NAME}
       osrf_testing_tools_cpp::memory_tools
       rcl::rcl
-      ${test_msgs_TARGETS}
+      test_msgs::test_msgs
     )
     target_include_directories(test_wait PRIVATE
       src
@@ -237,7 +237,7 @@ if(BUILD_TESTING)
       ${PROJECT_NAME}
       osrf_testing_tools_cpp::memory_tools
       rcl::rcl
-      ${test_msgs_TARGETS}
+      test_msgs::test_msgs
     )
     target_include_directories(test_action_name_remapping PRIVATE
       src

--- a/rcl_lifecycle/CMakeLists.txt
+++ b/rcl_lifecycle/CMakeLists.txt
@@ -50,7 +50,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
 
 target_link_libraries(${PROJECT_NAME} PUBLIC
-  ${lifecycle_msgs_TARGETS}
+  lifecycle_msgs::lifecycle_msgs
   rcl::rcl
 )
 
@@ -87,7 +87,7 @@ if(BUILD_TESTING)
   if(TARGET test_default_state_machine)
     target_link_libraries(test_default_state_machine
       ${PROJECT_NAME}
-      ${lifecycle_msgs_TARGETS}
+      lifecycle_msgs::lifecycle_msgs
       osrf_testing_tools_cpp::memory_tools
       rcl::rcl
       rcutils::rcutils
@@ -100,7 +100,9 @@ if(BUILD_TESTING)
     test/test_multiple_instances.cpp
   )
   if(TARGET test_multiple_instances)
-    target_link_libraries(test_multiple_instances ${PROJECT_NAME} ${lifecycle_msgs_TARGETS} osrf_testing_tools_cpp::memory_tools rcl::rcl)
+    target_link_libraries(test_multiple_instances ${PROJECT_NAME} lifecycle_msgs::lifecycle_msgs
+      osrf_testing_tools_cpp::memory_tools rcl::rcl
+    )
   endif()
   ament_add_ros_isolated_gtest(test_rcl_lifecycle
     test/test_rcl_lifecycle.cpp
@@ -108,7 +110,7 @@ if(BUILD_TESTING)
   if(TARGET test_rcl_lifecycle)
     target_link_libraries(test_rcl_lifecycle
       ${PROJECT_NAME}
-      ${lifecycle_msgs_TARGETS}
+      lifecycle_msgs::lifecycle_msgs
       osrf_testing_tools_cpp::memory_tools
       rcl::rcl
       rcutils::rcutils


### PR DESCRIPTION
## Description
There were some leftover "*_TARGET" variables that I converted to the new cmake targets.

Fixes #1302

### Is this user-facing behavior change?
No

### Did you use Generative AI?
No.