### PR TITLE
Preserve rmw_create_node error state in rcl_node_init

### DIFF
--- a/rcl/src/rcl/node.c
+++ b/rcl/src/rcl/node.c
@@ -246,13 +246,21 @@ rcl_node_init(
   node->impl->rmw_node_handle = rmw_create_node(
     &(node->context->impl->rmw_context),
     name, local_namespace_);
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    node->impl->rmw_node_handle, rmw_get_error_string().str, ret = RCL_RET_ERROR; goto fail);
+  if (NULL == node->impl->rmw_node_handle) {
+    // Preserve the error set by rmw_create_node rather than overwriting it.
+    RCL_EXPECT_ERROR_IS_SET(RCL_RET_ERROR);
+    ret = RCL_RET_ERROR;
+    goto fail;
+  }
 
   // graph guard condition
   rmw_graph_guard_condition = rmw_node_get_graph_guard_condition(node->impl->rmw_node_handle);
-  RCL_CHECK_FOR_NULL_WITH_MSG(
-    rmw_graph_guard_condition, rmw_get_error_string().str, ret = RCL_RET_ERROR; goto fail);
+  if (NULL == rmw_graph_guard_condition) {
+    // Preserve the error set by rmw_node_get_graph_guard_condition.
+    RCL_EXPECT_ERROR_IS_SET(RCL_RET_ERROR);
+    ret = RCL_RET_ERROR;
+    goto fail;
+  }
 
   node->impl->graph_guard_condition = (rcl_guard_condition_t *)allocator->allocate(
     sizeof(rcl_guard_condition_t), allocator->state);

--- a/rcl/test/rcl/test_node.cpp
+++ b/rcl/test/rcl/test_node.cpp
@@ -20,6 +20,7 @@
 
 #include "rcl/rcl.h"
 #include "rcl/node.h"
+#include "rmw/error_handling.h"
 #include "rmw/rmw.h"  // For rmw_get_implementation_identifier.
 #include "rmw/validate_namespace.h"
 #include "rmw/validate_node_name.h"
@@ -489,6 +490,26 @@ TEST_F(TestNodeFixture, test_rcl_node_init_with_internal_errors) {
     auto mock = mocking_utils::patch_and_return("lib:rcl", rmw_create_node, nullptr);
     ret = rcl_node_init(&node, name, namespace_, &context, &options);
     EXPECT_EQ(RCL_RET_ERROR, ret);
+    rcl_reset_error();
+  }
+
+  // Verify rmw_create_node error message is preserved through rcl_node_init failure path.
+  // Regression test for https://github.com/ros2/rcl/issues/983
+  {
+    auto mock = mocking_utils::patch(
+      "lib:rcl", rmw_create_node,
+      [](auto, auto, auto) -> rmw_node_t * {
+        RMW_SET_ERROR_MSG("test_rmw_create_node_failure_reason");
+        return nullptr;
+      });
+    ret = rcl_node_init(&node, name, namespace_, &context, &options);
+    EXPECT_EQ(RCL_RET_ERROR, ret);
+    ASSERT_TRUE(rcl_error_is_set());
+    // The RMW error message must be preserved, not overwritten with
+    // the generic "rcl node's rmw handle is invalid" message.
+    EXPECT_NE(
+      std::string(rcl_get_error_string().str).find("test_rmw_create_node_failure_reason"),
+      std::string::npos) << "RMW error was overwritten: " << rcl_get_error_string().str;
     rcl_reset_error();
   }
 


### PR DESCRIPTION
Fixes #983

## Problem

When `rmw_create_node` or `rmw_node_get_graph_guard_condition` fail, they set a descriptive RMW error message via `RMW_SET_ERROR_MSG` before returning NULL. The previous `RCL_CHECK_FOR_NULL_WITH_MSG` calls at these two sites used `rmw_get_error_string().str` as the message argument, but `RCL_CHECK_FOR_NULL_WITH_MSG` unconditionally calls `RCL_SET_ERROR_MSG`, triggering the rcutils "overwriting error state" warning and replacing the specific root-cause message with an identical copy — or, in code paths where additional cleanup runs before the error is read, losing the original message entirely.

The result: callers (e.g. rclcpp node constructors, Nav2 lifecycle managers) see a generic error instead of the actual RMW failure reason, making diagnosis significantly harder.

## Fix

Replace both `RCL_CHECK_FOR_NULL_WITH_MSG(…, rmw_get_error_string().str, …)` calls with explicit NULL guards that use the `RCL_EXPECT_ERROR_IS_SET` macro introduced in #1312:

```c
if (NULL == node->impl->rmw_node_handle) {
  RCL_EXPECT_ERROR_IS_SET(RCL_RET_ERROR);
  ret = RCL_RET_ERROR;
  goto fail;
}
```

`RCL_EXPECT_ERROR_IS_SET` preserves the error set by `rmw_create_node`; it only sets a fallback message if no error was set (defensive case).

## Existing Behavior Audit (OPS-RULE-016)

| File | Line | What it does |
|------|------|-------------|
| `rcl/src/rcl/node.c` | ~246–250 | `rmw_create_node` called; on NULL return, RMW has set an error via `RMW_SET_ERROR_MSG` |
| `rcl/src/rcl/node.c` | ~249–250 (pre-fix) | `RCL_CHECK_FOR_NULL_WITH_MSG` overwrites that error via unconditional `RCL_SET_ERROR_MSG` |
| `rcl/src/rcl/node.c` | ~253–255 | Same pattern for `rmw_node_get_graph_guard_condition` |
| `rcl/include/rcl/error_handling.h` | `RCL_EXPECT_ERROR_IS_SET` | New macro (from #1312): preserves existing error, sets fallback if none |

## Scope Classification (OPS-RULE-017)

**Category (a): Bug fix.** The function contract requires the error set by lower-level RMW code to propagate unchanged to the caller. No API changes, no new public symbols.

## Test

Added regression test to `rcl/test/rcl/test_node.cpp` using the existing `mocking_utils::patch` infrastructure. The mock sets `RMW_SET_ERROR_MSG("test_rmw_create_node_failure_reason")` before returning nullptr; the test asserts that `rcl_get_error_string()` after `rcl_node_init` failure contains that exact substring.

## Prior Art (OPS-RULE-018)

1. **#1312** — *Add RCL_EXPECT_ERROR_IS_SET macro* (merged 2026-04-10, @sloretz) — introduces the macro this fix uses; applied to `timer.c` and `wait.c` for the same class of problem
2. **#985** — *Prior fix attempt for this issue* (reviewed 2022, fujitatomoya) — identified the correct problem but reviewer requested a broader refactor; this PR targets only the two sites that produce the overwrite warning
3. **#1304** — *Remove the check for content filter support at the RCL layer* (merged 2026-03-23) — demonstrates the recurring theme of rcl redundantly checking RMW state; this fix goes in the same direction: trust RMW error propagation

*AI-assisted — authored with Claude, reviewed by Komada.*