### PR TITLE
Use pthread_once in rcl_yaml_param_parser on Apple

### DIFF
--- a/rcl_yaml_param_parser/src/parse.c
+++ b/rcl_yaml_param_parser/src/parse.c
@@ -20,6 +20,11 @@
 
 #ifdef _WIN32
 #include <windows.h>
+#elif defined(__APPLE__)
+#include <pthread.h>
+typedef pthread_once_t once_flag;
+#define ONCE_FLAG_INIT PTHREAD_ONCE_INIT
+#define call_once(flag, func) pthread_once((flag), (func))
 #else
 #include <threads.h>
 #endif


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

This upstreams `patch/ros-rolling-rcl-yaml-param-parser.patch`, authored in RoboStack by wep21 `<daisuke.nishimatsu1021@gmail.com>`.

Apple platforms do not provide the C11 threads API used here on other POSIX platforms. This maps the `once_flag` and `call_once` usage to `pthread_once` on Apple while keeping the existing Windows and C11 threads paths unchanged.