### PR TITLE
Fix clang-tidy warning for ubuntu26

### DIFF
--- a/rcl_yaml_param_parser/src/parse.c
+++ b/rcl_yaml_param_parser/src/parse.c
@@ -570,7 +570,7 @@ _validate_name(const char * name, rcutils_allocator_t allocator)
   }
 
   rcutils_ret_t ret = RCUTILS_RET_OK;
-  char * separator_pos = strrchr(name, '/');
+  const char * separator_pos = strrchr(name, '/');
   char * node_name = NULL;
   char * absolute_namespace = NULL;
   if (NULL == separator_pos) {


### PR DESCRIPTION
## Description

For `-Wdiscarded-qualifiers`

https://github.com/ros2/ci/issues/838#issuecomment-4118939903

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
