### PR TITLE
Treat bare YAML nan and inf as strings

### DIFF
--- a/rcl_yaml_param_parser/src/parse.c
+++ b/rcl_yaml_param_parser/src/parse.c
@@ -15,6 +15,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <locale.h>
+#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -138,6 +139,7 @@ _get_int_value(
 /// \param[in] value the float value to get
 /// \param[out] val_type the value type
 /// \param[out] ret_val the converted value when value is valid
+/// \param[in] allow_nonfinite_fallback whether generic non-finite forms are allowed
 /// \param[in] allocator the allocator to use
 /// \return RCUTILS_RET_OK if value is valid, or
 /// \return RCUTILS_RET_ERROR if value is not valid
@@ -147,6 +149,7 @@ _get_float_value(
   const char * const value,
   data_types_t * val_type,
   void ** ret_val,
+  const bool allow_nonfinite_fallback,
   const rcutils_allocator_t allocator);
 
 ///
@@ -213,7 +216,7 @@ void * get_value(
 
     /// Check for float tag
     if (strcmp(YAML_FLOAT_TAG, (char *)tag) == 0) {
-      if (_get_float_value(value, val_type, &ret_val, allocator) != RCUTILS_RET_ERROR) {
+      if (_get_float_value(value, val_type, &ret_val, true, allocator) != RCUTILS_RET_ERROR) {
         return ret_val;
       } else {
         return NULL;
@@ -247,7 +250,7 @@ void * get_value(
     }
 
     /// Check for float
-    if (_get_float_value(value, val_type, &ret_val, allocator) != RCUTILS_RET_ERROR) {
+    if (_get_float_value(value, val_type, &ret_val, false, allocator) != RCUTILS_RET_ERROR) {
       return ret_val;
     }
   }
@@ -855,6 +858,7 @@ _get_float_value(
   const char * const value,
   data_types_t * val_type,
   void ** ret_val,
+  const bool allow_nonfinite_fallback,
   const rcutils_allocator_t allocator)
 {
   errno = 0;
@@ -884,6 +888,10 @@ _get_float_value(
     }
   } else {
     dval = strtod_locale_independent(value, &endptr);
+    // Implicit YAML floats require the dot-prefixed forms handled above.
+    if (!allow_nonfinite_fallback && (isnan(dval) || isinf(dval))) {
+      endptr = (char *)value;
+    }
   }
   if ((0 == errno) && (NULL != endptr)) {
     if ((NULL != endptr) && (endptr != value)) {

--- a/rcl_yaml_param_parser/test/special_float.yaml
+++ b/rcl_yaml_param_parser/test/special_float.yaml
@@ -1,4 +1,5 @@
 test_node:
     ros__parameters:
-        isstring: [string, .nananan, .nAN, .Nan, .infinf, .INf, .infinity]
+        isstring: [string, .nananan, .nAN, .Nan, .infinf, .INf, .infinity, nan, inf, +inf, -inf]
         nan_inf: [1.1, 2.2, .nan, .NAN, .inf, +.Inf, -.INF]
+        tagged_bare_nan_inf: [!!float nan, !!float inf, !!float +inf, !!float -inf]

--- a/rcl_yaml_param_parser/test/test_parse_yaml.cpp
+++ b/rcl_yaml_param_parser/test/test_parse_yaml.cpp
@@ -666,10 +666,15 @@ TEST(test_file_parser, special_float_point) {
   rcl_variant_t * param_value = rcl_yaml_node_struct_get("test_node", "isstring", params_hdl);
   ASSERT_TRUE(NULL != param_value) << rcutils_get_error_string().str;
   ASSERT_TRUE(NULL != param_value->string_array_value);
+  ASSERT_EQ(11U, param_value->string_array_value->size);
   EXPECT_STREQ(".nananan", param_value->string_array_value->data[1]);
   EXPECT_STREQ(".nAN", param_value->string_array_value->data[2]);
   EXPECT_STREQ(".infinf", param_value->string_array_value->data[4]);
   EXPECT_STREQ(".INf", param_value->string_array_value->data[5]);
+  EXPECT_STREQ("nan", param_value->string_array_value->data[7]);
+  EXPECT_STREQ("inf", param_value->string_array_value->data[8]);
+  EXPECT_STREQ("+inf", param_value->string_array_value->data[9]);
+  EXPECT_STREQ("-inf", param_value->string_array_value->data[10]);
   param_value = rcl_yaml_node_struct_get(
     "test_node", "nan_inf", params_hdl);
   ASSERT_TRUE(NULL != param_value) << rcutils_get_error_string().str;
@@ -681,6 +686,15 @@ TEST(test_file_parser, special_float_point) {
   EXPECT_TRUE(std::isinf(param_value->double_array_value->values[4]));
   EXPECT_TRUE(std::isinf(param_value->double_array_value->values[5]));
   EXPECT_TRUE(std::isinf(param_value->double_array_value->values[6]));
+  param_value = rcl_yaml_node_struct_get(
+    "test_node", "tagged_bare_nan_inf", params_hdl);
+  ASSERT_TRUE(NULL != param_value) << rcutils_get_error_string().str;
+  ASSERT_TRUE(NULL != param_value->double_array_value);
+  ASSERT_EQ(4U, param_value->double_array_value->size);
+  EXPECT_TRUE(std::isnan(param_value->double_array_value->values[0]));
+  EXPECT_TRUE(std::isinf(param_value->double_array_value->values[1]));
+  EXPECT_GT(param_value->double_array_value->values[2], 0.0);
+  EXPECT_LT(param_value->double_array_value->values[3], 0.0);
 }
 
 TEST(test_file_parser, empty_name_in_ns) {


### PR DESCRIPTION
## Description

`rcl_yaml_param_parser` explicitly handles the YAML 1.1 dot-prefixed non-finite forms such as `.nan` and `.inf`. Its generic `strtod()` fallback also accepted untagged bare `nan`, `inf`, `+inf`, and `-inf`, even though YAML treats those forms as strings.

Reject non-finite results only during implicit type inference, leaving both the existing dot-prefixed forms and explicitly tagged values such as `!!float nan` unchanged. Extend the special-float integration fixture to verify the four implicit bare forms remain strings and the four explicitly tagged forms remain doubles.

Fixes #1320.

### Is this user-facing behavior change?

Yes. Untagged bare `nan` and `inf` parameter values are now strings, matching YAML and the composable-node parameter loading path. Valid dot-prefixed and explicit `!!float` non-finite values continue to be parsed as doubles.

### Did you use Generative AI?

Yes. OpenAI Codex assisted with root-cause analysis and preparing the focused code and regression test. I reviewed the diff and verification results.

### Additional Information

Local verification:
- a native C probe verified implicit bare non-finite values are rejected as floats, explicit-tag mode accepts them, dot-prefixed forms remain floats, and finite values are unchanged
- PyYAML verification confirmed the fixture has 11 string entries and four explicitly tagged non-finite doubles
- source invariants confirm only the explicit `YAML_FLOAT_TAG` path enables generic non-finite parsing
- all changed lines are at most 100 characters
- UTF-8/CRLF and `git diff --check`

The full `rcl_yaml_param_parser` gtest requires ROS 2 build dependencies that are unavailable on this Windows host; repository CI covers the integration test.