### PR TITLE
Warn when deprecated/removed env vars are set (ROS_LOCALHOST_ONLY)

### DIFF
--- a/rcl/src/rcl/discovery_options.c
+++ b/rcl/src/rcl/discovery_options.c
@@ -49,6 +49,31 @@ rcl_get_automatic_discovery_range(rmw_discovery_options_t * discovery_options)
   RCUTILS_CAN_SET_MSG_AND_RETURN_WITH_ERROR_OF(RCL_RET_ERROR);
   RCL_CHECK_ARGUMENT_FOR_NULL(discovery_options, RCL_RET_INVALID_ARGUMENT);
 
+  // Warn if any deprecated/removed environment variables are set, so that
+  // users who still have them in their environment receive actionable feedback.
+  {
+    const char * deprecated_val = NULL;
+    if (NULL == rcutils_get_env("ROS_LOCALHOST_ONLY", &deprecated_val) &&
+      NULL != deprecated_val && strcmp(deprecated_val, "") != 0)
+    {
+      RCUTILS_LOG_WARN_NAMED(
+        ROS_PACKAGE_NAME,
+        "Environment variable 'ROS_LOCALHOST_ONLY' is set but has been removed. "
+        "Use 'ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST' instead. "
+        "The value of 'ROS_LOCALHOST_ONLY' will be ignored.");
+    }
+    deprecated_val = NULL;
+    if (NULL == rcutils_get_env("LOCALHOST_ONLY", &deprecated_val) &&
+      NULL != deprecated_val && strcmp(deprecated_val, "") != 0)
+    {
+      RCUTILS_LOG_WARN_NAMED(
+        ROS_PACKAGE_NAME,
+        "Environment variable 'LOCALHOST_ONLY' is set but has been removed. "
+        "Use 'ROS_AUTOMATIC_DISCOVERY_RANGE=LOCALHOST' instead. "
+        "The value of 'LOCALHOST_ONLY' will be ignored.");
+    }
+  }
+
   get_env_error_str = rcutils_get_env(
     RCL_AUTOMATIC_DISCOVERY_RANGE_ENV_VAR,
     &ros_automatic_discovery_range_env_val);

--- a/rcl/test/rcl/test_discovery_options.cpp
+++ b/rcl/test/rcl/test_discovery_options.cpp
@@ -275,3 +275,39 @@ TEST(TestDiscoveryInfo, test_get_both) {
   EXPECT_EQ(0u, discovery_options_var.static_peers_count);
   EXPECT_EQ(RCL_RET_OK, rmw_discovery_options_fini(&discovery_options_var));
 }
+
+// Regression test for https://github.com/ros2/rcl/issues/1241:
+// Deprecated/removed env vars must be silently ignored with a warning rather than
+// causing incorrect configuration or a crash.
+TEST(TestDiscoveryInfo, test_deprecated_env_vars_ignored) {
+  // Ensure the canonical var is set to SUBNET so we can verify the deprecated
+  // vars do not alter the result.
+  ASSERT_TRUE(rcutils_set_env("ROS_AUTOMATIC_DISCOVERY_RANGE", "SUBNET"));
+  OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT(
+  {
+    ASSERT_TRUE(rcutils_set_env("ROS_AUTOMATIC_DISCOVERY_RANGE", ""));
+    ASSERT_TRUE(rcutils_set_env("ROS_LOCALHOST_ONLY", ""));
+    ASSERT_TRUE(rcutils_set_env("LOCALHOST_ONLY", ""));
+  });
+
+  // ROS_LOCALHOST_ONLY set but removed: function must still succeed and use the
+  // canonical ROS_AUTOMATIC_DISCOVERY_RANGE value.
+  ASSERT_TRUE(rcutils_set_env("ROS_LOCALHOST_ONLY", "1"));
+  rmw_discovery_options_t discovery_options_var = rmw_get_zero_initialized_discovery_options();
+  EXPECT_EQ(RCL_RET_OK, rcl_get_automatic_discovery_range(&discovery_options_var));
+  EXPECT_EQ(
+    RMW_AUTOMATIC_DISCOVERY_RANGE_SUBNET,
+    discovery_options_var.automatic_discovery_range)
+    << "ROS_LOCALHOST_ONLY must not override ROS_AUTOMATIC_DISCOVERY_RANGE";
+  ASSERT_TRUE(rcutils_set_env("ROS_LOCALHOST_ONLY", ""));
+
+  // LOCALHOST_ONLY set but removed: same requirement.
+  ASSERT_TRUE(rcutils_set_env("LOCALHOST_ONLY", "1"));
+  discovery_options_var = rmw_get_zero_initialized_discovery_options();
+  EXPECT_EQ(RCL_RET_OK, rcl_get_automatic_discovery_range(&discovery_options_var));
+  EXPECT_EQ(
+    RMW_AUTOMATIC_DISCOVERY_RANGE_SUBNET,
+    discovery_options_var.automatic_discovery_range)
+    << "LOCALHOST_ONLY must not override ROS_AUTOMATIC_DISCOVERY_RANGE";
+  ASSERT_TRUE(rcutils_set_env("LOCALHOST_ONLY", ""));
+}


### PR DESCRIPTION
Closes #1241.

## Summary

When a user's environment still contains `ROS_LOCALHOST_ONLY` or `LOCALHOST_ONLY` — variables that were removed from rcl — the node starts silently mis-configured with no diagnostic output. This PR makes `rcl_get_automatic_discovery_range()` emit a `RCUTILS_LOG_WARN_NAMED` diagnostic for each removed variable that is present, so users receive actionable feedback.

## Changes

- `rcl/src/rcl/discovery_options.c` — check for `ROS_LOCALHOST_ONLY` and `LOCALHOST_ONLY` at the start of `rcl_get_automatic_discovery_range()`; emit `RCUTILS_LOG_WARN_NAMED` with migration guidance if either is set. The new canonical variable (`ROS_AUTOMATIC_DISCOVERY_RANGE`) is read and respected as before.
- `rcl/test/rcl/test_discovery_options.cpp` — new test `test_deprecated_env_vars_ignored` verifying that setting either deprecated variable does not alter the discovery range returned when `ROS_AUTOMATIC_DISCOVERY_RANGE` is canonical.

## Existing Behavior Audit (OPS-RULE-016)

| File | Location | Env var | Status |
|------|----------|---------|--------|
| `rcl/src/rcl/discovery_options.c` | `rcl_get_automatic_discovery_range()` line 52 | `ROS_AUTOMATIC_DISCOVERY_RANGE` | Current canonical var — unchanged |
| `rcl/src/rcl/discovery_options.c` | `rcl_get_discovery_static_peers()` line 120 | `ROS_STATIC_PEERS` | Current canonical var — unchanged |
| `rcl/src/rcl/domain_id.c` | `rcl_get_default_domain_id()` line 38 | `ROS_DOMAIN_ID` | Current canonical var — no deprecated alias found |
| `rcl/src/rcl/discovery_options.c` | *(new)* | `ROS_LOCALHOST_ONLY`, `LOCALHOST_ONLY` | Removed — now detected and warned |

`rcutils/env.h` (`rcutils_get_env`) and `rcutils/logging_macros.h` (`RCUTILS_LOG_WARN_NAMED`) are already included in `discovery_options.c`. No new dependencies added.

## Scope Classification (OPS-RULE-017)

**(a) Bug fix** — the issue describes silent mis-configuration: a developer setting a removed env var receives no feedback. This is a targeted addition of detection logic at the existing env-reading call site.

## Prior Art (OPS-RULE-018)

1. **Issue #1241** — "Always check/reject all deprecated/removed env variable" — this PR is the direct fix.
2. **PR #1238** — "remove unnecessary test_with_localhost_only" (merged 2025-05-14) — confirms `LOCALHOST_ONLY` was already removed; the test was deleted without adding a deprecation warning, which is precisely the gap this PR fills.
3. **PR #689** — "Keep domain id if ROS_DOMAIN_ID is invalid" (merged 2020-06-22) — establishes that env var validation/error-handling in `rcl` is a known concern; env var edge cases have been fixed at `domain_id.c` before.
4. **`init.c` lines 186–193** (rolling) — existing `RCUTILS_LOG_WARN_NAMED` call for `ROS_STATIC_PEERS` / `ROS_AUTOMATIC_DISCOVERY_RANGE=OFF` conflict — this is the model for the warning pattern used here.

This change is consistent with the existing pattern of `RCUTILS_LOG_WARN_NAMED` in `init.c` for misconfigured env var combinations.

## Test Evidence (OPS-RULE-011)

New test `TEST(TestDiscoveryInfo, test_deprecated_env_vars_ignored)` in `rcl/test/rcl/test_discovery_options.cpp`:
- Sets `ROS_LOCALHOST_ONLY=1`, calls `rcl_get_automatic_discovery_range`, asserts `RCL_RET_OK` and `RMW_AUTOMATIC_DISCOVERY_RANGE_SUBNET` (from the canonical var, not the deprecated one).
- Sets `LOCALHOST_ONLY=1`, same assertions.
- Uses `OSRF_TESTING_TOOLS_CPP_SCOPE_EXIT` to clean up env vars.

---

*AI-assisted — authored with Claude, reviewed by Komada.*