### PR TITLE
Copy subscription buffer backend options

### DIFF
--- a/rcl/src/rcl/subscription.c
+++ b/rcl/src/rcl/subscription.c
@@ -103,6 +103,14 @@ rcl_subscription_init(
 
   // options
   subscription->impl->options = *options;
+  subscription->impl->options.rmw_subscription_options.acceptable_buffer_backends = NULL;
+  ret = rcl_subscription_options_set_acceptable_buffer_backends(
+    options->rmw_subscription_options.acceptable_buffer_backends,
+    &subscription->impl->options);
+  if (RCL_RET_OK != ret) {
+    fail_ret = ret;
+    goto fail;
+  }
   subscription->impl->in_use_by_waitset = false;
 
   // Fill out the implemenation struct.


### PR DESCRIPTION
## Summary
- deep-copy acceptable Buffer backend strings into subscription-owned options
- initialize copied option storage before assignment
- preserve the original error when option copying fails

## Dependency
Independent correctness fix discovered while exercising Rust native Buffer subscriptions.

## Test plan
- [x] Build and run the `rcl` test suite
- [x] Exercise subscription initialization and finalization with CUDA backend options
- [x] Verify the previous invalid free is absent