### PR TITLE
Add RCL_EXPECT_ERROR_IS_SET macro

### DIFF
--- a/rcl/include/rcl/error_handling.h
+++ b/rcl/include/rcl/error_handling.h
@@ -40,6 +40,21 @@ typedef rcutils_error_string_t rcl_error_string_t;
 
 #define rcl_error_is_set rcutils_error_is_set
 
+// RCL_EXPECT_ERROR_IS_SET checks something has set the rcl error state.
+// Use when you want to propagate an error set by another function.
+// Typical usage:
+//   rcl_ret_t ret = rcl_some_function_that_can_fail()
+//   if (ret != RCL_RET_OK) {
+//    RCL_EXPECT_ERROR_IS_SET(ret);
+//    return ret;
+//   }
+#define RCL_EXPECT_ERROR_IS_SET(ret) \
+  do { \
+    if (!rcl_error_is_set()) { \
+      RCL_SET_ERROR_MSG_WITH_FORMAT_STRING("Expected error message, but none set: %d", ret); \
+    } \
+  } while (0)
+
 #define rcl_get_error_state rcutils_get_error_state
 
 #define rcl_get_error_string rcutils_get_error_string

--- a/rcl/src/rcl/timer.c
+++ b/rcl/src/rcl/timer.c
@@ -156,6 +156,7 @@ rcl_timer_init2(
   rcl_time_point_value_t now;
   rcl_ret_t now_ret = rcl_clock_get_now(clock, &now);
   if (now_ret != RCL_RET_OK) {
+    RCL_EXPECT_ERROR_IS_SET(now_ret);
     return now_ret;  // rcl error state should already be set.
   }
   rcl_timer_impl_t impl;
@@ -283,6 +284,7 @@ rcl_timer_call_with_info(rcl_timer_t * timer, rcl_timer_call_info_t * call_info)
   rcl_time_point_value_t now;
   rcl_ret_t now_ret = rcl_clock_get_now(timer->impl->clock, &now);
   if (now_ret != RCL_RET_OK) {
+    RCL_EXPECT_ERROR_IS_SET(now_ret);
     return now_ret;  // rcl error state should already be set.
   }
   if (now < 0) {
@@ -337,6 +339,7 @@ rcl_timer_is_ready(const rcl_timer_t * timer, bool * is_ready)
     *is_ready = false;
     return RCL_RET_OK;
   } else if (ret != RCL_RET_OK) {
+    RCL_EXPECT_ERROR_IS_SET(ret);
     return ret;  // rcl error state should already be set.
   }
   *is_ready = (time_until_next_call <= 0);
@@ -371,6 +374,7 @@ rcl_timer_get_time_until_next_call(const rcl_timer_t * timer, int64_t * time_unt
   rcl_time_point_value_t now;
   rcl_ret_t ret = rcl_clock_get_now(timer->impl->clock, &now);
   if (ret != RCL_RET_OK) {
+    RCL_EXPECT_ERROR_IS_SET(ret);
     return ret;  // rcl error state should already be set.
   }
   *time_until_next_call =
@@ -389,6 +393,7 @@ rcl_timer_get_time_since_last_call(
   rcl_time_point_value_t now;
   rcl_ret_t ret = rcl_clock_get_now(timer->impl->clock, &now);
   if (ret != RCL_RET_OK) {
+    RCL_EXPECT_ERROR_IS_SET(ret);
     return ret;  // rcl error state should already be set.
   }
   *time_since_last_call =
@@ -489,6 +494,7 @@ rcl_timer_reset(rcl_timer_t * timer)
   rcl_time_point_value_t now;
   rcl_ret_t now_ret = rcl_clock_get_now(timer->impl->clock, &now);
   if (now_ret != RCL_RET_OK) {
+    RCL_EXPECT_ERROR_IS_SET(now_ret);
     return now_ret;  // rcl error state should already be set.
   }
   int64_t period = rcutils_atomic_load_int64_t(&timer->impl->period);

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -698,7 +698,7 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
   }
   // Check for timeout, return RCL_RET_TIMEOUT only if it wasn't a timer.
   if (ret != RMW_RET_OK && ret != RMW_RET_TIMEOUT) {
-    RCL_SET_ERROR_MSG(rmw_get_error_string().str);
+    RCL_SET_ERROR_MSG_WITH_FORMAT_STRING("Error from rmw_wait(): %d %s", ret, rmw_get_error_string().str);
     return RCL_RET_ERROR;
   }
   // Set corresponding rcl subscription handles NULL.

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -564,23 +564,29 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
       }
 
       rcl_clock_t * clock;
-      if (rcl_timer_clock(wait_set->timers[t_idx], &clock) != RCL_RET_OK) {
+      rcl_ret_t ret = rcl_timer_clock(wait_set->timers[t_idx], &clock);
+      if (ret != RCL_RET_OK) {
         // should never happen
+        RCL_EXPECT_ERROR_IS_SET(ret);
         return RCL_RET_ERROR;
       }
 
       if (clock->type == RCL_ROS_TIME) {
         bool timer_override_active = false;
-        if (rcl_is_enabled_ros_time_override(clock, &timer_override_active) != RCL_RET_OK) {
+        ret = rcl_is_enabled_ros_time_override(clock, &timer_override_active);
+        if (ret != RCL_RET_OK) {
           // should never happen
+          RCL_EXPECT_ERROR_IS_SET(ret);
           return RCL_RET_ERROR;
         }
 
         if (timer_override_active) {
           // we need to check, it the timer is already ready
           bool override_timer_is_ready = false;
-          if (rcl_timer_is_ready(wait_set->timers[t_idx], &override_timer_is_ready) != RCL_RET_OK) {
+          ret = rcl_timer_is_ready(wait_set->timers[t_idx], &override_timer_is_ready);
+          if (ret != RCL_RET_OK) {
             // should never happen
+            RCL_EXPECT_ERROR_IS_SET(ret);
             return RCL_RET_ERROR;
           }
 
@@ -599,12 +605,13 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
 
       // get the time of the next call to the timer
       int64_t next_call_time = INT64_MAX;
-      rcl_ret_t ret = rcl_timer_get_next_call_time(wait_set->timers[t_idx], &next_call_time);
+      ret = rcl_timer_get_next_call_time(wait_set->timers[t_idx], &next_call_time);
       if (ret == RCL_RET_TIMER_CANCELED) {
         wait_set->timers[t_idx] = NULL;
         continue;
       }
       if (ret != RCL_RET_OK) {
+        RCL_EXPECT_ERROR_IS_SET(ret);
         return ret;  // The rcl error state should already be set.
       }
       if (next_call_time < min_next_call_time[clock->type]) {
@@ -631,6 +638,7 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
       int64_t cur_time;
       rmw_ret_t ret = rcl_clock_get_now(clocks[i], &cur_time);
       if (ret != RCL_RET_OK) {
+        RCL_EXPECT_ERROR_IS_SET(ret);
         return ret;  // The rcl error state should already be set.
       }
 
@@ -679,6 +687,7 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
     bool current_timer_is_ready = false;
     rcl_ret_t ret = rcl_timer_is_ready(wait_set->timers[i], &current_timer_is_ready);
     if (ret != RCL_RET_OK) {
+      RCL_EXPECT_ERROR_IS_SET(ret);
       return ret;  // The rcl error state should already be set.
     }
     if (!current_timer_is_ready) {

--- a/rcl/src/rcl/wait.c
+++ b/rcl/src/rcl/wait.c
@@ -698,7 +698,8 @@ rcl_wait(rcl_wait_set_t * wait_set, int64_t timeout)
   }
   // Check for timeout, return RCL_RET_TIMEOUT only if it wasn't a timer.
   if (ret != RMW_RET_OK && ret != RMW_RET_TIMEOUT) {
-    RCL_SET_ERROR_MSG_WITH_FORMAT_STRING("Error from rmw_wait(): %d %s", ret, rmw_get_error_string().str);
+    RCL_SET_ERROR_MSG_WITH_FORMAT_STRING(
+      "Error from rmw_wait(): %d %s", ret, rmw_get_error_string().str);
     return RCL_RET_ERROR;
   }
   // Set corresponding rcl subscription handles NULL.


### PR DESCRIPTION
## Description

Some functions expect another `rcl_...()` function set the rcl error state. However, there's at least one bug where something returns an error without doing that. I don't know where this bug is, so I added a new macro that checks that the error state is set.

Requires https://github.com/ros2/rcutils/pull/550

### Is this user-facing behavior change?

Sort of. It might set an error state where none was set previously, but in those cases the code should have already been setting an error state.

### Did you use Generative AI?

I generated the code changes in this PR with a gemini-based agent.

### Additional Information

I'm trying to get more information about the fialing `test_two_timers` tests on Windows. I can't reproduce them on my Windows machine. The test assertions tell me `rcl_wait()` returned `RCL_RET_ERROR`, but whatever set the error did not also set the error state. I'm hoping this new macro gives me more information about what raised the error.

```
38: [ RUN      ] TestTimerFixture.test_two_timers_ready_before_timeout
38: C:\ci\ws\src\ros2\rcl\rcl\test\rcl\test_timer.cpp(350): error: Expected equality of these values:
38:   0
38:   ret
38:     Which is: 2
38: error not set
38: 
38: unknown file: error: SEH exception with code 0xc0000005 thrown in the test body.
38: Stack trace:
38: 
38: 
38: [  FAILED  ] TestTimerFixture.test_two_timers_ready_before_timeout (28 ms)
```