### PR TITLE
Fix deprecated atomic initialization

### DIFF
--- a/rcl/src/rcl/init.c
+++ b/rcl/src/rcl/init.c
@@ -40,7 +40,11 @@ extern "C"
 #include "./context_impl.h"
 #include "./init_options_impl.h"
 
-static atomic_uint_least64_t __rcl_next_unique_id = ATOMIC_VAR_INIT(1);
+#if defined(_WIN32) && !defined(__MINGW64__)
+static atomic_uint_least64_t __rcl_next_unique_id = {1};
+#else
+static atomic_uint_least64_t __rcl_next_unique_id = 1;
+#endif
 
 rcl_ret_t
 rcl_init(


### PR DESCRIPTION

## Description

Similar to https://github.com/ros2/rcutils/pull/587

```
--- stderr: rcl
/Users/maurice/ros2_projects/pixi_ws/src/rcl/rcl/src/rcl/init.c:43:53: warning: macro 'ATOMIC_VAR_INIT' has been marked as deprecated [-Wdeprecated-pragma]
   43 | static atomic_uint_least64_t __rcl_next_unique_id = ATOMIC_VAR_INIT(1);
      |                                                     ^
/Users/maurice/ros2_projects/pixi_ws/.pixi/envs/default/lib/clang/21/include/stdatomic.h:62:41: note: macro marked 'deprecated' here
   62 | #pragma clang deprecated(ATOMIC_VAR_INIT)
      |                                         ^
1 warning generated.
```

### Is this user-facing behavior change?

No

### Did you use Generative AI?

No

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
