### PR TITLE
rcl_yaml_param_parser: Fix build on MacOS

### DIFF
--- a/rcl_yaml_param_parser/src/parse.c
+++ b/rcl_yaml_param_parser/src/parse.c
@@ -15,6 +15,9 @@
 #include <ctype.h>
 #include <errno.h>
 #include <locale.h>
+#ifdef __APPLE__
+#include <xlocale.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 


### PR DESCRIPTION
## Description

Apple's `<locale.h>` doesn't declare `locale_t`, `newlocale`, `uselocale`, `LC_NUMERIC_MASK`; they live in `<xlocale.h>`.

Without this change, I'm getting the following errors:

    /nix/var/nix/builds/nix-5044-3197885420/rcl-release-release-lyrical-rcl_yaml_param_parser-10.4.4-1/src/parse.c:811:8: error: unknown type name 'locale_t'
      811 | static locale_t c_locale = 0;
          |        ^
    /nix/var/nix/builds/nix-5044-3197885420/rcl-release-release-lyrical-rcl_yaml_param_parser-10.4.4-1/src/parse.c:816:14: error: call to undeclared function 'newlocale'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
      816 |   c_locale = newlocale(LC_NUMERIC_MASK, "C", 0);
          |              ^
    /nix/var/nix/builds/nix-5044-3197885420/rcl-release-release-lyrical-rcl_yaml_param_parser-10.4.4-1/src/parse.c:816:14: note: did you mean 'setlocale'?
    /nix/store/vhgvw78l3ziv7kgrbnrfbb8j37112bxk-apple-sdk-14.4/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/locale.h:53:8: note: 'setlocale' declared here
       53 | char            *setlocale(int, const char *);
          |                  ^
    /nix/var/nix/builds/nix-5044-3197885420/rcl-release-release-lyrical-rcl_yaml_param_parser-10.4.4-1/src/parse.c:816:24: error: use of undeclared identifier 'LC_NUMERIC_MASK'
      816 |   c_locale = newlocale(LC_NUMERIC_MASK, "C", 0);
          |                        ^~~~~~~~~~~~~~~
    /nix/var/nix/builds/nix-5044-3197885420/rcl-release-release-lyrical-rcl_yaml_param_parser-10.4.4-1/src/parse.c:851:3: error: use of undeclared identifier 'locale_t'
      851 |   locale_t old_locale = uselocale(c_locale);
          |   ^~~~~~~~
    /nix/var/nix/builds/nix-5044-3197885420/rcl-release-release-lyrical-rcl_yaml_param_parser-10.4.4-1/src/parse.c:853:3: error: call to undeclared function 'uselocale'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
      853 |   uselocale(old_locale);
          |   ^
    /nix/var/nix/builds/nix-5044-3197885420/rcl-release-release-lyrical-rcl_yaml_param_parser-10.4.4-1/src/parse.c:853:3: note: did you mean 'setlocale'?
    /nix/store/vhgvw78l3ziv7kgrbnrfbb8j37112bxk-apple-sdk-14.4/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/locale.h:53:8: note: 'setlocale' declared here
       53 | char            *setlocale(int, const char *);
          |                  ^
    /nix/var/nix/builds/nix-5044-3197885420/rcl-release-release-lyrical-rcl_yaml_param_parser-10.4.4-1/src/parse.c:853:13: error: use of undeclared identifier 'old_locale'; did you mean 'c_locale'?
      853 |   uselocale(old_locale);
          |             ^~~~~~~~~~
          |             c_locale
    /nix/var/nix/builds/nix-5044-3197885420/rcl-release-release-lyrical-rcl_yaml_param_parser-10.4.4-1/src/parse.c:811:17: note: 'c_locale' declared here
      811 | static locale_t c_locale = 0;
          |                 ^

### Is this user-facing behavior change?

no

### Did you use Generative AI?

The first sentence in commit message body is generated by Claude.
